### PR TITLE
Move secret key length back to scheme-level META

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ See the section [API](#API) below.
     type: <kem|signature>
     claimed-nist-level: <N>
     length-public-key: <N>          # KEM and signature
+    length-secret-key: <N>          # KEM and signature
     length-ciphertext: <N>          # KEM only
     length-shared-secret: <N>       # KEM only
     length-signature: <N>           # Signature only
@@ -37,7 +38,6 @@ See the section [API](#API) below.
       - ...
     implementations:
       - name: clean
-        length-secret-key: <N>       # KEM and signature
         version: <some version indicator>
     ```
 

--- a/crypto_kem/frodokem1344aes/META.yml
+++ b/crypto_kem/frodokem1344aes/META.yml
@@ -2,6 +2,7 @@ name: FrodoKEM-1344-AES
 type: kem
 claimed-nist-level: 5
 length-public-key: 21520
+length-secret-key: 43088
 length-ciphertext: 21632
 length-shared-secret: 32
 testvectors-sha256: 91dce2e12200afc88f951aff9349b72d1dda6e53e305135a891aa1a67ef88352
@@ -22,4 +23,3 @@ auxiliary-submitters:
 implementations:
 - name: clean
   version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/437e228fca580a82435cab09f30ae14b03183119
-  length-secret-key: 43088

--- a/crypto_kem/frodokem1344shake/META.yml
+++ b/crypto_kem/frodokem1344shake/META.yml
@@ -2,6 +2,7 @@ name: FrodoKEM-1344-SHAKE
 type: kem
 claimed-nist-level: 5
 length-public-key: 21520
+length-secret-key: 43088
 length-ciphertext: 21632
 length-shared-secret: 32
 testvectors-sha256: 8b62fc01fc1e4b4e336776b09b37aaf55d161b7c815b3298f39d4444b011e10c
@@ -22,4 +23,3 @@ auxiliary-submitters:
 implementations:
 - name: clean
   version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/437e228fca580a82435cab09f30ae14b03183119
-  length-secret-key: 43088

--- a/crypto_kem/frodokem640aes/META.yml
+++ b/crypto_kem/frodokem640aes/META.yml
@@ -2,6 +2,7 @@ name: FrodoKEM-640-AES
 type: kem
 claimed-nist-level: 1
 length-public-key: 9616
+length-secret-key: 19888
 length-ciphertext: 9720
 length-shared-secret: 16
 testvectors-sha256: d4c7d30254a8cac8ad73b742b31813e47dcae6532a4dcbe13c04d72a2920a086
@@ -22,4 +23,3 @@ auxiliary-submitters:
 implementations:
 - name: clean
   version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/437e228fca580a82435cab09f30ae14b03183119
-  length-secret-key: 19888

--- a/crypto_kem/frodokem640shake/META.yml
+++ b/crypto_kem/frodokem640shake/META.yml
@@ -2,6 +2,7 @@ name: FrodoKEM-640-SHAKE
 type: kem
 claimed-nist-level: 1
 length-public-key: 9616
+length-secret-key: 19888
 length-ciphertext: 9720
 length-shared-secret: 16
 testvectors-sha256: 8f922de02d41005fcc3c4164b2ab74c4c7b588ed69e34e22607d1ae4ab13d2c5
@@ -22,4 +23,3 @@ auxiliary-submitters:
 implementations:
 - name: clean
   version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/437e228fca580a82435cab09f30ae14b03183119
-  length-secret-key: 19888

--- a/crypto_kem/frodokem976aes/META.yml
+++ b/crypto_kem/frodokem976aes/META.yml
@@ -2,6 +2,7 @@ name: FrodoKEM-976-AES
 type: kem
 claimed-nist-level: 1
 length-public-key: 15632
+length-secret-key: 31296
 length-ciphertext: 15744
 length-shared-secret: 24
 testvectors-sha256: 30a2a3f2d834b5d90cd10241f53c4a4379abeea0dbd4eb65b260749b2ba81391
@@ -22,4 +23,3 @@ auxiliary-submitters:
 implementations:
 - name: clean
   version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/437e228fca580a82435cab09f30ae14b03183119
-  length-secret-key: 31296

--- a/crypto_kem/frodokem976shake/META.yml
+++ b/crypto_kem/frodokem976shake/META.yml
@@ -2,6 +2,7 @@ name: FrodoKEM-976-SHAKE
 type: kem
 claimed-nist-level: 3
 length-public-key: 15632
+length-secret-key: 31296
 length-ciphertext: 15744
 length-shared-secret: 24
 testvectors-sha256: 00707dc8158c6e51e70e9a7b23a87054c5f2167b77a2e5940b8e82519834717b
@@ -22,4 +23,3 @@ auxiliary-submitters:
 implementations:
 - name: clean
   version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/437e228fca580a82435cab09f30ae14b03183119
-  length-secret-key: 31296

--- a/crypto_kem/kyber768/META.yml
+++ b/crypto_kem/kyber768/META.yml
@@ -2,6 +2,7 @@ name: Kyber768
 type: kem
 claimed-nist-level: 3
 length-public-key: 1088
+length-secret-key: 2400
 length-ciphertext: 1152
 length-shared-secret: 32
 testvectors-sha256: 2f5cf9937959eb4a3bc910f71e830e9e0de029b28093c6192d2c3e915913016f
@@ -20,4 +21,3 @@ auxiliary-submitters:
 implementations:
     - name: clean
       version: https://github.com/pq-crystals/kyber/commit/ab996e7460e5356b0e23aa034e7c2fe6922e60e6
-      length-secret-key: 2400

--- a/crypto_kem/ntruhps2048509/META.yml
+++ b/crypto_kem/ntruhps2048509/META.yml
@@ -2,6 +2,7 @@ name: ntru-hps2048509
 type: kem
 claimed-nist-level: 1
 length-public-key: 699
+length-secret-key: 935
 length-ciphertext: 699
 length-shared-secret: 32
 testvectors-sha256: 1a7c207b96f29043fad3e31e69a806aacd98e035ec0128fdf97350ec833f3b83
@@ -19,4 +20,3 @@ auxiliary-submitters:
 implementations:
     - name: clean
       version: https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-2/submissions/NTRU-Round2.zip reference implemntation
-      length-secret-key: 935

--- a/crypto_sign/sphincs-shake256-128f-simple/META.yml
+++ b/crypto_sign/sphincs-shake256-128f-simple/META.yml
@@ -2,6 +2,7 @@ name: SPHINCS+
 type: signature
 claimed-nist-level: 1
 length-public-key: 32
+length-secret-key: 64
 length-signature: 16976
 testvectors-sha256: a14cb8e4f149493fc5979e465e09ce943e8d669186ff5c7c3d11239fa869def6
 principal-submitter: Andreas Hülsing
@@ -24,4 +25,3 @@ auxiliary-submitters:
 implementations:
     - name: clean
       version: https://github.com/sphincs/sphincsplus/commit/492ec4f1f6d3b3dc4b435783bbaaf4e41cdb6f32
-      length-secret-key: 64

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -46,6 +46,7 @@ EXPECTED_FIELDS = {
     'type': {'type': str},
     'claimed-nist-level': {'type': int, 'min': 1, 'max': 5},
     'length-public-key': {'type': int, 'min': 1},
+    'length-secret-key': {'type': int, 'min': 1},
     'testvectors-sha256': {'type': str, 'length': 64},
     'principal-submitter': {'type': str},
     'auxiliary-submitters': {'type': list, 'elements': {'type': str}},
@@ -56,7 +57,6 @@ EXPECTED_FIELDS = {
             'spec': {
                 'name': {'type': str},
                 'version': {'type': str},
-                'length-secret-key': {'type': int, 'min': 1},
             },
         },
     },

--- a/test/test_metadata_sizes.py
+++ b/test/test_metadata_sizes.py
@@ -33,7 +33,7 @@ def check_metadata_sizes(implementation):
 
     parsed = json.loads(out)
 
-    assert parsed['CRYPTO_SECRETKEYBYTES'] == impl_meta['length-secret-key']
+    assert parsed['CRYPTO_SECRETKEYBYTES'] == metadata['length-secret-key']
     assert parsed['CRYPTO_PUBLICKEYBYTES'] == metadata['length-public-key']
 
     if implementation.scheme.type == 'kem':


### PR DESCRIPTION
As we concluded in #93 that the secret key is actually a scheme property (and not a free choice by the implementation), its length belongs at the scheme level in `META.yml`.

Closes #151