### PR TITLE
Valgrind in python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,21 +41,6 @@ else
 	@echo "Valgrind not supported on this platform."
 endif
 
-bin/sanitizer_$(subst /,_,$(SCHEME)): test/$(dir $(SCHEME))functest.c $(wildcard $(SCHEME)/clean/*.c) $(wildcard $(SCHEME)/clean/*.h) | require_scheme
-	mkdir -p bin
-	$(CC) $(CFLAGS) -fsanitize=address,undefined \
-		-DPQCLEAN_NAMESPACE=$(shell echo PQCLEAN_$(subst -,,$(notdir $(SCHEME)))_CLEAN | tr a-z A-Z) \
-		-iquote "./common/" \
-		-iquote "$(SCHEME)/clean/" \
-		-o bin/sanitizer_$(subst /,_,$(SCHEME)) \
-		$(COMMON_FILES) \
-		$(RANDOM_IMPL) \
-		$(SCHEME)/clean/*.c \
-		$<
-
-.PHONY: sanitizer
-sanitizer: bin/sanitizer_$(subst /,_,$(SCHEME))
-
 bin/shared_$(subst /,_,$(SCHEME))_clean.so: $(wildcard $(SCHEME)/clean/*.c) | require_scheme
 	mkdir -p bin
 	$(CC) $(CFLAGS) \
@@ -100,10 +85,7 @@ apply-tidy:
 help:
 	@echo "make test-all				Run all tests"
 	@echo "make functest SCHEME=scheme		Build functional tests for SCHEME"
-	@echo "make functest-all			Build functional tests for all schemes"
 	@echo "make run-functest SCHEME=scheme		Run functional tests for SCHEME"
-	@echo "make run-functest-all			Run all functests"
-	@echo "make run-sanitizer-all			Run address sanitizer for all schemes"
 	@echo "make run-valgrind SCHEME=scheme		Run valgrind checks for SCHEME"
 	@echo "make run-valgrind-all			Run valgrind checks all schemes"
 	@echo "make clean				Clean up the bin/ folder"
@@ -114,17 +96,6 @@ help:
 	@echo "make apply-tidy-all			Tidy up all schemes"
 	@echo "make help				Displays this message"
 
-.PHONY: functest-all
-functest-all:
-	@for scheme in $(ALL_SCHEMES); do \
-	    $(MAKE) functest SCHEME=$$scheme || exit 1; \
-	done
-
-.PHONY: sanitizer-all
-sanitizer-all:
-	@for scheme in $(ALL_SCHEMES); do \
-	    $(MAKE) sanitizer SCHEME=$$scheme || exit 1; \
-	done
 
 .PHONY: run-valgrind-all
 run-valgrind-all:
@@ -132,24 +103,8 @@ run-valgrind-all:
 	    $(MAKE) run-valgrind SCHEME=$$scheme || exit 1; \
 	done
 
-.PHONY: run-functest-all
-run-functest-all: functest-all
-	@for functest in $$(find bin/ -maxdepth 1 -name 'functest_*' -not -type d) ; do \
-		echo ./$$functest ; \
-		./$$functest || exit 1 ;\
-	done
-	@echo Tests completed
-
-.PHONY: run-sanitizer-all
-run-sanitizer-all: sanitizer-all
-	@for sanitizer in $$(find bin/ -maxdepth 1 -name 'sanitizer_*' -not -type d) ; do \
-		echo ./$$sanitizer ; \
-		./$$sanitizer || exit 1 ;\
-	done
-	@echo Tests completed
-
 .PHONY: test-all
-test-all: run-functest-all run-valgrind-all run-sanitizer-all
+test-all: run-valgrind-all
 
 .PHONY: tidy-all
 tidy-all:

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,6 +22,16 @@ all: $(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION) $(DEST_DIR)/testvectors_$(
 build-scheme:
 	cd $(SCHEME_DIR) && $(MAKE)
 
+.PHONY: clean-scheme
+clean-scheme:
+	cd $(SCHEME_DIR) && $(MAKE) clean
+
+.PHONY: functest
+functest: $(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION)
+
+.PHONY: testvectors
+testvectors: $(DEST_DIR)/testvectors_$(SCHEME)_$(IMPLEMENTATION)
+
 $(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION): build-scheme crypto_$(TYPE)/functest.c $(COMMON_FILES) $(COMMON_DIR)/randombytes.c $(COMMON_HEADERS)
 	mkdir -p $(DEST_DIR)
 	$(CC) $(CFLAGS) -DPQCLEAN_NAMESPACE=PQCLEAN_$(SCHEME_UPPERCASE)_$(IMPLEMENTATION_UPPERCASE) -I$(SCHEME_DIR) crypto_$(TYPE)/functest.c $(COMMON_FILES) $(COMMON_DIR)/notrandombytes.c -o $@ -L$(SCHEME_DIR) -l$(SCHEME)_$(IMPLEMENTATION)

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,6 +14,7 @@ COMMON_FILES=$(COMMON_DIR)/fips202.c $(COMMON_DIR)/sha2.c
 COMMON_HEADERS=$(COMMON_DIR)/fips202.h $(COMMON_DIR)/randombytes.h $(COMMON_DIR)/sha2.h
 DEST_DIR=../bin
 
+# This -Wall was supported by the European Commission through the ERC Starting Grant 805031 (EPOQUE)
 CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I$(COMMON_DIR) $(EXTRAFLAGS)
 
 all: $(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION) $(DEST_DIR)/testvectors_$(SCHEME)_$(IMPLEMENTATION)

--- a/test/Makefile.Microsoft_nmake
+++ b/test/Makefile.Microsoft_nmake
@@ -2,6 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 # override as desired
+# vim: set ts=4 sw=4 et:
 TYPE=kem
 SCHEME=kyber768
 SCHEME_UPPERCASE=KYBER768
@@ -23,6 +24,11 @@ all: $(DEST_DIR)\functest_$(SCHEME)_$(IMPLEMENTATION).EXE $(DEST_DIR)\testvector
 build-scheme:
     cd $(SCHEME_DIR)
     nmake /f Makefile.Microsoft_nmake
+    cd ..\..\..\test
+
+clean-scheme:
+    cd $(SCHEME_DIR)
+    nmake /f Makefile.Microsoft_nmake clean
     cd ..\..\..\test
 
 $(DEST_DIR)\functest_$(SCHEME)_$(IMPLEMENTATION).EXE: build-scheme $(COMMON_OBJECTS) $(COMMON_DIR)\randombytes.obj

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -19,3 +19,21 @@ def run_subprocess(command, working_dir='.', expected_returncode=0):
     print(result.stdout.decode('utf-8'))
     assert(result.returncode == expected_returncode)
     return result.stdout.decode('utf-8')
+
+
+def make(*args, working_dir='.', **kwargs):
+    """
+    Runs a make target in the specified working directory
+
+    Usage:
+        make('clean', 'targetb', SCHEME='bla')
+    """
+    make_command = 'make'
+    return run_subprocess(
+        [
+            make_command,
+            *args,
+            *['{}={}'.format(k, v) for k, v in kwargs.items()],
+        ],
+        working_dir=working_dir,
+    )

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,11 +1,17 @@
+import os
 import subprocess
 
 
-def run_subprocess(command, working_dir='.', expected_returncode=0):
+def run_subprocess(command, working_dir='.', env=None, expected_returncode=0):
     """
     Helper function to run a shell command and report success/failure
     depending on the exit status of the shell command.
     """
+    if env is not None:
+        env_ = os.environ.copy()
+        env_.update(env)
+        env = env_
+
     # Note we need to capture stdout/stderr from the subprocess,
     # then print it, which nose/unittest will then capture and
     # buffer appropriately
@@ -13,7 +19,8 @@ def run_subprocess(command, working_dir='.', expected_returncode=0):
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        cwd=working_dir
+        cwd=working_dir,
+        env=env,
     )
     print(working_dir + " > " + " ".join(command))
     print(result.stdout.decode('utf-8'))
@@ -21,7 +28,7 @@ def run_subprocess(command, working_dir='.', expected_returncode=0):
     return result.stdout.decode('utf-8')
 
 
-def make(*args, working_dir='.', **kwargs):
+def make(*args, working_dir='.', env=None, **kwargs):
     """
     Runs a make target in the specified working directory
 
@@ -36,4 +43,5 @@ def make(*args, working_dir='.', **kwargs):
             *['{}={}'.format(k, v) for k, v in kwargs.items()],
         ],
         working_dir=working_dir,
+        env=env,
     )

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -46,7 +46,7 @@ def check_functest_sanitizers(scheme_name, implementation_name):
     elif platform.machine() in ['armv7l', 'aarch64']:
         env = {'ASAN_OPTIONS': 'detect_leaks=0'}
     else:
-        print("Supported platform: {}".format(platform.machine))
+        print("Supported platform: {}".format(platform.machine()))
     implementation = pqclean.Implementation.by_name(
         scheme_name, implementation_name)
     helpers.make('clean-scheme', 'functest',

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -41,7 +41,7 @@ def check_functest(scheme_name, implementation_name):
 
 def check_functest_sanitizers(scheme_name, implementation_name):
     env = None
-    if platform.machine() == 'powerpc':
+    if platform.machine() == 'ppc' and os.environ.get('CC', 'gcc') == 'clang':
         raise unittest.SkipTest()
     elif platform.machine() in ['armv7l', 'aarch64']:
         env = {'ASAN_OPTIONS': 'detect_leaks=0'}

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -43,7 +43,7 @@ def check_functest_sanitizers(scheme_name, implementation_name):
     env = None
     if platform.machine() == 'powerpc':
         raise unittest.SkipTest()
-    elif platform.machine() in ['arm32', 'aarch64']:
+    elif platform.machine() in ['armv7l', 'aarch64']:
         env = {'ASAN_OPTIONS': 'detect_leaks=0'}
     else:
         print("Supported platform: {}".format(platform.machine))

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -4,6 +4,9 @@ and executed for every scheme/implementation.
 """
 
 import os
+import platform
+import unittest
+
 import pqclean
 import helpers
 
@@ -12,6 +15,12 @@ def test_functest():
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
             yield check_functest, scheme.name, implementation.name
+
+
+def test_functest_sanitizers():
+    for scheme in pqclean.Scheme.all_schemes():
+        for implementation in scheme.implementations:
+            yield check_functest_sanitizers, scheme.name, implementation.name
 
 
 def check_functest(scheme_name, implementation_name):
@@ -28,6 +37,24 @@ def check_functest(scheme_name, implementation_name):
         ['./functest_{}_{}'.format(scheme_name, implementation_name)],
         os.path.join('..', 'bin'),
     )
+
+
+def check_functest_sanitizers(scheme_name, implementation_name):
+    if platform.machine() not in ['i386', 'x86_64']:
+        raise unittest.SkipTest()
+    implementation = pqclean.Implementation.by_name(
+        scheme_name, implementation_name)
+    helpers.make('clean-scheme', 'functest',
+                 TYPE=implementation.scheme.type,
+                 SCHEME=scheme_name,
+                 IMPLEMENTATION=implementation_name,
+                 working_dir=os.path.join('..', 'test'),
+                 EXTRAFLAGS='-fsanitize=address,undefined')
+    helpers.run_subprocess(
+        ['./functest_{}_{}'.format(scheme_name, implementation_name)],
+        os.path.join('..', 'bin'),
+    )
+    return check_functest(scheme_name, implementation_name)
 
 
 if __name__ == '__main__':

--- a/test/test_valgrind.py
+++ b/test/test_valgrind.py
@@ -1,0 +1,40 @@
+"""
+Runs the test files under valgrind to detect memory problems
+"""
+
+import os
+import platform
+import unittest
+
+import pqclean
+import helpers
+
+
+def test_functest():
+    for scheme in pqclean.Scheme.all_schemes():
+        for implementation in scheme.implementations:
+            yield check_valgrind, implementation
+
+
+def check_valgrind(implementation: pqclean.Implementation):
+    if (platform.machine() not in ('i386', 'x86_64') or
+            platform.system() != 'Linux'):
+        raise unittest.SkipTest()
+
+    helpers.make(TYPE=implementation.scheme.type,
+                 SCHEME=implementation.scheme.name,
+                 IMPLEMENTATION=implementation.name,
+                 working_dir=os.path.join('..', 'test'))
+    functest_name = './functest_{}_{}'.format(implementation.scheme.name,
+                                              implementation.name)
+    helpers.run_subprocess(['valgrind', functest_name],
+                           os.path.join('..', 'bin'))
+
+
+if __name__ == '__main__':
+    try:
+        import nose2
+        nose2.main()
+    except ImportError:
+        import nose
+        nose.runmodule()


### PR DESCRIPTION
Moves Valgrind into the python-based testing framework.

Builds on #53 because I use the new `helper.make` function.