### PR TITLE
Clean up tests

### DIFF
--- a/test/pqclean.py
+++ b/test/pqclean.py
@@ -59,6 +59,9 @@ class Scheme:
             print("Can't open {}: {}".format(metafile, e))
             return None
 
+    def __repr__(self):
+        return "<{}({})>".format(self.type.title(), self.name)
+
 
 class Implementation:
 
@@ -96,7 +99,7 @@ class Implementation:
         return "{} implementation of {}".format(self.name, self.scheme.name)
 
     def __repr__(self):
-        return "<Implementation({}, {})>".format(self.name, self.scheme.name)
+        return "<Implementation({}, {})>".format(self.scheme.name, self.name)
 
 
 class KEM(Scheme):

--- a/test/test_compile_lib.py
+++ b/test/test_compile_lib.py
@@ -10,20 +10,11 @@ import helpers
 def test_compile_lib():
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
-            yield check_compile_lib, scheme.name, implementation.name
+            yield check_compile_lib, implementation
 
 
-def check_compile_lib(scheme_name, implementation_name):
-    implementation = pqclean.Implementation.by_name(
-            scheme_name, implementation_name)
-    helpers.run_subprocess(
-        ['make', 'clean'],
-        implementation.path()
-    )
-    helpers.run_subprocess(
-        ['make'],
-        implementation.path()
-    )
+def check_compile_lib(implementation):
+    helpers.make(working_dir=implementation.path())
 
 
 if __name__ == '__main__':

--- a/test/test_dynamic_memory.py
+++ b/test/test_dynamic_memory.py
@@ -15,21 +15,15 @@ def test_dynamic_memory():
         for implementation in scheme.implementations:
             # Keep this loop outside, to allow multiple assertions
             for function in ['malloc', 'free', 'realloc', 'calloc']:
-                yield (check_dynamic_memory,
-                       scheme.name, implementation.name, function)
+                yield (check_dynamic_memory, implementation, function)
 
 
-def check_dynamic_memory(scheme_name, implementation_name, function):
-    implementation = pqclean.Implementation.by_name(
-        scheme_name, implementation_name)
+def check_dynamic_memory(implementation, function):
     # 'make' will take care of not rebuilding existing library files
-    helpers.run_subprocess(
-        ['make'],
-        implementation.path()
-    )
+    helpers.make(working_dir=implementation.path())
+    scheme_name = implementation.scheme.name
     out = helpers.run_subprocess(
-        ['nm', '-g', 'lib{}_{}.a'.format(scheme_name,
-                                         implementation_name)],
+        ['nm', '-g', 'lib{}_{}.a'.format(scheme_name, implementation.name)],
         implementation.path()
     )
 
@@ -39,6 +33,7 @@ def check_dynamic_memory(scheme_name, implementation_name, function):
         if 'U {}'.format(function) in line:
             raise AssertionError(
                 "Illegal use of dynamic memory function '{}'".format(function))
+
 
 if __name__ == '__main__':
     try:

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -10,12 +10,10 @@ import pqclean
 def test_license():
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
-            yield check_license, scheme.name, implementation.name
+            yield check_license, implementation
 
 
-def check_license(scheme_name, implementation_name):
-    implementation = pqclean.Implementation.by_name(
-        scheme_name, implementation_name)
+def check_license(implementation):
     p1 = os.path.join(implementation.path(), 'LICENSE')
     p2 = os.path.join(implementation.path(), 'LICENSE.txt')
     assert(os.path.isfile(p1) or os.path.isfile(p2))

--- a/test/test_makefile_dependencies.py
+++ b/test/test_makefile_dependencies.py
@@ -14,20 +14,16 @@ def test_makefile_dependencies():
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
             # initial build - want to have *all* files in place at beginning
-            helpers.run_subprocess(['make', 'clean'], implementation.path())
-            helpers.run_subprocess(['make'], implementation.path())
+            helpers.make('clean', working_dir=implementation.path())
+            helpers.make(working_dir=implementation.path())
             # test case for each candidate file
             cfiles = glob.glob(os.path.join(implementation.path(), '*.c'))
             hfiles = glob.glob(os.path.join(implementation.path(), '*.h'))
             for file in cfiles + hfiles:
-                yield (check_makefile_dependencies, scheme.name,
-                       implementation.name, file)
+                yield (check_makefile_dependencies, implementation, file)
 
 
-def check_makefile_dependencies(scheme_name, implementation_name, file):
-    implementation = pqclean.Implementation.by_name(scheme_name,
-                                                    implementation_name)
-
+def check_makefile_dependencies(implementation, file):
     cfiles = glob.glob(os.path.join(implementation.path(), '*.c'))
     hfiles = glob.glob(os.path.join(implementation.path(), '*.h'))
     ofiles = glob.glob(os.path.join(implementation.path(), '*.o'))

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -9,11 +9,10 @@ import pqclean
 
 def test_metadata():
     for scheme in pqclean.Scheme.all_schemes():
-        yield check_metadata, scheme.name
+        yield check_metadata, scheme
 
 
-def check_metadata(scheme_name):
-    scheme = pqclean.Scheme.by_name(scheme_name)
+def check_metadata(scheme):
     metadata = scheme.metadata()
 
     specification = EXPECTED_FIELDS.items()

--- a/test/test_no_symlinks.py
+++ b/test/test_no_symlinks.py
@@ -4,17 +4,15 @@ Checks that no implementation makes use of symbolic links.
 
 import os
 import pqclean
-import sys
+
 
 def test_no_symlinks():
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
-            yield check_no_symlinks, scheme.name, implementation.name
+            yield check_no_symlinks, implementation
 
 
-def check_no_symlinks(scheme_name, implementation_name):
-    implementation = pqclean.Implementation.by_name(
-        scheme_name, implementation_name)
+def check_no_symlinks(implementation):
     for file in os.listdir(implementation.path()):
         fpath = os.path.join(implementation.path(), file)
         if os.path.islink(fpath):

--- a/test/test_symbol_namespace.py
+++ b/test/test_symbol_namespace.py
@@ -14,18 +14,14 @@ def test_symbol_namespace():
         raise unittest.SkipTest()
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
-            yield check_symbol_namespace, scheme.name, implementation.name
+            yield check_symbol_namespace, implementation
 
 
-def check_symbol_namespace(scheme_name, implementation_name):
-    implementation = pqclean.Implementation.by_name(
-        scheme_name, implementation_name)
-    helpers.run_subprocess(
-        ['make'],
-        implementation.path()
-    )
+def check_symbol_namespace(implementation):
+    helpers.make(working_dir=implementation.path())
     out = helpers.run_subprocess(
-        ['nm', '-g', 'lib{}_{}.a'.format(scheme_name, implementation_name)],
+        ['nm', '-g', 'lib{}_{}.a'.format(implementation.scheme.name,
+                                         implementation.name)],
         implementation.path()
     )
 

--- a/test/test_testvectors.py
+++ b/test/test_testvectors.py
@@ -7,26 +7,26 @@ import hashlib
 import os
 import pqclean
 import helpers
-import subprocess
 
 
 def test_testvectors():
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
-            yield check_vectors, scheme.name, implementation.name
+            yield check_vectors, implementation
 
-def check_vectors(scheme_name, implementation_name):
-    scheme = pqclean.Scheme.by_name(scheme_name)
-    implementation = pqclean.Implementation.by_name(scheme_name, implementation_name)
-    helpers.run_subprocess(
-        ['make', 'TYPE=' + implementation.scheme.type, 'SCHEME=' + scheme_name, 'IMPLEMENTATION=' + implementation_name],
-        os.path.join('..', 'test')
-    )
+
+def check_vectors(implementation):
+    helpers.make(TYPE=implementation.scheme.type,
+                 SCHEME=implementation.scheme.name,
+                 IMPLEMENTATION=implementation.name,
+                 working_dir=os.path.join('..', 'test'))
     out = helpers.run_subprocess(
-        ['./testvectors_{}_{}'.format(scheme_name, implementation_name)],
+        ['./testvectors_{}_{}'.format(implementation.scheme.name,
+                                      implementation.name)],
         os.path.join('..', 'bin'),
     )
-    assert(scheme.metadata()['testvectors-sha256'].lower() == hashlib.sha256(out.encode('utf-8')).hexdigest().lower())
+    assert(implementation.scheme.metadata()['testvectors-sha256'].lower()
+           == hashlib.sha256(out.encode('utf-8')).hexdigest().lower())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Modify the tests to no longer construct the classes multiple times and
to have them make use of the new helpers.make() function.