### PR TITLE
Add -Wmissing-prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _The checking of items on this list is still being developed. Checked items shou
 * [x] Passes functional tests
 * [x] API functions do not write outside provided buffers
 * [x] `api.h` cannot include external files
-* [x] Compiles with `-Wall -Wextra -Wpedantic -Werror` with `gcc` and `clang`
+* [x] Compiles with `-Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes` with `gcc` and `clang`
 * [x] `#if`/`#ifdef`s only for header encapsulation
 * [x] Consistent test vectors across runs
 * [x] Consistent test vectors on big-endian and little-endian machines

--- a/common/aes.c
+++ b/common/aes.c
@@ -62,7 +62,7 @@ static inline void br_enc32le(unsigned char *dst, uint32_t x) {
 }
 
 
-void br_range_enc32le(unsigned char *dst, const uint32_t *v, size_t num) {
+static void br_range_enc32le(unsigned char *dst, const uint32_t *v, size_t num) {
     while (num-- > 0) {
         br_enc32le(dst, *v ++);
         dst += 4;
@@ -387,7 +387,7 @@ static void br_aes_ct64_keysched(uint64_t *comp_skey, const unsigned char *key, 
     }
 }
 
-void br_aes_ct64_skey_expand(uint64_t *skey, const uint64_t *comp_skey, unsigned int nrounds) {
+static void br_aes_ct64_skey_expand(uint64_t *skey, const uint64_t *comp_skey, unsigned int nrounds) {
     unsigned u, v, n;
 
     n = (nrounds + 1) << 1;

--- a/crypto_kem/frodokem1344aes/clean/Makefile
+++ b/crypto_kem/frodokem1344aes/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem1344aes_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_aes.o noise.o util.o
 
-CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem1344aes/clean/noise.c
+++ b/crypto_kem/frodokem1344aes/clean/noise.c
@@ -12,7 +12,7 @@
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;
 
-void PQCLEAN_FRODOKEM1344AES_CLEAN_sample_n(uint16_t *s, const size_t n) {
+void PQCLEAN_FRODOKEM1344AES_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.

--- a/crypto_kem/frodokem1344aes/clean/noise.c
+++ b/crypto_kem/frodokem1344aes/clean/noise.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;

--- a/crypto_kem/frodokem1344aes/clean/util.c
+++ b/crypto_kem/frodokem1344aes/clean/util.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))

--- a/crypto_kem/frodokem1344aes/clean/util.c
+++ b/crypto_kem/frodokem1344aes/clean/util.c
@@ -13,11 +13,11 @@
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
-uint16_t PQCLEAN_FRODOKEM1344AES_CLEAN_LE_TO_UINT16(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM1344AES_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));
 }
 
-uint16_t PQCLEAN_FRODOKEM1344AES_CLEAN_UINT16_TO_LE(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM1344AES_CLEAN_UINT16_TO_LE(uint16_t n) {
     uint16_t y;
     uint8_t *z = (uint8_t *) &y;
     z[0] = n & 0xFF;
@@ -126,7 +126,7 @@ void PQCLEAN_FRODOKEM1344AES_CLEAN_key_decode(uint16_t *out, const uint16_t *in)
 }
 
 
-void PQCLEAN_FRODOKEM1344AES_CLEAN_pack(uint8_t *out, const size_t outlen, const uint16_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM1344AES_CLEAN_pack(uint8_t *out, size_t outlen, const uint16_t *in, size_t inlen, uint8_t lsb) {
     // Pack the input uint16 vector into a char output vector, copying lsb bits from each input element.
     // If inlen * lsb / 8 > outlen, only outlen * 8 bits are copied.
     memset(out, 0, outlen);
@@ -175,7 +175,7 @@ void PQCLEAN_FRODOKEM1344AES_CLEAN_pack(uint8_t *out, const size_t outlen, const
 }
 
 
-void PQCLEAN_FRODOKEM1344AES_CLEAN_unpack(uint16_t *out, const size_t outlen, const uint8_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM1344AES_CLEAN_unpack(uint16_t *out, size_t outlen, const uint8_t *in, size_t inlen, uint8_t lsb) {
     // Unpack the input char vector into a uint16_t output vector, copying lsb bits
     // for each output element from input. outlen must be at least ceil(inlen * 8 / lsb).
     memset(out, 0, outlen * sizeof(uint16_t));

--- a/crypto_kem/frodokem1344shake/clean/Makefile
+++ b/crypto_kem/frodokem1344shake/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem1344shake_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_shake.o noise.o util.o
 
-CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem1344shake/clean/noise.c
+++ b/crypto_kem/frodokem1344shake/clean/noise.c
@@ -12,7 +12,7 @@
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;
 
-void PQCLEAN_FRODOKEM1344SHAKE_CLEAN_sample_n(uint16_t *s, const size_t n) {
+void PQCLEAN_FRODOKEM1344SHAKE_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.

--- a/crypto_kem/frodokem1344shake/clean/noise.c
+++ b/crypto_kem/frodokem1344shake/clean/noise.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;

--- a/crypto_kem/frodokem1344shake/clean/util.c
+++ b/crypto_kem/frodokem1344shake/clean/util.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))

--- a/crypto_kem/frodokem1344shake/clean/util.c
+++ b/crypto_kem/frodokem1344shake/clean/util.c
@@ -13,11 +13,11 @@
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
-uint16_t PQCLEAN_FRODOKEM1344SHAKE_CLEAN_LE_TO_UINT16(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM1344SHAKE_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));
 }
 
-uint16_t PQCLEAN_FRODOKEM1344SHAKE_CLEAN_UINT16_TO_LE(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM1344SHAKE_CLEAN_UINT16_TO_LE(uint16_t n) {
     uint16_t y;
     uint8_t *z = (uint8_t *) &y;
     z[0] = n & 0xFF;
@@ -126,7 +126,7 @@ void PQCLEAN_FRODOKEM1344SHAKE_CLEAN_key_decode(uint16_t *out, const uint16_t *i
 }
 
 
-void PQCLEAN_FRODOKEM1344SHAKE_CLEAN_pack(uint8_t *out, const size_t outlen, const uint16_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM1344SHAKE_CLEAN_pack(uint8_t *out, size_t outlen, const uint16_t *in, size_t inlen, uint8_t lsb) {
     // Pack the input uint16 vector into a char output vector, copying lsb bits from each input element.
     // If inlen * lsb / 8 > outlen, only outlen * 8 bits are copied.
     memset(out, 0, outlen);
@@ -175,7 +175,7 @@ void PQCLEAN_FRODOKEM1344SHAKE_CLEAN_pack(uint8_t *out, const size_t outlen, con
 }
 
 
-void PQCLEAN_FRODOKEM1344SHAKE_CLEAN_unpack(uint16_t *out, const size_t outlen, const uint8_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM1344SHAKE_CLEAN_unpack(uint16_t *out, size_t outlen, const uint8_t *in, size_t inlen, uint8_t lsb) {
     // Unpack the input char vector into a uint16_t output vector, copying lsb bits
     // for each output element from input. outlen must be at least ceil(inlen * 8 / lsb).
     memset(out, 0, outlen * sizeof(uint16_t));

--- a/crypto_kem/frodokem640aes/clean/Makefile
+++ b/crypto_kem/frodokem640aes/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem640aes_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_aes.o noise.o util.o
 
-CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem640aes/clean/noise.c
+++ b/crypto_kem/frodokem640aes/clean/noise.c
@@ -12,7 +12,7 @@
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;
 
-void PQCLEAN_FRODOKEM640AES_CLEAN_sample_n(uint16_t *s, const size_t n) {
+void PQCLEAN_FRODOKEM640AES_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.

--- a/crypto_kem/frodokem640aes/clean/noise.c
+++ b/crypto_kem/frodokem640aes/clean/noise.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;

--- a/crypto_kem/frodokem640aes/clean/util.c
+++ b/crypto_kem/frodokem640aes/clean/util.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))

--- a/crypto_kem/frodokem640aes/clean/util.c
+++ b/crypto_kem/frodokem640aes/clean/util.c
@@ -13,11 +13,11 @@
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
-uint16_t PQCLEAN_FRODOKEM640AES_CLEAN_LE_TO_UINT16(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM640AES_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));
 }
 
-uint16_t PQCLEAN_FRODOKEM640AES_CLEAN_UINT16_TO_LE(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM640AES_CLEAN_UINT16_TO_LE(uint16_t n) {
     uint16_t y;
     uint8_t *z = (uint8_t *) &y;
     z[0] = n & 0xFF;
@@ -126,7 +126,7 @@ void PQCLEAN_FRODOKEM640AES_CLEAN_key_decode(uint16_t *out, const uint16_t *in) 
 }
 
 
-void PQCLEAN_FRODOKEM640AES_CLEAN_pack(uint8_t *out, const size_t outlen, const uint16_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM640AES_CLEAN_pack(uint8_t *out, size_t outlen, const uint16_t *in, size_t inlen, uint8_t lsb) {
     // Pack the input uint16 vector into a char output vector, copying lsb bits from each input element.
     // If inlen * lsb / 8 > outlen, only outlen * 8 bits are copied.
     memset(out, 0, outlen);
@@ -175,7 +175,7 @@ void PQCLEAN_FRODOKEM640AES_CLEAN_pack(uint8_t *out, const size_t outlen, const 
 }
 
 
-void PQCLEAN_FRODOKEM640AES_CLEAN_unpack(uint16_t *out, const size_t outlen, const uint8_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM640AES_CLEAN_unpack(uint16_t *out, size_t outlen, const uint8_t *in, size_t inlen, uint8_t lsb) {
     // Unpack the input char vector into a uint16_t output vector, copying lsb bits
     // for each output element from input. outlen must be at least ceil(inlen * 8 / lsb).
     memset(out, 0, outlen * sizeof(uint16_t));

--- a/crypto_kem/frodokem640shake/clean/Makefile
+++ b/crypto_kem/frodokem640shake/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem640shake_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_shake.o noise.o util.o
 
-CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem640shake/clean/noise.c
+++ b/crypto_kem/frodokem640shake/clean/noise.c
@@ -12,7 +12,7 @@
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;
 
-void PQCLEAN_FRODOKEM640SHAKE_CLEAN_sample_n(uint16_t *s, const size_t n) {
+void PQCLEAN_FRODOKEM640SHAKE_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.

--- a/crypto_kem/frodokem640shake/clean/noise.c
+++ b/crypto_kem/frodokem640shake/clean/noise.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;

--- a/crypto_kem/frodokem640shake/clean/util.c
+++ b/crypto_kem/frodokem640shake/clean/util.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))

--- a/crypto_kem/frodokem640shake/clean/util.c
+++ b/crypto_kem/frodokem640shake/clean/util.c
@@ -13,11 +13,11 @@
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
-uint16_t PQCLEAN_FRODOKEM640SHAKE_CLEAN_LE_TO_UINT16(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM640SHAKE_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));
 }
 
-uint16_t PQCLEAN_FRODOKEM640SHAKE_CLEAN_UINT16_TO_LE(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM640SHAKE_CLEAN_UINT16_TO_LE(uint16_t n) {
     uint16_t y;
     uint8_t *z = (uint8_t *) &y;
     z[0] = n & 0xFF;
@@ -126,7 +126,7 @@ void PQCLEAN_FRODOKEM640SHAKE_CLEAN_key_decode(uint16_t *out, const uint16_t *in
 }
 
 
-void PQCLEAN_FRODOKEM640SHAKE_CLEAN_pack(uint8_t *out, const size_t outlen, const uint16_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM640SHAKE_CLEAN_pack(uint8_t *out, size_t outlen, const uint16_t *in, size_t inlen, uint8_t lsb) {
     // Pack the input uint16 vector into a char output vector, copying lsb bits from each input element.
     // If inlen * lsb / 8 > outlen, only outlen * 8 bits are copied.
     memset(out, 0, outlen);
@@ -175,7 +175,7 @@ void PQCLEAN_FRODOKEM640SHAKE_CLEAN_pack(uint8_t *out, const size_t outlen, cons
 }
 
 
-void PQCLEAN_FRODOKEM640SHAKE_CLEAN_unpack(uint16_t *out, const size_t outlen, const uint8_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM640SHAKE_CLEAN_unpack(uint16_t *out, size_t outlen, const uint8_t *in, size_t inlen, uint8_t lsb) {
     // Unpack the input char vector into a uint16_t output vector, copying lsb bits
     // for each output element from input. outlen must be at least ceil(inlen * 8 / lsb).
     memset(out, 0, outlen * sizeof(uint16_t));

--- a/crypto_kem/frodokem976aes/clean/Makefile
+++ b/crypto_kem/frodokem976aes/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem976aes_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_aes.o noise.o util.o
 
-CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem976aes/clean/noise.c
+++ b/crypto_kem/frodokem976aes/clean/noise.c
@@ -12,7 +12,7 @@
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;
 
-void PQCLEAN_FRODOKEM976AES_CLEAN_sample_n(uint16_t *s, const size_t n) {
+void PQCLEAN_FRODOKEM976AES_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.

--- a/crypto_kem/frodokem976aes/clean/noise.c
+++ b/crypto_kem/frodokem976aes/clean/noise.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;

--- a/crypto_kem/frodokem976aes/clean/util.c
+++ b/crypto_kem/frodokem976aes/clean/util.c
@@ -13,11 +13,11 @@
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
-uint16_t PQCLEAN_FRODOKEM976AES_CLEAN_LE_TO_UINT16(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM976AES_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));
 }
 
-uint16_t PQCLEAN_FRODOKEM976AES_CLEAN_UINT16_TO_LE(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM976AES_CLEAN_UINT16_TO_LE(uint16_t n) {
     uint16_t y;
     uint8_t *z = (uint8_t *) &y;
     z[0] = n & 0xFF;
@@ -126,7 +126,7 @@ void PQCLEAN_FRODOKEM976AES_CLEAN_key_decode(uint16_t *out, const uint16_t *in) 
 }
 
 
-void PQCLEAN_FRODOKEM976AES_CLEAN_pack(uint8_t *out, const size_t outlen, const uint16_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM976AES_CLEAN_pack(uint8_t *out, size_t outlen, const uint16_t *in, size_t inlen, uint8_t lsb) {
     // Pack the input uint16 vector into a char output vector, copying lsb bits from each input element.
     // If inlen * lsb / 8 > outlen, only outlen * 8 bits are copied.
     memset(out, 0, outlen);
@@ -175,7 +175,7 @@ void PQCLEAN_FRODOKEM976AES_CLEAN_pack(uint8_t *out, const size_t outlen, const 
 }
 
 
-void PQCLEAN_FRODOKEM976AES_CLEAN_unpack(uint16_t *out, const size_t outlen, const uint8_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM976AES_CLEAN_unpack(uint16_t *out, size_t outlen, const uint8_t *in, size_t inlen, uint8_t lsb) {
     // Unpack the input char vector into a uint16_t output vector, copying lsb bits
     // for each output element from input. outlen must be at least ceil(inlen * 8 / lsb).
     memset(out, 0, outlen * sizeof(uint16_t));

--- a/crypto_kem/frodokem976aes/clean/util.c
+++ b/crypto_kem/frodokem976aes/clean/util.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))

--- a/crypto_kem/frodokem976shake/clean/Makefile
+++ b/crypto_kem/frodokem976shake/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem976shake_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_shake.o noise.o util.o
 
-CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem976shake/clean/noise.c
+++ b/crypto_kem/frodokem976shake/clean/noise.c
@@ -12,7 +12,7 @@
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;
 
-void PQCLEAN_FRODOKEM976SHAKE_CLEAN_sample_n(uint16_t *s, const size_t n) {
+void PQCLEAN_FRODOKEM976SHAKE_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.

--- a/crypto_kem/frodokem976shake/clean/noise.c
+++ b/crypto_kem/frodokem976shake/clean/noise.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 static uint16_t CDF_TABLE[CDF_TABLE_LEN] = CDF_TABLE_DATA;

--- a/crypto_kem/frodokem976shake/clean/util.c
+++ b/crypto_kem/frodokem976shake/clean/util.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "api.h"
+#include "common.h"
 #include "params.h"
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))

--- a/crypto_kem/frodokem976shake/clean/util.c
+++ b/crypto_kem/frodokem976shake/clean/util.c
@@ -13,11 +13,11 @@
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
-uint16_t PQCLEAN_FRODOKEM976SHAKE_CLEAN_LE_TO_UINT16(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM976SHAKE_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));
 }
 
-uint16_t PQCLEAN_FRODOKEM976SHAKE_CLEAN_UINT16_TO_LE(const uint16_t n) {
+uint16_t PQCLEAN_FRODOKEM976SHAKE_CLEAN_UINT16_TO_LE(uint16_t n) {
     uint16_t y;
     uint8_t *z = (uint8_t *) &y;
     z[0] = n & 0xFF;
@@ -126,7 +126,7 @@ void PQCLEAN_FRODOKEM976SHAKE_CLEAN_key_decode(uint16_t *out, const uint16_t *in
 }
 
 
-void PQCLEAN_FRODOKEM976SHAKE_CLEAN_pack(uint8_t *out, const size_t outlen, const uint16_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM976SHAKE_CLEAN_pack(uint8_t *out, size_t outlen, const uint16_t *in, size_t inlen, uint8_t lsb) {
     // Pack the input uint16 vector into a char output vector, copying lsb bits from each input element.
     // If inlen * lsb / 8 > outlen, only outlen * 8 bits are copied.
     memset(out, 0, outlen);
@@ -175,7 +175,7 @@ void PQCLEAN_FRODOKEM976SHAKE_CLEAN_pack(uint8_t *out, const size_t outlen, cons
 }
 
 
-void PQCLEAN_FRODOKEM976SHAKE_CLEAN_unpack(uint16_t *out, const size_t outlen, const uint8_t *in, const size_t inlen, const uint8_t lsb) {
+void PQCLEAN_FRODOKEM976SHAKE_CLEAN_unpack(uint16_t *out, size_t outlen, const uint8_t *in, size_t inlen, uint8_t lsb) {
     // Unpack the input char vector into a uint16_t output vector, copying lsb bits
     // for each output element from input. outlen must be at least ceil(inlen * 8 / lsb).
     memset(out, 0, outlen * sizeof(uint16_t));

--- a/crypto_kem/kyber768/clean/Makefile
+++ b/crypto_kem/kyber768/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libkyber768_clean.a
 HEADERS=api.h cbd.h indcpa.h ntt.h params.h poly.h polyvec.h reduce.h verify.h
 OBJECTS=cbd.o indcpa.o kem.o ntt.o poly.o polyvec.o precomp.o reduce.o verify.o
 
-CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/kyber768/clean/verify.c
+++ b/crypto_kem/kyber768/clean/verify.c
@@ -1,6 +1,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "verify.h"
+
 /*************************************************
  * Name:        verify
  *

--- a/crypto_sign/sphincs-shake256-128f-simple/clean/Makefile
+++ b/crypto_sign/sphincs-shake256-128f-simple/clean/Makefile
@@ -5,7 +5,7 @@ LIB=libsphincs-shake256-128f-simple_clean.a
 HEADERS = params.h address.h wots.h utils.h fors.h api.h  hash.h thash.h
 OBJECTS =          address.o wots.o utils.o fors.o sign.o hash_shake256.o thash_shake256_simple.o
 
-CFLAGS=-Wall -Wconversion -Wextra -Wpedantic -Werror -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-Wall -Wconversion -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_sign/sphincs-shake256-128f-simple/clean/address.c
+++ b/crypto_sign/sphincs-shake256-128f-simple/clean/address.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 
+#include "address.h"
 #include "params.h"
 #include "utils.h"
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,7 +16,7 @@ DEST_DIR=../bin
 
 # This -Wall was supported by the European Commission through the ERC Starting Grant 805031 (EPOQUE)
 CFLAGS=-Wall -Wextra -Wpedantic -Werror -std=c99 \
-	   -Wundef -Wshadow -Wcast-align -Wpointer-arith \
+	   -Wundef -Wshadow -Wcast-align -Wpointer-arith -Wmissing-prototypes\
 	   -fstrict-aliasing -fno-common -pipe \
 	   -I$(COMMON_DIR) $(EXTRAFLAGS)
 


### PR DESCRIPTION
Fixes #108. 

We are currently not including `-Wmissing-prototypes`.

When turning it on, I found that:

- [address.c](https://github.com/PQClean/PQClean/blob/master/crypto_sign/sphincs-shake256-128f-simple/clean/address.c) of SPHINCS doesn't include address.h - which it should
- The functions `br_range_enc32le` and `br_aes_ct64_skey_expand` in [aes.c](https://github.com/PQClean/PQClean/blob/master/common/aes.c) should be static, but are not. 
-  Frodo's [noise.c](https://github.com/PQClean/PQClean/blob/master/crypto_kem/frodokem640shake/clean/noise.c) should include [common.h](https://github.com/PQClean/PQClean/blob/master/crypto_kem/frodokem640shake/clean/common.h)
- Frodo's [utils.c](https://github.com/PQClean/PQClean/blob/master/crypto_kem/frodokem640shake/clean/util.c) should include [common.h](https://github.com/PQClean/PQClean/blob/master/crypto_kem/frodokem640shake/clean/common.h)
- Kyber's [verify.c](https://github.com/PQClean/PQClean/blob/master/crypto_kem/kyber768/clean/verify.c) should include [verify.h](https://github.com/PQClean/PQClean/blob/master/crypto_kem/kyber768/clean/verify.h)
- Some functions in Frodo differ from their prototypes in the sense that the implementation has const non-pointer arguments whereas the prototype does not. gcc+clang are fine with this, but on Windows it breaks. Since those consts don't change anything, I've removed them. 

I've fixed all of those issues. 