### PR TITLE
Make all apis use the uint8_t and size_t types

### DIFF
--- a/crypto_kem/kyber768/clean/api.h
+++ b/crypto_kem/kyber768/clean/api.h
@@ -1,6 +1,8 @@
 #ifndef API_H
 #define API_H
 
+#include <stdint.h>
+
 #include "params.h"
 
 #define CRYPTO_SECRETKEYBYTES KYBER_SECRETKEYBYTES
@@ -10,10 +12,10 @@
 
 #define CRYPTO_ALGNAME "Kyber768"
 
-int PQCLEAN_KYBER768_CLEAN_crypto_kem_keypair(unsigned char *pk, unsigned char *sk);
+int PQCLEAN_KYBER768_CLEAN_crypto_kem_keypair(uint8_t *pk, uint8_t *sk);
 
-int PQCLEAN_KYBER768_CLEAN_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk);
+int PQCLEAN_KYBER768_CLEAN_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
 
-int PQCLEAN_KYBER768_CLEAN_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned char *sk);
+int PQCLEAN_KYBER768_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
 
 #endif

--- a/crypto_sign/dilithium-iii/clean/api.h
+++ b/crypto_sign/dilithium-iii/clean/api.h
@@ -1,6 +1,9 @@
 #ifndef API_H
 #define API_H
 
+#include <stddef.h>
+#include <stdint.h>
+
 #define MODE 2
 
 #define CRYPTO_PUBLICKEYBYTES 1472U
@@ -9,19 +12,19 @@
 
 #define CRYPTO_ALGNAME "Dilithium-III"
 
-int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_keypair(unsigned char *pk,
-        unsigned char *sk);
+int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_keypair(uint8_t *pk,
+        uint8_t *sk);
 
-int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign(unsigned char *sm,
-        unsigned long long *smlen,
-        const unsigned char *msg,
-        unsigned long long len,
-        const unsigned char *sk);
+int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign(uint8_t *sm,
+        size_t *smlen,
+        const uint8_t *msg,
+        size_t len,
+        const uint8_t *sk);
 
-int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_open(unsigned char *m,
-        unsigned long long *mlen,
-        const unsigned char *sm,
-        unsigned long long smlen,
-        const unsigned char *pk);
+int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_open(uint8_t *m,
+        size_t *mlen,
+        const uint8_t *sm,
+        size_t smlen,
+        const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium-iii/clean/sign.c
+++ b/crypto_sign/dilithium-iii/clean/sign.c
@@ -102,15 +102,15 @@ void PQCLEAN_DILITHIUMIII_CLEAN_challenge(poly *c, const unsigned char mu[CRHBYT
  *
  * Description: Generates public and private key.
  *
- * Arguments:   - unsigned char *pk: pointer to output public key (allocated
+ * Arguments:   - uint8_t *pk: pointer to output public key (allocated
  *                                   array of CRYPTO_PUBLICKEYBYTES bytes)
- *              - unsigned char *sk: pointer to output private key (allocated
+ *              - uint8_t *sk: pointer to output private key (allocated
  *                                   array of CRYPTO_SECRETKEYBYTES bytes)
  *
  * Returns 0 (success)
  **************************************************/
-int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_keypair(unsigned char *pk,
-        unsigned char *sk) {
+int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_keypair(uint8_t *pk,
+        uint8_t *sk) {
     unsigned int i;
     unsigned char seedbuf[3 * SEEDBYTES];
     unsigned char tr[CRHBYTES];
@@ -168,26 +168,25 @@ int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_keypair(unsigned char *pk,
  *
  * Description: Compute signed message.
  *
- * Arguments:   - unsigned char *sm: pointer to output signed message (allocated
+ * Arguments:   - uint8_t *sm: pointer to output signed message (allocated
  *                                   array with CRYPTO_BYTES + mlen bytes),
  *                                   can be equal to m
- *              - unsigned long long *smlen: pointer to output length of signed
+ *              - size_t *smlen: pointer to output length of signed
  *                                           message
- *              - const unsigned char *m: pointer to message to be signed
- *              - unsigned long long mlen: length of message
- *              - const unsigned char *sk: pointer to bit-packed secret key
+ *              - const uint8_t *m: pointer to message to be signed
+ *              - size_t mlen: length of message
+ *              - const uint8_t *sk: pointer to bit-packed secret key
  *
  * Returns 0 (success)
  **************************************************/
-int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign(unsigned char *sm,
-        unsigned long long *smlen,
-        const unsigned char *m,
-        unsigned long long mlen,
-        const unsigned char *sk) {
+int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign(uint8_t *sm,
+        size_t *smlen,
+        const uint8_t *m,
+        size_t mlen,
+        const uint8_t *sk) {
     unsigned long long i, j;
     unsigned int n;
-    unsigned char
-    seedbuf[2 * SEEDBYTES + CRHBYTES]; // TODO(thom): nonce in seedbuf (2x)
+    unsigned char seedbuf[2 * SEEDBYTES + CRHBYTES]; // TODO(thom): nonce in seedbuf (2x)
     unsigned char tr[CRHBYTES];
     unsigned char *rho, *key, *mu;
     uint16_t nonce = 0;
@@ -307,20 +306,20 @@ rej:
  *
  * Description: Verify signed message.
  *
- * Arguments:   - unsigned char *m: pointer to output message (allocated
+ * Arguments:   - uint8_t *m: pointer to output message (allocated
  *                                  array with smlen bytes), can be equal to sm
- *              - unsigned long long *mlen: pointer to output length of message
- *              - const unsigned char *sm: pointer to signed message
- *              - unsigned long long smlen: length of signed message
- *              - const unsigned char *sk: pointer to bit-packed public key
+ *              - size_t *mlen: pointer to output length of message
+ *              - const uint8_t *sm: pointer to signed message
+ *              - size_t smlen: length of signed message
+ *              - const uint8_t *sk: pointer to bit-packed public key
  *
  * Returns 0 if signed message could be verified correctly and -1 otherwise
  **************************************************/
-int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_open(unsigned char *m,
-        unsigned long long *mlen,
-        const unsigned char *sm,
-        unsigned long long smlen,
-        const unsigned char *pk) {
+int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_open(uint8_t *m,
+        size_t *mlen,
+        const uint8_t *sm,
+        size_t smlen,
+        const uint8_t *pk) {
     unsigned long long i;
     unsigned char rho[SEEDBYTES];
     unsigned char mu[CRHBYTES];
@@ -394,7 +393,7 @@ int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_open(unsigned char *m,
 
     /* Signature verification failed */
 badsig:
-    *mlen = (unsigned long long) -1;
+    *mlen = 0;
     for (i = 0; i < smlen; ++i) {
         m[i] = 0;
     }

--- a/crypto_sign/dilithium-iii/clean/sign.h
+++ b/crypto_sign/dilithium-iii/clean/sign.h
@@ -1,28 +1,30 @@
 #ifndef SIGN_H
 #define SIGN_H
+#include <stddef.h>
+#include <stdint.h>
 
 #include "params.h"
 #include "poly.h"
 #include "polyvec.h"
 
 void PQCLEAN_DILITHIUMIII_CLEAN_expand_mat(polyvecl mat[K],
-        const unsigned char rho[SEEDBYTES]);
-void PQCLEAN_DILITHIUMIII_CLEAN_challenge(poly *c, const unsigned char mu[CRHBYTES],
+        const uint8_t rho[SEEDBYTES]);
+void PQCLEAN_DILITHIUMIII_CLEAN_challenge(poly *c, const uint8_t mu[CRHBYTES],
         const polyveck *w1);
 
-int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_keypair(unsigned char *pk,
-        unsigned char *sk);
+int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_keypair(uint8_t *pk,
+        uint8_t *sk);
 
-int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign(unsigned char *sm,
-        unsigned long long *smlen,
-        const unsigned char *m,
-        unsigned long long mlen,
-        const unsigned char *sk);
+int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign(uint8_t *sm,
+        size_t *smlen,
+        const uint8_t *m,
+        size_t mlen,
+        const uint8_t *sk);
 
-int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_open(unsigned char *m,
-        unsigned long long *mlen,
-        const unsigned char *sm,
-        unsigned long long smlen,
-        const unsigned char *pk);
+int PQCLEAN_DILITHIUMIII_CLEAN_crypto_sign_open(uint8_t *m,
+        size_t *mlen,
+        const uint8_t *sm,
+        size_t smlen,
+        const uint8_t *pk);
 
 #endif

--- a/test/crypto_kem/functest.c
+++ b/test/crypto_kem/functest.c
@@ -1,27 +1,30 @@
-#include "api.h"
-#include "randombytes.h"
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
+#include "api.h"
+#include "randombytes.h"
+
 #define NTESTS 10
 
-const unsigned char canary[8] = {
+const uint8_t canary[8] = {
     0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF
 };
 
 /* allocate a bit more for all keys and messages and
  * make sure it is not touched by the implementations.
  */
-static void write_canary(unsigned char *d) {
+static void write_canary(uint8_t *d) {
     for (int i = 0; i < 8; i++) {
         d[i] = canary[i];
     }
 }
 
-static int check_canary(const unsigned char *d) {
+static int check_canary(const uint8_t *d) {
     for (int i = 0; i < 8; i++) {
-        if (d[i] != canary[i])
+        if (d[i] != canary[i]) {
             return -1;
+        }
     }
     return 0;
 }
@@ -47,11 +50,11 @@ static int test_keys(void) {
      * 16 extra bytes for canary
      * 1 extra byte for unalignment
      */
-    unsigned char key_a_aligned[CRYPTO_BYTES + 16 + 1];
-    unsigned char key_b_aligned[CRYPTO_BYTES + 16 + 1];
-    unsigned char pk_aligned[CRYPTO_PUBLICKEYBYTES + 16 + 1];
-    unsigned char sendb_aligned[CRYPTO_CIPHERTEXTBYTES + 16 + 1];
-    unsigned char sk_a_aligned[CRYPTO_SECRETKEYBYTES + 16 + 1];
+    uint8_t key_a_aligned[CRYPTO_BYTES + 16 + 1];
+    uint8_t key_b_aligned[CRYPTO_BYTES + 16 + 1];
+    uint8_t pk_aligned[CRYPTO_PUBLICKEYBYTES + 16 + 1];
+    uint8_t sendb_aligned[CRYPTO_CIPHERTEXTBYTES + 16 + 1];
+    uint8_t sk_a_aligned[CRYPTO_SECRETKEYBYTES + 16 + 1];
 
     /*
      * Make sure all pointers are odd.
@@ -59,11 +62,11 @@ static int test_keys(void) {
      * data alignment. For example this would catch if an implementation
      * directly uses these pointers to load into vector registers using movdqa.
      */
-    unsigned char *key_a = (unsigned char *) ((uintptr_t) key_a_aligned|(uintptr_t) 1);
-    unsigned char *key_b = (unsigned char *) ((uintptr_t) key_b_aligned|(uintptr_t) 1);
-    unsigned char *pk    = (unsigned char *) ((uintptr_t) pk_aligned|(uintptr_t) 1);
-    unsigned char *sendb = (unsigned char *) ((uintptr_t) sendb_aligned|(uintptr_t) 1);
-    unsigned char *sk_a  = (unsigned char *) ((uintptr_t) sk_a_aligned|(uintptr_t) 1);
+    uint8_t *key_a = (uint8_t *) ((uintptr_t) key_a_aligned|(uintptr_t) 1);
+    uint8_t *key_b = (uint8_t *) ((uintptr_t) key_b_aligned|(uintptr_t) 1);
+    uint8_t *pk    = (uint8_t *) ((uintptr_t) pk_aligned|(uintptr_t) 1);
+    uint8_t *sendb = (uint8_t *) ((uintptr_t) sendb_aligned|(uintptr_t) 1);
+    uint8_t *sk_a  = (uint8_t *) ((uintptr_t) sk_a_aligned|(uintptr_t) 1);
 
     /*
      * Write 8 byte canary before and after the actual memory regions.
@@ -114,10 +117,10 @@ static int test_keys(void) {
 }
 
 static int test_invalid_sk_a(void) {
-    unsigned char sk_a[CRYPTO_SECRETKEYBYTES];
-    unsigned char key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
-    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
-    unsigned char sendb[CRYPTO_CIPHERTEXTBYTES];
+    uint8_t sk_a[CRYPTO_SECRETKEYBYTES];
+    uint8_t key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
+    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+    uint8_t sendb[CRYPTO_CIPHERTEXTBYTES];
     int i;
     int returncode;
 
@@ -149,16 +152,16 @@ static int test_invalid_sk_a(void) {
 }
 
 static int test_invalid_ciphertext(void) {
-    unsigned char sk_a[CRYPTO_SECRETKEYBYTES];
-    unsigned char key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
-    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
-    unsigned char sendb[CRYPTO_CIPHERTEXTBYTES];
+    uint8_t sk_a[CRYPTO_SECRETKEYBYTES];
+    uint8_t key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
+    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+    uint8_t sendb[CRYPTO_CIPHERTEXTBYTES];
     int i;
     size_t pos;
     int returncode;
 
     for (i = 0; i < NTESTS; i++) {
-        randombytes((unsigned char *)&pos, sizeof(size_t));
+        randombytes((uint8_t *)&pos, sizeof(size_t));
 
         // Alice generates a public key
         RETURNS_ZERO(crypto_kem_keypair(pk, sk_a));

--- a/test/crypto_kem/testvectors.c
+++ b/test/crypto_kem/testvectors.c
@@ -1,12 +1,15 @@
-#include "api.h"
-#include "randombytes.h"
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
+#include "api.h"
+#include "randombytes.h"
+
 #define NTESTS 100
 
-static void printbytes(const unsigned char *x, unsigned long long xlen) {
-    unsigned long long i;
+static void printbytes(const uint8_t *x, size_t xlen) {
+    size_t i;
     for (i = 0; i < xlen; i++) {
         printf("%02x", x[i]);
     }
@@ -23,10 +26,10 @@ static void printbytes(const unsigned char *x, unsigned long long xlen) {
 #define crypto_kem_dec NAMESPACE(crypto_kem_dec)
 
 int main(void) {
-    unsigned char key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
-    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
-    unsigned char sendb[CRYPTO_CIPHERTEXTBYTES];
-    unsigned char sk_a[CRYPTO_SECRETKEYBYTES];
+    uint8_t key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
+    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+    uint8_t sendb[CRYPTO_CIPHERTEXTBYTES];
+    uint8_t sk_a[CRYPTO_SECRETKEYBYTES];
     int i, j;
     for (i = 0; i < NTESTS; i++) {
         // Key-pair generation

--- a/test/crypto_sign/functest.c
+++ b/test/crypto_sign/functest.c
@@ -1,28 +1,32 @@
-#include "api.h"
-#include "randombytes.h"
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "api.h"
+#include "randombytes.h"
 
 #define NTESTS 15
 #define MLEN 32
 
-const unsigned char canary[8] = {
+const uint8_t canary[8] = {
     0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF
 };
 
 /* allocate a bit more for all keys and messages and
  * make sure it is not touched by the implementations.
  */
-static void write_canary(unsigned char *d) {
+static void write_canary(uint8_t *d) {
     for (int i = 0; i < 8; i++) {
         d[i] = canary[i];
     }
 }
 
-static int check_canary(const unsigned char *d) {
+static int check_canary(const uint8_t *d) {
     for (int i = 0; i < 8; i++) {
-        if (d[i] != canary[i])
+        if (d[i] != canary[i]) {
             return -1;
+        }
     }
     return 0;
 }
@@ -48,10 +52,10 @@ static int test_sign(void) {
      * 16 extra bytes for canary
      * 1 extra byte for unalignment
      */
-    unsigned char pk_aligned[CRYPTO_PUBLICKEYBYTES + 16 + 1];
-    unsigned char sk_aligned[CRYPTO_SECRETKEYBYTES + 16 + 1];
-    unsigned char sm_aligned[MLEN + CRYPTO_BYTES + 16 + 1];
-    unsigned char m_aligned[MLEN + 16 + 1];
+    uint8_t pk_aligned[CRYPTO_PUBLICKEYBYTES + 16 + 1];
+    uint8_t sk_aligned[CRYPTO_SECRETKEYBYTES + 16 + 1];
+    uint8_t sm_aligned[MLEN + CRYPTO_BYTES + 16 + 1];
+    uint8_t m_aligned[MLEN + 16 + 1];
 
     /*
      * Make sure all pointers are odd.
@@ -59,13 +63,13 @@ static int test_sign(void) {
      * data alignment. For example this would catch if an implementation
      * directly uses these pointers to load into vector registers using movdqa.
      */
-    unsigned char *pk = (unsigned char *) ((uintptr_t) pk_aligned|(uintptr_t) 1);
-    unsigned char *sk = (unsigned char *) ((uintptr_t) sk_aligned|(uintptr_t) 1);
-    unsigned char *sm = (unsigned char *) ((uintptr_t) sm_aligned|(uintptr_t) 1);
-    unsigned char *m  = (unsigned char *) ((uintptr_t) m_aligned|(uintptr_t) 1);
+    uint8_t *pk = (uint8_t *) ((uintptr_t) pk_aligned|(uintptr_t) 1);
+    uint8_t *sk = (uint8_t *) ((uintptr_t) sk_aligned|(uintptr_t) 1);
+    uint8_t *sm = (uint8_t *) ((uintptr_t) sm_aligned|(uintptr_t) 1);
+    uint8_t *m  = (uint8_t *) ((uintptr_t) m_aligned|(uintptr_t) 1);
 
-    unsigned long long mlen;
-    unsigned long long smlen;
+    size_t mlen;
+    size_t smlen;
     int returncode;
 
     int i;
@@ -114,14 +118,14 @@ static int test_sign(void) {
 }
 
 static int test_wrong_pk(void) {
-    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
-    unsigned char pk2[CRYPTO_PUBLICKEYBYTES];
-    unsigned char sk[CRYPTO_SECRETKEYBYTES];
-    unsigned char sm[MLEN + CRYPTO_BYTES];
-    unsigned char m[MLEN];
+    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+    uint8_t pk2[CRYPTO_PUBLICKEYBYTES];
+    uint8_t sk[CRYPTO_SECRETKEYBYTES];
+    uint8_t sm[MLEN + CRYPTO_BYTES];
+    uint8_t m[MLEN];
 
-    unsigned long long mlen;
-    unsigned long long smlen;
+    size_t mlen;
+    size_t smlen;
 
     int returncode;
 

--- a/test/crypto_sign/testvectors.c
+++ b/test/crypto_sign/testvectors.c
@@ -1,13 +1,16 @@
-#include "api.h"
-#include "randombytes.h"
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "api.h"
+#include "randombytes.h"
 
 #define NTESTS 100
 #define MAXMLEN 2048
 
-static void printbytes(const unsigned char *x, unsigned long long xlen) {
-    unsigned long long i;
+static void printbytes(const uint8_t *x, size_t xlen) {
+    size_t i;
     for (i = 0; i < xlen; i++) {
         printf("%02x", x[i]);
     }
@@ -24,16 +27,16 @@ static void printbytes(const unsigned char *x, unsigned long long xlen) {
 #define crypto_sign_open NAMESPACE(crypto_sign_open)
 
 int main(void) {
-    unsigned char sk[CRYPTO_SECRETKEYBYTES];
-    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+    uint8_t sk[CRYPTO_SECRETKEYBYTES];
+    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
 
-    unsigned char mi[MAXMLEN];
-    unsigned char sm[MAXMLEN + CRYPTO_BYTES];
-    unsigned long long smlen;
-    unsigned long long mlen;
+    uint8_t mi[MAXMLEN];
+    uint8_t sm[MAXMLEN + CRYPTO_BYTES];
+    size_t smlen;
+    size_t mlen;
 
     int r;
-    unsigned long long i, k;
+    size_t i, k;
 
     for (i = 0; i < MAXMLEN; i = (i == 0) ? i + 1 : i << 1) {
         randombytes(mi, i);


### PR DESCRIPTION
While we may not want to start (imposing) cleaning up the internals of implementations, I do think we should already prepare the API to use the `uint8_t` and `size_t` types over `unsigned char` and `unsigned long long`, because otherwise consumers might need to change their wrappers/interfacing with adoptions of PQClean-provided schemes.