### PR TITLE
Prohibit using char without explicit sign modifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ version: 2
           docker run -e CI=true --rm -v `pwd`:`pwd` -w `pwd` "pqclean/ci-container:$ARCH" /bin/bash -c "
           uname -a &&
           export CC=${CC} &&
+          pip3 install -r requirements.txt
           cd test && python3 -m nose --rednose --verbose"
 
 .native_job: &nativejob

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ version: 2
         name: Run tests
         command: |
           export CC=${CC}
+          pip3 install -r requirements.txt
           cd test && python3 -m nose --rednose --verbose
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,11 @@ version: 2
   steps:
     - checkout
     - run:
+        name: Pull submodules
+        command: |
+          git submodule init
+          git submodule update
+    - run:
         name: Install the emulation handlers
         command: docker run --rm --privileged multiarch/qemu-user-static:register --reset
     - run:
@@ -20,6 +25,11 @@ version: 2
     - image: pqclean/ci-container:$ARCH
   steps:
     - checkout
+    - run:
+        name: Pull submodules
+        command: |
+          git submodule init
+          git submodule update
     - run:
         name: Run tests
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ version: 2
           docker run -e CI=true --rm -v `pwd`:`pwd` -w `pwd` "pqclean/ci-container:$ARCH" /bin/bash -c "
           uname -a &&
           export CC=${CC} &&
-          pip3 install -r requirements.txt
+          pip3 install -r requirements.txt &&
           cd test && python3 -m nose --rednose --verbose"
 
 .native_job: &nativejob
@@ -35,7 +35,7 @@ version: 2
         name: Run tests
         command: |
           export CC=${CC}
-          pip3 install -r requirements.txt
+          pip3 install -r requirements.txt &&
           cd test && python3 -m nose --rednose --verbose
 
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/pycparser"]
+	path = test/pycparser
+	url = https://github.com/eliben/pycparser.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
         - pip3 install -r requirements.txt
         - export PATH="/usr/local/bin:$PATH"
         - ln -s /usr/local/Cellar/gcc/8.3.0/bin/gcc-8 /usr/local/bin/gcc
-        - ln -s /usr/local/Cellar/gcc/8.3.0/bin/cpp-8 /usr/local/bin/cpp
         - gcc --version
       script:
         - "cd test && python3 -m nose --rednose --verbose"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,12 @@ matrix:
         homebrew:
           packages:
             - astyle
-            - gcc
+            - gcc@8
       before_install:
         - pip3 install -r requirements.txt
+        - brew link gcc
         - export PATH="/usr/local/bin:$PATH"
-        - ln -s /usr/local/Cellar/gcc/8.3.0/bin/gcc-8 /usr/local/bin/gcc
+        - ln -s /usr/local/bin/gcc-8 /usr/local/bin/gcc
         - gcc --version
       script:
         - "cd test && python3 -m nose --rednose --verbose"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,12 @@ matrix:
         homebrew:
           packages:
             - astyle
-            - gcc@8
+            - gcc
       before_install:
         - pip3 install -r requirements.txt
+        - export PATH="/usr/local/bin:$PATH"
+        - ln -s /usr/local/Cellar/gcc/8.3.0/bin/gcc-8 /usr/local/bin/gcc
+        - ln -s /usr/local/Cellar/gcc/8.3.0/bin/cpp-8 /usr/local/bin/cpp
         - gcc --version
       script:
         - "cd test && python3 -m nose --rednose --verbose"

--- a/README.md
+++ b/README.md
@@ -139,10 +139,16 @@ To do this, make sure the following is installed:
 * Python 3.5+
 * `nosetests` or `nose2` (either for Python 3)
 
+You will also need to make sure the submodules are initialized by running:
+
+```
+git submodule update --init
+```
+
 Run the Python-based tests by going into the `test` directory and running `nosetests -v` or `nose2 -B -v`, depending on what you installed.
 If you have the `rednose` plugin for `nosetests` installed, run `nosetests --rednose` to get colored output.
 
-You may also run `python <testmodule>` where `<testmodule>` is any of the files starting with `test_` in the `test/` folder.
+You may also run `python3 <testmodule>` where `<testmodule>` is any of the files starting with `test_` in the `test/` folder.
 
 [circleci-pqc]: https://circleci.com/gh/PQClean/PQClean/
 [travis-pqc]: https://travis-ci.com/PQClean/PQClean/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML
 nose
 rednose
+pycparser

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -86,7 +86,6 @@ def ensure_available(executable):
     """
     path = shutil.which(executable)
     if path:
-        print("Found", path)
         return path
 
     # Installing clang-tidy on LLVM will be too much of a mess.

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -7,8 +7,7 @@ This is ambiguous; compilers can freely choose `signed` or `unsigned` char.
 import pqclean
 import pycparser
 import os
-import unittest
-import shutil
+import helpers
 
 
 def test_char():
@@ -26,9 +25,8 @@ def walk_tree(ast):
         yield from walk_tree(child)  # recursively yield prohibited nodes
 
 
+@helpers.skip_windows()
 def check_char(implementation):
-    if not shutil.which('cpp'):
-        raise unittest.SkipTest("C pre-processor (cpp) was not found.")
     errors = []
     for fname in os.listdir(implementation.path()):
         if not fname.endswith(".c"):

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -35,7 +35,7 @@ def check_char(implementation):
         ast = pycparser.parse_file(
             os.path.join(implementation.path(), fname),
             use_cpp=True,
-            cpp_path='cc',
+            cpp_path='cc',  # not all platforms link cpp correctly; cc -E works
             cpp_args=[
                 '-E',
                 '-std=c99',

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -37,7 +37,9 @@ def check_char(implementation):
         ast = pycparser.parse_file(
             os.path.join(implementation.path(), fname),
             use_cpp=True,
+            cpp_path='cc',
             cpp_args=[
+                '-E',
                 '-std=c99',
                 '-nostdinc',  # pycparser cannot deal with e.g. __attribute__
                 '-I{}'.format(os.path.join(tdir, "../common")),

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -1,0 +1,62 @@
+
+"""
+Checks that the implementation does not make use of the `char` type.
+This is ambiguous; compilers can freely choose `signed` or `unsigned` char.
+"""
+
+import pqclean
+import pycparser
+import os
+
+
+def test_char():
+    for scheme in pqclean.Scheme.all_schemes():
+        for implementation in scheme.implementations:
+            yield check_char, implementation
+
+
+def walk_tree(ast):
+    if type(ast) is pycparser.c_ast.IdentifierType:
+        if ast.names == ['char']:
+            yield ast
+
+    for (_, child) in ast.children():
+        yield from walk_tree(child)  # recursively yield prohibited nodes
+
+
+def check_char(implementation):
+    errors = []
+    for fname in os.listdir(implementation.path()):
+        if not fname.endswith(".c"):
+            continue
+        tdir, _ = os.path.split(os.path.realpath(__file__))
+        ast = pycparser.parse_file(
+            os.path.join(implementation.path(), fname),
+            use_cpp=True,
+            cpp_args=[
+                '-nostdinc',  # pycparser cannot deal with e.g. __attribute__
+                '-I{}'.format(os.path.join(tdir, "../common")),
+                # necessary to mock e.g. <stdint.h>
+                '-I{}'.format(
+                    os.path.join(tdir, 'pycparser/utils/fake_libc_include')),
+            ]
+        )
+        for node in walk_tree(ast):
+            # flatten nodes to a string to easily enforce uniqueness
+            err = "\n at {c.file}:{c.line}:{c.column}".format(c=node.coord)
+            if err not in errors:
+                errors.append(err)
+    if errors:
+        raise AssertionError(
+            "Prohibited use of char without explicit signed/unsigned" +
+            "".join(errors)
+        )
+
+
+if __name__ == '__main__':
+    try:
+        import nose2
+        nose2.main()
+    except ImportError:
+        import nose
+        nose.runmodule()

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -7,6 +7,8 @@ This is ambiguous; compilers can freely choose `signed` or `unsigned` char.
 import pqclean
 import pycparser
 import os
+import unittest
+import shutil
 
 
 def test_char():
@@ -25,6 +27,8 @@ def walk_tree(ast):
 
 
 def check_char(implementation):
+    if not shutil.which('cpp'):
+        raise unittest.SkipTest("C pre-processor (cpp) was not found.")
     errors = []
     for fname in os.listdir(implementation.path()):
         if not fname.endswith(".c"):
@@ -34,6 +38,7 @@ def check_char(implementation):
             os.path.join(implementation.path(), fname),
             use_cpp=True,
             cpp_args=[
+                '-std=c99',
                 '-nostdinc',  # pycparser cannot deal with e.g. __attribute__
                 '-I{}'.format(os.path.join(tdir, "../common")),
                 # necessary to mock e.g. <stdint.h>


### PR DESCRIPTION
Related to #79; compilers are free to choose whether `char` is signed or unsigned.