### PR TITLE
test_format wasn't actually checking output of astyle

### DIFF
--- a/crypto_kem/frodokem1344shake/clean/util.c
+++ b/crypto_kem/frodokem1344shake/clean/util.c
@@ -13,7 +13,7 @@
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
 uint16_t PQCLEAN_FRODOKEM1344SHAKE_CLEAN_LE_TO_UINT16(const uint16_t n) {
-    return (((uint8_t *) &(n))[0] | (((uint8_t *) &(n))[1] << 8));
+    return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));
 }
 
 uint16_t PQCLEAN_FRODOKEM1344SHAKE_CLEAN_UINT16_TO_LE(const uint16_t n) {

--- a/crypto_kem/frodokem640shake/clean/util.c
+++ b/crypto_kem/frodokem640shake/clean/util.c
@@ -13,7 +13,7 @@
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
 uint16_t PQCLEAN_FRODOKEM640SHAKE_CLEAN_LE_TO_UINT16(const uint16_t n) {
-    return (((uint8_t *) &(n))[0] | (((uint8_t *) &(n))[1] << 8));
+    return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));
 }
 
 uint16_t PQCLEAN_FRODOKEM640SHAKE_CLEAN_UINT16_TO_LE(const uint16_t n) {

--- a/crypto_kem/frodokem976shake/clean/util.c
+++ b/crypto_kem/frodokem976shake/clean/util.c
@@ -13,7 +13,7 @@
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
 uint16_t PQCLEAN_FRODOKEM976SHAKE_CLEAN_LE_TO_UINT16(const uint16_t n) {
-    return (((uint8_t *) &(n))[0] | (((uint8_t *) &(n))[1] << 8));
+    return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));
 }
 
 uint16_t PQCLEAN_FRODOKEM976SHAKE_CLEAN_UINT16_TO_LE(const uint16_t n) {

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -13,11 +13,12 @@ def check_format(implementation: pqclean.Implementation):
     helpers.ensure_available('astyle')
     cfiles = implementation.cfiles()
     hfiles = implementation.hfiles()
-    helpers.run_subprocess(['astyle',
+    result = helpers.run_subprocess(['astyle',
                     '--dry-run',
                     '--options=../.astylerc',
                     *cfiles,
                     *hfiles])
+    assert(not('Formatted' in result))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It was only checking the return code, but astyle was always returning 0. 
Changed to parse the output and look for the string "Formatted"

<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->


#### Manually checked properties
<!-- These checkboxes serve for the maintainers of PQClean to verify your submission. Please do not check them yourself. -->

* [ ] No stringification macros
* [ ] Output-parameter pointers in functions are on the left
* [ ] Negative return values on failure of API functions (within restrictions of FO transform).
* [ ] `const` arguments are labeled as `const`
* [ ] variable declarations at the beginning (except in `for (size_t i=...`)
* Optional:
  * [ ] All integer types are of fixed size, using `stdint.h` types (including `uint8_t` instead of `unsigned char`)
  * [ ] Integers used for indexing are of size `size_t`
