### PR TITLE
Fix problems in the NTRU source code

### DIFF
--- a/crypto_kem/frodokem1344aes/clean/noise.c
+++ b/crypto_kem/frodokem1344aes/clean/noise.c
@@ -16,7 +16,8 @@ void PQCLEAN_FRODOKEM1344AES_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.
-    unsigned int i, j;
+    size_t i;
+    unsigned int j;
 
     for (i = 0; i < n; ++i) {
         uint8_t sample = 0;

--- a/crypto_kem/frodokem1344shake/clean/noise.c
+++ b/crypto_kem/frodokem1344shake/clean/noise.c
@@ -16,7 +16,8 @@ void PQCLEAN_FRODOKEM1344SHAKE_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.
-    unsigned int i, j;
+    size_t i;
+    unsigned int j;
 
     for (i = 0; i < n; ++i) {
         uint8_t sample = 0;

--- a/crypto_kem/frodokem640aes/clean/noise.c
+++ b/crypto_kem/frodokem640aes/clean/noise.c
@@ -16,7 +16,8 @@ void PQCLEAN_FRODOKEM640AES_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.
-    unsigned int i, j;
+    size_t i;
+    unsigned int j;
 
     for (i = 0; i < n; ++i) {
         uint8_t sample = 0;

--- a/crypto_kem/frodokem640shake/clean/noise.c
+++ b/crypto_kem/frodokem640shake/clean/noise.c
@@ -16,7 +16,8 @@ void PQCLEAN_FRODOKEM640SHAKE_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.
-    unsigned int i, j;
+    size_t i;
+    unsigned int j;
 
     for (i = 0; i < n; ++i) {
         uint8_t sample = 0;

--- a/crypto_kem/frodokem976aes/clean/noise.c
+++ b/crypto_kem/frodokem976aes/clean/noise.c
@@ -16,7 +16,8 @@ void PQCLEAN_FRODOKEM976AES_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.
-    unsigned int i, j;
+    size_t i;
+    unsigned int j;
 
     for (i = 0; i < n; ++i) {
         uint8_t sample = 0;

--- a/crypto_kem/frodokem976shake/clean/noise.c
+++ b/crypto_kem/frodokem976shake/clean/noise.c
@@ -16,7 +16,8 @@ void PQCLEAN_FRODOKEM976SHAKE_CLEAN_sample_n(uint16_t *s, size_t n) {
     // Fills vector s with n samples from the noise distribution which requires 16 bits to sample.
     // The distribution is specified by its CDF.
     // Input: pseudo-random values (2*n bytes) passed in s. The input is overwritten by the output.
-    unsigned int i, j;
+    size_t i;
+    unsigned int j;
 
     for (i = 0; i < n; ++i) {
         uint8_t sample = 0;

--- a/crypto_kem/ntruhps2048509/clean/crypto_sort.c
+++ b/crypto_kem/ntruhps2048509/clean/crypto_sort.c
@@ -8,7 +8,7 @@
 #define int32_MINMAX(a,b) \
     do { \
         int32_t ab = (b) ^ (a); \
-        int32_t c = (b) - (a); \
+        int32_t c = (int32_t)((int64_t)(b) - (int64_t)(a)); \
         c ^= ab & (c ^ (b)); \
         c >>= 31; \
         c &= ab; \

--- a/crypto_kem/ntruhps2048509/clean/kem.c
+++ b/crypto_kem/ntruhps2048509/clean/kem.c
@@ -52,7 +52,7 @@ int PQCLEAN_NTRUHPS2048509_CLEAN_crypto_kem_dec(uint8_t *k, const uint8_t *c, co
     for (i = 0; i < NTRU_CIPHERTEXTBYTES; i++) {
         cmp[i] = c[i];
     }
-    sha3_256(rm, cmp, NTRU_PRFKEYBYTES + NTRU_CIPHERTEXTBYTES);
+    sha3_256(rm, cmp, NTRU_CIPHERTEXTBYTES);
 
     PQCLEAN_NTRUHPS2048509_CLEAN_cmov(k, rm, NTRU_SHAREDKEYBYTES, (unsigned char) fail);
 

--- a/crypto_kem/ntruhps2048509/clean/kem.c
+++ b/crypto_kem/ntruhps2048509/clean/kem.c
@@ -37,7 +37,6 @@ int PQCLEAN_NTRUHPS2048509_CLEAN_crypto_kem_dec(uint8_t *k, const uint8_t *c, co
     int i, fail;
     uint8_t rm[NTRU_OWCPA_MSGBYTES];
     uint8_t buf[NTRU_PRFKEYBYTES + NTRU_CIPHERTEXTBYTES];
-    uint8_t *cmp = buf + NTRU_PRFKEYBYTES;
 
     fail = PQCLEAN_NTRUHPS2048509_CLEAN_owcpa_dec(rm, c, sk);
     /* If fail = 0 then c = Enc(h, rm), there is no need to re-encapsulate. */
@@ -50,9 +49,9 @@ int PQCLEAN_NTRUHPS2048509_CLEAN_crypto_kem_dec(uint8_t *k, const uint8_t *c, co
         buf[i] = sk[i + NTRU_OWCPA_SECRETKEYBYTES];
     }
     for (i = 0; i < NTRU_CIPHERTEXTBYTES; i++) {
-        cmp[i] = c[i];
+        buf[NTRU_PRFKEYBYTES + i] = c[i];
     }
-    sha3_256(rm, cmp, NTRU_CIPHERTEXTBYTES);
+    sha3_256(rm, buf, NTRU_PRFKEYBYTES + NTRU_CIPHERTEXTBYTES);
 
     PQCLEAN_NTRUHPS2048509_CLEAN_cmov(k, rm, NTRU_SHAREDKEYBYTES, (unsigned char) fail);
 

--- a/crypto_kem/ntruhps2048509/clean/sample.c
+++ b/crypto_kem/ntruhps2048509/clean/sample.c
@@ -25,15 +25,15 @@ void PQCLEAN_NTRUHPS2048509_CLEAN_sample_iid(poly *r, const unsigned char unifor
 void PQCLEAN_NTRUHPS2048509_CLEAN_sample_fixed_type(poly *r, const unsigned char u[NTRU_SAMPLE_FT_BYTES]) {
     // Assumes NTRU_SAMPLE_FT_BYTES = ceil(30*(n-1)/8)
 
-    int32_t s[NTRU_N - 1];
+    uint32_t s[NTRU_N - 1];
     int i;
 
     // Use 30 bits of u per word
     for (i = 0; i < (NTRU_N - 1) / 4; i++) {
-        s[4 * i + 0] =                              (u[15 * i + 0] << 2) + (u[15 * i + 1] << 10) + (u[15 * i + 2] << 18) + (u[15 * i + 3] << 26);
-        s[4 * i + 1] = ((u[15 * i + 3] & 0xc0) >> 4) + (u[15 * i + 4] << 4) + (u[15 * i + 5] << 12) + (u[15 * i + 6] << 20) + (u[15 * i + 7] << 28);
-        s[4 * i + 2] = ((u[15 * i + 7] & 0xf0) >> 2) + (u[15 * i + 8] << 6) + (u[15 * i + 9] << 14) + (u[15 * i + 10] << 22) + (u[15 * i + 11] << 30);
-        s[4 * i + 3] =  (u[15 * i + 11] & 0xfc)       + (u[15 * i + 12] << 8) + (u[15 * i + 13] << 15) + (u[15 * i + 14] << 24);
+        s[4 * i + 0] =                                  (u[15 * i +  0] << 2) + (u[15 * i +  1] << 10) + (u[15 * i +  2] << 18) + ((uint32_t)u[15 * i + 3] << 26);
+        s[4 * i + 1] = ((u[15 * i +  3] & 0xc0) >> 4) + (u[15 * i +  4] << 4) + (u[15 * i +  5] << 12) + (u[15 * i +  6] << 20) + ((uint32_t)u[15 * i + 7] << 28);
+        s[4 * i + 2] = ((u[15 * i +  7] & 0xf0) >> 2) + (u[15 * i +  8] << 6) + (u[15 * i +  9] << 14) + (u[15 * i + 10] << 22) + ((uint32_t)u[15 * i + 11] << 30);
+        s[4 * i + 3] =  (u[15 * i + 11] & 0xfc)       + (u[15 * i + 12] << 8) + (u[15 * i + 13] << 15) + ((uint32_t)u[15 * i + 14] << 24);
     }
 
     for (i = 0; i < NTRU_WEIGHT / 2; i++) {


### PR DESCRIPTION
Fix issues in the NTRU source code:

* `size_t` and `unsigned int` comparison
* `int` overflows
* `sha3_256` being fed an incorrect length.