### PR TITLE
Enable address and UB sanitizers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,21 +57,21 @@ matrix:
       os: linux
       services: docker
       env:
-        - MAKETARGET="run-functest-all"
+        - MAKETARGET="run-functest-all run-sanitizer-all"
       script:
         - docker run --rm --privileged multiarch/qemu-user-static:register --reset
         - docker run --rm -v `pwd`:`pwd` -w `pwd` "pqclean/debian-buster-arm" /bin/bash -c "uname -a &&
-          make ${MAKETARGET} &&
+          ASAN_OPTIONS=detect_leaks=0 make ${MAKETARGET} &&
           cd test && python3 -m nose --rednose --verbose"
     - name: "Run tests on qemu-aarch64 (GCC)"
       os: linux
       services: docker
       env:
-        - MAKETARGET="run-functest-all"
+        - MAKETARGET="run-functest-all run-sanitizer-all"
       script:
         - docker run --rm --privileged multiarch/qemu-user-static:register --reset
         - docker run --rm -v `pwd`:`pwd` -w `pwd` "pqclean/debian-buster-aarch64" /bin/bash -c "uname -a &&
-          make ${MAKETARGET} &&
+          ASAN_OPTIONS=detect_leaks=0 make ${MAKETARGET} &&
           cd test && python3 -m nose --rednose --verbose"
     - name: "MacOS + Clang"
       os: osx


### PR DESCRIPTION
This enables address sanitizer and undefined behaviour sanitizer,
but disables leak detection sanitizer.
It seema there is an issue in qemu that we are using, which prevents
spawning leaksanitizer's tracer thread. But as leak detection is
already done by valgrind on x86 build, this functionality is not
absolute need at the moment.

Closes #33 