### PR TITLE
Greatly simplify container builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 
 dist: xenial
+language: minimal
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,75 +4,6 @@ dist: xenial
 
 matrix:
   include:
-    - name: "Linux + GCC + Linting"
-      os: linux
-      compiler: gcc
-      env:
-        - MAKETARGET="test-all tidy-all check-format"
-      addons:
-        apt:
-          packages: &xenial-packages
-            - astyle
-            - python3-yaml
-            - python3-nose
-            - python3-rednose
-            - valgrind
-    - name: "Linux + Clang"
-      os: linux
-      compiler: clang
-      env:
-        - MAKETARGET=test-all
-      addons:
-        apt:
-          packages: *xenial-packages
-    - name: "Linux 32-bit GCC"
-      os: linux
-      compiler: gcc  # Clang has i386-libasan problems on xenial
-      addons:
-        apt:
-          packages:  # no way to re-use xenial-packages with lists :(
-            - astyle
-            - gcc-multilib
-            - python3-yaml
-            - python3-nose
-            - python3-rednose
-            - valgrind
-      before_install:
-        - sudo dpkg --add-architecture i386
-        - sudo apt update -qq && sudo apt-get install -qqy libc6-dbg:i386
-      env:
-        - MAKETARGET=test-all
-        - EXTRAFLAGS=-m32
-    - name: "Run tests on qemu-ppc (GCC)"
-      os: linux
-      services: docker
-      env:
-        - MAKETARGET="run-functest-all run-sanitizer-all"
-      script:
-        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-        - docker run --rm -v `pwd`:`pwd` -w `pwd` "pqclean/debian-unstable-ppc" /bin/bash -c "uname -a &&
-          make ${MAKETARGET} &&
-          cd test && python3 -m nose --rednose --verbose"
-    - name: "Run tests on qemu-arm32 (GCC)"
-      os: linux
-      services: docker
-      env:
-        - MAKETARGET="run-functest-all run-sanitizer-all"
-      script:
-        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-        - docker run --rm -v `pwd`:`pwd` -w `pwd` "pqclean/debian-buster-arm" /bin/bash -c "uname -a &&
-          ASAN_OPTIONS=detect_leaks=0 make ${MAKETARGET} &&
-          cd test && python3 -m nose --rednose --verbose"
-    - name: "Run tests on qemu-aarch64 (GCC)"
-      os: linux
-      services: docker
-      env:
-        - MAKETARGET="run-functest-all run-sanitizer-all"
-      script:
-        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-        - docker run --rm -v `pwd`:`pwd` -w `pwd` "pqclean/debian-buster-aarch64" /bin/bash -c "uname -a &&
-          ASAN_OPTIONS=detect_leaks=0 make ${MAKETARGET} &&
-          cd test && python3 -m nose --rednose --verbose"
     - name: "MacOS + Clang"
       os: osx
       osx_image: xcode10.1
@@ -95,9 +26,27 @@ matrix:
       env:
         - MAKETARGET=test-all
 
+env:
+  matrix:
+    - CC=gcc    ARCH=armhf
+    - CC=clang  ARCH=armhf
+    - CC=gcc    ARCH=arm64
+    - CC=clang  ARCH=arm64
+    - CC=gcc    ARCH=i386
+    - CC=clang  ARCH=i386
+    - CC=gcc    ARCH=amd64
+    - CC=clang  ARCH=amd64
+    - CC=gcc    ARCH=unstable-ppc
+    - CC=clang  ARCH=unstable-ppc
+
+before_script:
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+
 script:
-  - make ${MAKETARGET}
-  - cd test && python3 -m nose --rednose --verbose
+  - docker run --rm -v `pwd`:`pwd` -w `pwd` "pqclean/ci-containers:$ARCH" /bin/bash -c "
+      uname -a &&
+      export CC=${CC} &&
+      cd test && python3 -m nose --rednose --verbose"
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ matrix:
       compiler: clang
       before_install:
         - pip3 install -r requirements.txt
-      env:
-        - MAKETARGET=test-all
+      script:
+        - "cd test && python3 -m nose --rednose --verbose"
     - name: "MacOS + GCC8"
       os: osx
       osx_image: xcode10.1
@@ -23,8 +23,9 @@ matrix:
       before_install:
         - pip3 install -r requirements.txt
         - gcc --version
-      env:
-        - MAKETARGET=test-all
+      script:
+        - "cd test && python3 -m nose --rednose --verbose"
+
 
 env:
   matrix:
@@ -39,11 +40,9 @@ env:
     - CC=gcc    ARCH=unstable-ppc
     - CC=clang  ARCH=unstable-ppc
 
-before_script:
-  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-
 script:
-  - docker run --rm -v `pwd`:`pwd` -w `pwd` "pqclean/ci-containers:$ARCH" /bin/bash -c "
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+  - docker run --rm -v `pwd`:`pwd` -w `pwd` "pqclean/ci-container:$ARCH" /bin/bash -c "
       uname -a &&
       export CC=${CC} &&
       cd test && python3 -m nose --rednose --verbose"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: c
-
 dist: xenial
 language: minimal
 

--- a/test/test_symbol_namespace.py
+++ b/test/test_symbol_namespace.py
@@ -42,7 +42,7 @@ def check_symbol_namespace(scheme_name, implementation_name):
         if symtype in 'TR':
             if (not symbol.startswith(namespace) and
                     # weird things on i386
-                    not symbol.startwith('__x86.get_pc_thunk.') and
+                    not symbol.startswith('__x86.get_pc_thunk.') and
                     not symbol.startswith('_' + namespace)):
                 non_namespaced.append(symbol)
 

--- a/test/test_symbol_namespace.py
+++ b/test/test_symbol_namespace.py
@@ -41,6 +41,8 @@ def check_symbol_namespace(scheme_name, implementation_name):
         *_, symtype, symbol = symbolstr.split()
         if symtype in 'TR':
             if (not symbol.startswith(namespace) and
+                    # weird things on i386
+                    not symbol.startwith('__x86.get_pc_thunk.') and
                     not symbol.startswith('_' + namespace)):
                 non_namespaced.append(symbol)
 


### PR DESCRIPTION
By just building everything in a container, the build script is much simpler.

This does expect us to merge the checks that are currently still in the makefile to the python scripts soon, because they are not run by this PR.