### PR TITLE
Test for symbolic links

### DIFF
--- a/test/test_no_symlinks.py
+++ b/test/test_no_symlinks.py
@@ -1,0 +1,30 @@
+"""
+Checks that no implementation makes use of symbolic links.
+"""
+
+import os
+import pqclean
+import sys
+
+def test_no_symlinks():
+    for scheme in pqclean.Scheme.all_schemes():
+        for implementation in scheme.implementations:
+            yield check_no_symlinks, scheme.name, implementation.name
+
+
+def check_no_symlinks(scheme_name, implementation_name):
+    implementation = pqclean.Implementation.by_name(
+        scheme_name, implementation_name)
+    for file in os.listdir(implementation.path()):
+        fpath = os.path.join(implementation.path(), file)
+        if os.path.islink(fpath):
+            raise AssertionError("{} is a symbolic link!".format(fpath))
+
+
+if __name__ == '__main__':
+    try:
+        import nose2
+        nose2.main()
+    except ImportError:
+        import nose
+        nose.runmodule()


### PR DESCRIPTION
This implements part of the check that ensures separate directories per implementation and scheme instance. We disallow symbolic links to ensure implementations are standalone and more portable.