### PR TITLE
Enable some extra warnings

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -15,7 +15,10 @@ COMMON_HEADERS=$(COMMON_DIR)/fips202.h $(COMMON_DIR)/randombytes.h $(COMMON_DIR)
 DEST_DIR=../bin
 
 # This -Wall was supported by the European Commission through the ERC Starting Grant 805031 (EPOQUE)
-CFLAGS=-Wall -Wextra -Wpedantic -Werror -Wundef -std=c99 -I$(COMMON_DIR) $(EXTRAFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 \
+	   -Wundef -Wshadow -Wcast-align -Wpointer-arith \
+	   -fstrict-aliasing -fno-common -pipe \
+	   -I$(COMMON_DIR) $(EXTRAFLAGS)
 
 all: $(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION) $(DEST_DIR)/testvectors_$(SCHEME)_$(IMPLEMENTATION)
 


### PR DESCRIPTION
I've went through various blogposts etc and came up with these extra CFLAGS. I think they should help catch some code smells and stuff like bad pointer casts.

I think there's probably more we could do, or some of these might be more controversial than I'm realising, so I'm open to suggestions.