### PR TITLE
Move secret-key length in META file

### DIFF
--- a/crypto_kem/frodokem640shake/META.yml
+++ b/crypto_kem/frodokem640shake/META.yml
@@ -2,7 +2,6 @@ name: FrodoKEM-640-SHAKE
 type: kem
 claimed-nist-level: 1
 length-public-key: 9616
-length-secret-key: 19888
 length-ciphertext: 9720
 length-shared-secret: 16
 testvectors-sha256: 8f922de02d41005fcc3c4164b2ab74c4c7b588ed69e34e22607d1ae4ab13d2c5
@@ -22,3 +21,4 @@ auxiliary-submitters:
 implementations:
     - name: clean
       version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/437e228fca580a82435cab09f30ae14b03183119
+      length-secret-key: 19888

--- a/crypto_kem/kyber768/META.yml
+++ b/crypto_kem/kyber768/META.yml
@@ -2,7 +2,6 @@ name: Kyber768
 type: kem
 claimed-nist-level: 3
 length-public-key: 1088
-length-secret-key: 2400
 length-ciphertext: 1152
 length-shared-secret: 32
 testvectors-sha256: 2f5cf9937959eb4a3bc910f71e830e9e0de029b28093c6192d2c3e915913016f
@@ -20,3 +19,4 @@ auxiliary-submitters:
 implementations:
     - name: clean
       version: https://github.com/pq-crystals/kyber/commit/ab996e7460e5356b0e23aa034e7c2fe6922e60e6
+      length-secret-key: 2400

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -42,7 +42,6 @@ EXPECTED_FIELDS = {
     'type': {'type': str},
     'claimed-nist-level': {'type': int, 'min': 1, 'max': 5},
     'length-public-key': {'type': int, 'min': 1},
-    'length-secret-key': {'type': int, 'min': 1},
     'testvectors-sha256': {'type': str, 'length': 64},
     'principal-submitter': {'type': str},
     'auxiliary-submitters': {'type': list, 'elements': {'type': str}},
@@ -53,6 +52,7 @@ EXPECTED_FIELDS = {
             'spec': {
                 'name': {'type': str},
                 'version': {'type': str},
+                'length-secret-key': {'type': int, 'min': 1},
             },
         },
     },

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -29,6 +29,8 @@ def check_metadata(scheme):
 
     implementation_names_in_yaml = set(
         i['name'] for i in metadata['implementations'])
+    if len(implementation_names_in_yaml) != len(metadata['implementations']):
+        raise AssertionError("Implementations in YAML file are not distinct")
     implementations_on_disk = set(i.name for i in scheme.implementations)
     if implementation_names_in_yaml != implementations_on_disk:
         raise AssertionError("Implementations in YAML file {} and "

--- a/test/test_metadata_sizes.py
+++ b/test/test_metadata_sizes.py
@@ -13,6 +13,8 @@ def test_metadata_sizes():
 
 def check_metadata_sizes(implementation):
     metadata = implementation.scheme.metadata()
+    impl_meta = next((impl for impl in metadata['implementations']
+                      if impl['name'] == implementation.name), None)
     helpers.make('printparams',
                  TYPE=implementation.scheme.type,
                  SCHEME=implementation.scheme.name,
@@ -30,7 +32,7 @@ def check_metadata_sizes(implementation):
 
     parsed = json.loads(out)
 
-    assert parsed['CRYPTO_SECRETKEYBYTES'] == metadata['length-secret-key']
+    assert parsed['CRYPTO_SECRETKEYBYTES'] == impl_meta['length-secret-key']
     assert parsed['CRYPTO_PUBLICKEYBYTES'] == metadata['length-public-key']
 
     if implementation.scheme.type == 'kem':


### PR DESCRIPTION
Fixes #84. It probably makes sense to rebase #90 and #83.

Also adds a uniqueness check for implementation names in the YAML file, so that we can reliably use those as identifiers in other tests.