### PR TITLE
Slow tests

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -80,6 +80,15 @@ def skip_windows(message="This test is not supported on Windows"):
     return wrapper
 
 
+def slow_test(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        if 'CI' in os.environ and 'RUN_SLOW' not in os.environ:
+            raise unittest.SkipTest("Slow test skipped on CI run")
+        return f(*args, **kwargs)
+    return wrapper
+
+
 def ensure_available(executable):
     """
     Checks if a command is available.

--- a/test/test_api_h.py
+++ b/test/test_api_h.py
@@ -8,7 +8,7 @@ import pqclean
 def test_preprocessor():
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
-            if helpers.permit_test('preprocessor', implementation): 
+            if helpers.permit_test('preprocessor', implementation):
                 yield check_preprocessor, implementation
 
 

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -17,7 +17,7 @@ def test_char():
         )
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
-            if helpers.permit_test('char', implementation): 
+            if helpers.permit_test('char', implementation):
                 yield check_char, implementation
 
 

--- a/test/test_compile_lib.py
+++ b/test/test_compile_lib.py
@@ -10,7 +10,7 @@ import helpers
 def test_compile_lib():
     for scheme in pqclean.Scheme.all_schemes():
         for implementation in scheme.implementations:
-            if helpers.permit_test('compile_lib', implementation): 
+            if helpers.permit_test('compile_lib', implementation):
                 yield check_compile_lib, implementation
 
 

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -42,6 +42,7 @@ def check_functest(implementation):
 
 
 @helpers.skip_windows()
+@helpers.slow_test
 def check_functest_sanitizers(implementation):
     env = None
     if platform.machine() == 'ppc' and os.environ.get('CC', 'gcc') == 'clang':

--- a/test/test_preprocessor.py
+++ b/test/test_preprocessor.py
@@ -1,6 +1,3 @@
-import os
-from glob import glob
-
 import pqclean
 import helpers
 
@@ -28,6 +25,7 @@ def check_preprocessor(implementation: pqclean.Implementation):
         raise AssertionError(
             "Prohibited use of preprocessor conditional" + "".join(errors)
         )
+
 
 if __name__ == "__main__":
     try:

--- a/test/test_valgrind.py
+++ b/test/test_valgrind.py
@@ -17,12 +17,11 @@ def test_functest():
                 yield check_valgrind, implementation
 
 
+@helpers.slow_test
 def check_valgrind(implementation: pqclean.Implementation):
     if (platform.machine() not in ('i386', 'x86_64') or
             platform.system() != 'Linux'):
         raise unittest.SkipTest()
-    if os.environ.get('CIRCLECI') == 'true' and os.environ.get('ARCH') == 'i386' and (implementation.scheme.name == 'frodokem1344aes' or implementation.scheme.name == 'frodokem1344shake'):
-        raise unittest.SkipTest('Skipping too-slow valgrind test')
 
     helpers.make(TYPE=implementation.scheme.type,
                  SCHEME=implementation.scheme.name,


### PR DESCRIPTION
Annotate slow tests with the `helpers.slow_test` function decorator, and they'll be skipped if:

* `CI` is set in the environment
* `RUN_SLOW` is not set in the environment.