### PR TITLE
Avoid clang tidy segfault

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -30,8 +30,11 @@ def run_subprocess(command, working_dir='.', env=None, expected_returncode=0):
         env=env,
     )
     print(result.stdout.decode('utf-8'))
-    assert result.returncode == expected_returncode, \
-        "Got unexpected return code {}".format(result.returncode)
+    if expected_returncode is not None:
+        assert result.returncode == expected_returncode, \
+            "Got unexpected return code {}".format(result.returncode)
+    else:
+        return (result.returncode, result.stdout.decode('utf-8'))
     return result.stdout.decode('utf-8')
 
 

--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -34,10 +34,10 @@ def check_tidy(implementation: pqclean.Implementation):
     )
 
     # Detect and gracefully avoid segfaults
-    if returncode == 11:
+    if returncode == -11:
         raise unittest.SkipTest("clang-tidy segfaulted")
-
-    assert returncode == 0, "Clang-tidy returned %d" % returncode
+    else:
+        assert returncode == 0, "Clang-tidy returned %d" % returncode
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If clang-tidy segfaults, just ignore the result.