### PR TITLE
Allow to easily run individual test modules and add instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ _The checking of items on this list is still being developed. Checked items shou
 * [x] API functions do not write outside provided buffers
 * [x] Compiles with `-Wall -Wextra -Wpedantic -Werror` with `gcc` and `clang`
 * [x] Consistent test vectors across runs
-* [ ] Consistent test vectors on big-endian and little-endian machines
-* [ ] Consistent test vectors on 32-bit and 64-bit machines
+* [x] Consistent test vectors on big-endian and little-endian machines
+* [x] Consistent test vectors on 32-bit and 64-bit machines
 * [x] No errors/warnings reported by valgrind
 * [x] No errors/warnings reported by address sanitizer
 * [ ] Only dependencies:
@@ -131,3 +131,19 @@ Regarding #2, adding the files to your project's build system, each implementati
 Each subdirectory containing implementations contains a LICENSE file stating under what license
 that specific implementation is released. All other code for testing etc. in this repository
 is released under the conditions of [CC0](http://creativecommons.org/publicdomain/zero/1.0/).
+
+## Running tests locally
+
+While we run extensive automatic testing on [Travis CI][travis-pqc] and [Appveyor][appveyor-pqc], most tests can also be run locally.
+To do this, make sure the following is installed:
+
+* Python 3.5+
+* `nosetests` or `nose2` (either for Python 3)
+
+Run the Python-based tests by going into the `test` directory and running `nosetests -v` or `nose2 -B -v`, depending on what you installed.
+If you have the `rednose` plugin for `nosetests` installed, run `nosetests --rednose` to get colored output.
+
+You may also run `python <testmodule>` where `<testmodule>` is any of the files starting with `test_` in the `test/` folder.
+
+[travis-pqc]: https://travis-ci.com/PQClean/PQClean/
+[appveyor-pqc]: https://ci.appveyor.com/project/PQClean/pqclean

--- a/test/test_compile_lib.py
+++ b/test/test_compile_lib.py
@@ -21,3 +21,8 @@ def check_compile_lib(scheme_name, implementation_name):
         ['make'],
         implementation.path()
     )
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()

--- a/test/test_compile_lib.py
+++ b/test/test_compile_lib.py
@@ -24,5 +24,9 @@ def check_compile_lib(scheme_name, implementation_name):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    try:
+        import nose2
+        nose2.main()
+    except ImportError:
+        import nose
+        nose.runmodule()

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -24,5 +24,9 @@ def check_functest(scheme_name, implementation_name):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    try:
+        import nose2
+        nose2.main()
+    except ImportError:
+        import nose
+        nose.runmodule()

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -21,3 +21,8 @@ def check_functest(scheme_name, implementation_name):
         ['./functest_{}_{}'.format(scheme_name, implementation_name)],
         os.path.join('..', 'bin'),
     )
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -15,3 +15,8 @@ def check_license(scheme_name, implementation_name):
     p1 = os.path.join(implementation.path(), 'LICENSE')
     p2 = os.path.join(implementation.path(), 'LICENSE.txt')
     assert(os.path.isfile(p1) or os.path.isfile(p2))
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -18,5 +18,9 @@ def check_license(scheme_name, implementation_name):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    try:
+        import nose2
+        nose2.main()
+    except ImportError:
+        import nose
+        nose.runmodule()

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -119,5 +119,9 @@ def check_element(field, element, props):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    try:
+        import nose2
+        nose2.main()
+    except ImportError:
+        import nose
+        nose.runmodule()

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -116,3 +116,8 @@ def check_element(field, element, props):
 
     if type_ == dict:
         check_spec(element, props['spec'].items())
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()

--- a/test/test_symbol_namespace.py
+++ b/test/test_symbol_namespace.py
@@ -44,3 +44,8 @@ def check_symbol_namespace(scheme_name, implementation_name):
         for symbol in non_namespaced:
             print("\ttype: {}, symbol: {}".format(symtype, symbol))
         assert(False)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()

--- a/test/test_symbol_namespace.py
+++ b/test/test_symbol_namespace.py
@@ -47,5 +47,9 @@ def check_symbol_namespace(scheme_name, implementation_name):
 
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    try:
+        import nose2
+        nose2.main()
+    except ImportError:
+        import nose
+        nose.runmodule()


### PR DESCRIPTION
By adding a few lines of code to the test modules, you can now do `python3 test_bla.py` and run the tests specified by that module.

This also adds some hopefully helpful text to the README about how to run the python tests.