### PR TITLE
Initial attempt at Python-driven checking framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ bin/
 # Object and library files on Windows
 *.lib
 *.obj
+
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
         apt:
           packages:
             - python3
+            - python3-colorama
             - python3-yaml
             - valgrind
     - name: "Linux + Clang"
@@ -25,6 +26,7 @@ matrix:
           packages:
             - python3
             - python3-yaml
+            - python3-colorama
             - valgrind
     - name: "Linux 32-bit GCC"
       os: linux
@@ -34,6 +36,7 @@ matrix:
           packages:
             - gcc-multilib
             - python3
+            - python3-colorama
             - python3-yaml
             - valgrind
       before_install:
@@ -74,7 +77,7 @@ matrix:
 
 script:
   - make ${MAKETARGET}
-
+  - cd scripts && ./run_checks.py
 
 cache: pip
 

--- a/crypto_kem/kyber768/clean/Makefile
+++ b/crypto_kem/kyber768/clean/Makefile
@@ -8,8 +8,8 @@ CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I../../../common $(EXTRAFLAGS)
 all: $(LIB)
 
 $(LIB): $(OBJECTS)
-    $(AR) -r $@ $(OBJECTS)
+	$(AR) -r $@ $(OBJECTS)
 
 clean:
-    $(RM) $(OBJECTS)
-    $(RM) $(LIB)
+	$(RM) $(OBJECTS)
+	$(RM) $(LIB)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML
+colorama

--- a/scripts/PQClean.py
+++ b/scripts/PQClean.py
@@ -1,0 +1,81 @@
+import os
+import yaml
+
+class Scheme:
+    def __init__(self):
+        self.type = None
+        self.name = None
+        self.implementations = []
+
+    def path(self, base='..'):
+        return os.path.join(base, 'crypto_' + self.type, self.name)
+
+    @staticmethod
+    def all_schemes():
+        schemes = dict()
+        schemes.update(Scheme.all_schemes_of_type('kem'))
+        schemes.update(Scheme.all_schemes_of_type('sign'))
+        return schemes
+
+    @staticmethod
+    def all_schemes_of_type(type: str) -> list:
+        schemes = dict()
+        p = os.path.join('..', 'crypto_' + type)
+        for d in os.listdir(p):
+            if os.path.isdir(os.path.join(p, d)):
+                if type == 'kem':
+                    schemes[d] = KEM(d)
+                elif type == 'sign':
+                    schemes[d] = Signature(d)
+                else:
+                    assert('Unknown type')
+        return schemes
+
+    def metadata(self):
+        metafile = os.path.join(self.path(), 'META.yml')
+        try:
+            with open(metafile, encoding='utf-8') as f:
+                metadata = yaml.load(f.read())
+                return metadata
+        except Exception as e:
+            print("Can't open {}: {}".format(metafile, e))
+            return None
+
+class Implementation:
+
+    def __init__(self, scheme, name):
+        self.scheme = scheme
+        self.name = name
+
+    def path(self, base='..') -> str:
+        return os.path.join(self.scheme.path(), self.name)
+
+    @staticmethod
+    def all_implementations(scheme: Scheme) -> list:
+        implementations = dict()
+        for d in os.listdir(scheme.path()):
+            if os.path.isdir(os.path.join(scheme.path(), d)):
+                implementations[d] = Implementation(scheme, d)
+        return implementations
+
+class KEM(Scheme):
+
+    def __init__(self, name: str):
+        self.type = 'kem'
+        self.name = name;
+        self.implementations = Implementation.all_implementations(self)
+
+    @staticmethod
+    def all_kems() -> list:
+        return Scheme.all_schemes_of_type('kem')
+
+class Signature(Scheme):
+
+    def __init__(self, name: str):
+        self.type = 'sign'
+        self.name = name;
+        self.implementations = Implementation.all_implementations(self)
+
+    @staticmethod
+    def all_sigs():
+        return Scheme.all_schemes_of_type('sig')

--- a/scripts/Tests.py
+++ b/scripts/Tests.py
@@ -1,0 +1,68 @@
+"""
+Utility functions for running tests and logging the results.
+"""
+
+import colorama
+import PQClean
+import subprocess
+
+colorama.init()
+
+globalreturnvalue = 0
+
+successes = []
+
+def report_success(check: str, scheme: PQClean.Scheme, implementation: PQClean.Implementation, capture: str = None):
+    """Report a successful test.  Note that successful test results are not immediately output, and instead are saved for output via print_successess."""
+    global successess
+    entry = {'check': check, 'scheme': scheme, 'implementation': implementation}
+    if entry not in successes: successes.append(entry)
+
+def print_successes():
+    """Print table listing all successful tests."""
+    global successes
+    print(colorama.Fore.GREEN + "=======================SUCCESSES=========================")
+    print("{:18}, {:18}, {:15}".format("check", "scheme", "implementation"))
+    print("---------------------------------------------------------")
+    for entry in successes:
+        print("{:18}, ".format(entry["check"]), end='')
+        print("{:18}, ".format(entry["scheme"].name if entry["scheme"] else ""), end='')
+        print("{:15}".format(entry["implementation"].name if entry["implementation"] else ""))
+    print("=========================================================")
+    print(colorama.Style.RESET_ALL)
+
+def report_failure(check: str, scheme: PQClean.Scheme, implementation: PQClean.Implementation, message: str, capture: str = None):
+    """Report a failed test.  Note that failed test results are immediately output."""
+    global successess
+    entry = {'check': check, 'scheme': scheme, 'implementation': implementation}
+    if entry in successes: successes.remove(entry)
+    global globalreturnvalue
+    globalreturnvalue = -1
+    print(colorama.Fore.RED + "=========================================================")
+    print("====                    FAILURE                      ====")
+    print("=========================================================")
+    print("Check:            " + check)
+    if scheme: print("Scheme:           " + scheme.name)
+    if implementation: print("Implementation:   " + implementation.name)
+    if message: print("Error message:    " + message)
+    if capture != None:
+        print("")
+        print(colorama.Fore.BLACK + capture)
+    print(colorama.Fore.RED + "=========================================================")
+    print(colorama.Style.RESET_ALL)
+
+def run_subprocess(check_name, scheme, implementation, command, working_dir, error_message):
+    """Helper function to run a shell command and report success/failure depending on the exit status of the shell command."""
+    try:
+        result = subprocess.run(
+            command,
+            stdout = subprocess.PIPE,
+            stderr = subprocess.STDOUT,
+            cwd = working_dir
+        )
+        if result.returncode == 0:
+            report_success(check_name, scheme, implementation)
+        else:
+            report_failure(check_name, scheme, implementation, error_message, result.stdout.decode('utf-8'));
+    except Exception as e:
+        report_failure(check_name, scheme, implementation, "Python error during execution", e.strerror)

--- a/scripts/check_compile_lib.py
+++ b/scripts/check_compile_lib.py
@@ -1,0 +1,19 @@
+"""
+Checks that the archive library can be successfully built for every implementation of the specified scheme.
+"""
+
+import os
+import PQClean
+import Tests
+import subprocess
+
+def run(scheme: PQClean.Scheme):
+    for implementation in scheme.implementations.values():
+        Tests.run_subprocess(
+            "compile_lib",
+            scheme,
+            implementation,
+            ['make'],
+            implementation.path(),
+            "Compilation failed"
+        )

--- a/scripts/check_functest.py
+++ b/scripts/check_functest.py
@@ -1,0 +1,26 @@
+"""
+Checks that the functional test program (functest) can be successfully built and executed for every implementation of the specified scheme.
+"""
+
+import os
+import PQClean
+import Tests
+
+def run(scheme: PQClean.Scheme):
+    for implementation in scheme.implementations.values():
+        Tests.run_subprocess(
+            "functest",
+            scheme,
+            implementation,
+            ['make', 'TYPE=' + scheme.type, 'SCHEME=' + scheme.name, 'IMPLEMENTATION=' + implementation.name],
+            os.path.join('..', 'test'),
+            "Compilation failed"
+        )
+        Tests.run_subprocess(
+            "functest",
+            scheme,
+            implementation,
+            ['./functest_{}_{}'.format(scheme.name, implementation.name)],
+            os.path.join('..', 'bin'),
+            "Functional test failed"
+        )

--- a/scripts/check_license.py
+++ b/scripts/check_license.py
@@ -1,0 +1,20 @@
+"""
+Checks that a LICENSE or LICENSE.txt file is present for every implementation of the specified scheme.
+"""
+
+import os
+import PQClean
+import Tests
+
+def run(scheme: PQClean.Scheme):
+    for implementation in scheme.implementations.values():
+        found = False
+        potential_filenames = ['LICENSE', 'LICENSE.txt']
+        for filename in potential_filenames:
+            p = os.path.join(implementation.path(), filename)
+            if os.path.isfile(p):
+                found = True
+        if found:
+            Tests.report_success("license", scheme, implementation)
+        else:
+            Tests.report_failure("license", scheme, implementation, "No license file found")

--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""
+Run all (or requested) checks on all (or requested) schemes.
+"""
+
+import glob
+import sys
+import PQClean
+import Tests
+
+# populate all checks from files named check_*.py, and import those modules
+all_check_names = []
+for check in glob.iglob('check_*.py'):
+    check = check[6:] # remove check_ prefix
+    check = check[:-3] # remove .py extension
+    exec("import check_" + check)
+    all_check_names.append(check)
+
+all_schemes = PQClean.Scheme.all_schemes()
+all_scheme_names = all_schemes.keys()
+
+def run(check_names: list, scheme_names: list):
+    """Run the requested checks for the requested schemes."""
+    global all_schemes
+    for scheme in scheme_names:
+        for check in check_names:
+            eval("check_" + check).run(all_schemes[scheme])
+    Tests.print_successes()
+    exit(Tests.globalreturnvalue)
+
+if __name__ == "__main__":
+    # if any arguments were specified, filter to just those checks / schemes
+    requested_check_names = []
+    requested_scheme_names = []
+    for a in sys.argv[1:]:
+        if a in all_check_names: requested_check_names.append(a)
+        elif a in all_scheme_names: requested_scheme_names.append(a)
+        else:
+            print("Invalid argument {}.  Must be a check or scheme".format(a))
+            print("Known checks: " + ", ".join(all_check_names))
+            print("Known schemes: " + ", ".join(all_scheme_names))
+            exit(-1)
+    # if no checks / schemes were explicitly requested, use all of them
+    if len(requested_check_names) == 0: requested_check_names = all_check_names
+    if len(requested_scheme_names) == 0: requested_scheme_names = all_scheme_names
+    # run the requested checks for the requested schemes
+    run(requested_check_names, requested_scheme_names)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,25 @@
+# This Makefile can be used with GNU Make or BSD Make
+
+# override as desired
+TYPE=kem
+SCHEME=kyber768
+IMPLEMENTATION=clean
+
+SCHEME_DIR="../crypto_$(TYPE)/$(SCHEME)/$(IMPLEMENTATION)"
+SCHEME_UPPERCASE=$(shell echo $(SCHEME) | tr a-z A-Z | sed 's/-//')
+
+COMMON_DIR=../common
+COMMON_FILES=$(COMMON_DIR)/randombytes.c $(COMMON_DIR)/fips202.c $(COMMON_DIR)/sha2.c
+DEST_DIR=../bin
+
+CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I$(COMMON_DIR) $(EXTRAFLAGS)
+
+all: $(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION)
+
+$(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION): crypto_$(TYPE)/functest.c $(COMMON_FILES)
+	mkdir -p $(DEST_DIR)
+	cd $(SCHEME_DIR) && make clean && make
+	$(CC) $(CFLAGS) -DPQCLEAN_NAMESPACE=PQCLEAN_$(SCHEME_UPPERCASE) -I$(SCHEME_DIR) crypto_$(TYPE)/functest.c $(COMMON_FILES) -o $@ -L$(SCHEME_DIR) -l$(SCHEME)_$(IMPLEMENTATION)
+
+clean:
+	$(RM) $(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION)


### PR DESCRIPTION
Demonstrates how we might address issue #10.

Main ideas:

- `scripts/PQClean.py` gets all the available schemes/implementations, and loads their metadata from the yaml file.
- `scripts/Tests.py` contains some helper logger routines, including colour-coded output (although not using the colorlog package as suggested in https://github.com/PQClean/PQClean/issues/10#issuecomment-462803162
- Individual tests appear in `scripts/check_*.py`, which follow the same pattern: a `run` function which takes a scheme name, and runs a check, using `Tests.report_success` or `Tests.report_error` to log the result and output
- `scripts/run_checks.py`, which runs all checks for all schemes (or can take command-line arguments to only run some checks on some schemes).  For successful checks, only a summary table is printed.  For failed checks, the full stdout/stderr capture is printed.

I've only implemented 3 checks so far as a demo:

- `check_license` which checks to make sure a LICENSE file is present for every implementation
- `check_compile_lib` which checks to make sure that each implementation compiles using its own Makefile without errors
- `check_functest` which compiles the functional tests for each scheme and checks that they run without errors
    - To make `check_functest` work, I added a `test/Makefile` which will build the requested functional test using against the lib*.a file that was compiled using the scheme's local Makefile

I tried to minimize the amount of repeated code that is present in individual `check_*.py` files, outsourcing it as much as possible to `run_checks.py`, `Tests.py`, and `PQClean.py`.

So far this runs on macOS and Linux.  Assuming Python is present on Windows, we might actually be able to get most of the checks running on Windows too, as long as we avoid platform-specific Python where possible, and then in ones like `check_compile_lib` we might be able to switch them over to using `nmake` rather than `make.