### PR TITLE
Faster check of makefile dependencies

### DIFF
--- a/test/test_makefile_dependencies.py
+++ b/test/test_makefile_dependencies.py
@@ -3,11 +3,9 @@ Checks that every .c and .h file in an implementation is present as a
 dependency of that scheme's Makefile.
 """
 
-import hashlib
 import os
 import pqclean
 import helpers
-import subprocess
 import glob
 import datetime
 
@@ -15,19 +13,21 @@ import datetime
 def test_makefile_dependencies():
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
-            # initial build - want to have all files in place at beginning
+            # initial build - want to have *all* files in place at beginning
             helpers.run_subprocess(['make', 'clean'], implementation.path())
             helpers.run_subprocess(['make'], implementation.path())
             # test case for each candidate file
             cfiles = glob.glob(os.path.join(implementation.path(), '*.c'))
             hfiles = glob.glob(os.path.join(implementation.path(), '*.h'))
             for file in cfiles + hfiles:
-                yield check_makefile_dependencies, scheme.name, implementation.name, file
+                yield (check_makefile_dependencies, scheme.name,
+                       implementation.name, file)
+
 
 def check_makefile_dependencies(scheme_name, implementation_name, file):
-    scheme = pqclean.Scheme.by_name(scheme_name)
-    implementation = pqclean.Implementation.by_name(scheme_name, implementation_name)
-    
+    implementation = pqclean.Implementation.by_name(scheme_name,
+                                                    implementation_name)
+
     cfiles = glob.glob(os.path.join(implementation.path(), '*.c'))
     hfiles = glob.glob(os.path.join(implementation.path(), '*.h'))
     ofiles = glob.glob(os.path.join(implementation.path(), '*.o'))
@@ -41,22 +41,20 @@ def check_makefile_dependencies(scheme_name, implementation_name, file):
     ago10 = now - datetime.timedelta(seconds=10)
     ago5 = now - datetime.timedelta(seconds=5)
     formatstring = "%Y%m%d%H%M.%S"
-    helpers.run_subprocess(['touch', '-t', ago15.strftime(formatstring)] + cfiles + hfiles)
-    helpers.run_subprocess(['touch', '-t', ago10.strftime(formatstring)] + ofiles)
-    helpers.run_subprocess(['touch', '-t', ago5.strftime(formatstring), libfile])
-    mtime_lib_orig = os.stat(libfile).st_mtime_ns
+    helpers.run_subprocess(
+        ['touch', '-t', ago15.strftime(formatstring)] + cfiles + hfiles)
+    helpers.run_subprocess(
+        ['touch', '-t', ago10.strftime(formatstring)] + ofiles)
+    helpers.run_subprocess(
+        ['touch', '-t', ago5.strftime(formatstring), libfile])
 
     # touch the candidate .c / .h file
     helpers.run_subprocess(['touch', '-t', now.strftime(formatstring), file])
 
-    # rebuild
-    helpers.run_subprocess(['make'], implementation.path())
+    # check if it needs to be rebuilt using make -q
+    helpers.run_subprocess(['make', '-q'], implementation.path(),
+                           expected_returncode=1)
 
-    # make sure the libfile's modification time changed
-    mtime_lib_upd = os.stat(libfile).st_mtime_ns
-    if (mtime_lib_orig == mtime_lib_upd):
-        print("ERROR: Library was not updated after touching {}".format(file))
-    assert(mtime_lib_orig != mtime_lib_upd)
 
 if __name__ == '__main__':
     try:

--- a/test/test_makefile_dependencies.py
+++ b/test/test_makefile_dependencies.py
@@ -48,6 +48,10 @@ def check_makefile_dependencies(scheme_name, implementation_name, file):
     helpers.run_subprocess(
         ['touch', '-t', ago5.strftime(formatstring), libfile])
 
+    # Sanity check: the scheme is up to date
+    helpers.run_subprocess(['make', '-q'], implementation.path(),
+                           expected_returncode=0)
+
     # touch the candidate .c / .h file
     helpers.run_subprocess(['touch', '-t', now.strftime(formatstring), file])
 


### PR DESCRIPTION
We do not actually need to compile the files. Instead, we can use `make -q` to report if the scheme needs rebuilding.