### PR TITLE
enable undefined behaviour sanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 
 bin/sanitizer_$(subst /,_,$(SCHEME)): test/$(dir $(SCHEME))functest.c $(wildcard $(SCHEME)/clean/*.c) $(wildcard $(SCHEME)/clean/*.h) | require_scheme
 	mkdir -p bin
-	$(CC) $(CFLAGS) -fsanitize=address \
+	$(CC) $(CFLAGS) -fsanitize=address,undefined \
 		-DPQCLEAN_NAMESPACE=$(shell echo PQCLEAN_$(subst -,,$(notdir $(SCHEME))) | tr a-z A-Z) \
 		-iquote "./common/" \
 		-iquote "$(SCHEME)/clean/" \

--- a/test/crypto_sign/functest.c
+++ b/test/crypto_sign/functest.c
@@ -6,15 +6,17 @@
 #define NTESTS 15
 #define MLEN 32
 
+typedef uint64_t unaligned_uint64_t __attribute__((aligned(1)));
+
 /* allocate a bit more for all keys and messages and
  * make sure it is not touched by the implementations.
  */
 static void write_canary(unsigned char *d) {
-    *((uint64_t *)d) = 0x0123456789ABCDEF;
+    *((unaligned_uint64_t *)d) = 0x0123456789ABCDEF;
 }
 
 static int check_canary(const unsigned char *d) {
-    if (*(uint64_t *)d != 0x0123456789ABCDEF) {
+    if (*(unaligned_uint64_t *)d != 0x0123456789ABCDEF) {
         return -1;
     }
 


### PR DESCRIPTION
I would like to propose to enable undefined behavior sanitizer; as code suppose to be 'clean' UB may help to detect strange errors.

UB sanitizer has actually detected problem with unaligned access in dilithium-iii. I changed the code so that UB sanitizer is happy, but as far as I understand the ``write_canary`` and ``check_canary`` functions are not needed anymore (such canaries are implemented by address sanitizer).