### PR TITLE
Add remaining length values to META.yml

### DIFF
--- a/crypto_kem/frodokem640shake/META.yml
+++ b/crypto_kem/frodokem640shake/META.yml
@@ -2,7 +2,9 @@ name: FrodoKEM-640-SHAKE
 type: kem
 claimed-nist-level: 1
 length-public-key: 9616
+length-secret-key: 19888
 length-ciphertext: 9720
+length-shared-secret: 16
 testvectors-sha256: 521ff891de20efe74e6584d09612dae989427ac76261a41630c4e4d6a4fc78a4
 principal-submitter: Douglas Stebila, University of Waterloo
 auxiliary-submitters:

--- a/crypto_kem/kyber768/META.yml
+++ b/crypto_kem/kyber768/META.yml
@@ -2,7 +2,9 @@ name: Kyber768
 type: kem
 claimed-nist-level: 3
 length-public-key: 1088
+length-secret-key: 2400
 length-ciphertext: 1152
+length-shared-secret: 256
 testvectors-sha256: 0e002ee528febdab1709f100df79ceb00b31a809e03a4fb84e3a72c39235d372
 principal-submitter: Peter Schwabe
 auxiliary-submitters:

--- a/crypto_sign/dilithium-iii/META.yml
+++ b/crypto_sign/dilithium-iii/META.yml
@@ -2,6 +2,7 @@ name: Dilithium-III
 type: signature
 claimed-nist-level: 3
 length-public-key: 1472
+length-secret-key: 3504
 length-signature: 2701
 testvectors-sha256: e1852a975842c44a683c914ed131d95bee9b786c36c41e47bb77d7dd3c0c07be
 principal-submitter: Vadim Lyubashevsky

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -42,6 +42,7 @@ EXPECTED_FIELDS = {
     'type': {'type': str},
     'claimed-nist-level': {'type': int, 'min': 1, 'max': 5},
     'length-public-key': {'type': int, 'min': 1},
+    'length-secret-key': {'type': int, 'min': 1},
     'testvectors-sha256': {'type': str, 'length': 64},
     'principal-submitter': {'type': str},
     'auxiliary-submitters': {'type': list, 'elements': {'type': str}},
@@ -59,6 +60,7 @@ EXPECTED_FIELDS = {
 
 KEM_FIELDS = {
     'length-ciphertext': {'type': int, 'min': 1},
+    'length-shared-secret': {'type': int, 'min': 1},
 }
 
 SIGNATURE_FIELDS = {


### PR DESCRIPTION
Fixes #84

<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->


## Manually checked properties
<!-- These checkboxes serve for the maintainers of PQClean to verify your submission. Please do not check them yourself. -->

* [ ] `#ifdef`s only for header encapsulation
* [ ] `api.h` does not include other files
* [ ] No stringification macros
* [ ] Output-parameter pointers in functions are on the left
* [ ] Negative return values on failure of API functions (within restrictions of FO transform).
* [ ] `const` arguments are labeled as `const`
* [ ] variable declarations at the beginning (except in `for (size_t i=...`)
* Optional:
  * [ ] All integer types are of fixed size, using `stdint.h` types (including `uint8_t` instead of `unsigned char`)
  * [ ] Integers used for indexing are of size `size_t`
