### PR TITLE
Detect cron builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
         - git checkout $TRAVIS_BRANCH
         - git reset --hard $TRAVIS_COMMIT
       script:
-        - "cd test && python3 -m nose --rednose --verbose"
+        - "cd test && travis_wait 30 python3 -m nose --rednose --verbose"
       env:
         PQCLEAN_ONLY_DIFF: 1
       addons:
@@ -41,7 +41,7 @@ matrix:
         - ln -s /usr/local/bin/gcc-8 /usr/local/bin/gcc
         - gcc --version
       script:
-        - "cd test && python3 -m nose --rednose --verbose"
+        - "cd test && travis_wait 30 python3 -m nose --rednose --verbose"
 
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         - git checkout $TRAVIS_BRANCH
         - git reset --hard $TRAVIS_COMMIT
       script:
+        # Use travis-wait to allow slower tests to run
         - "cd test && travis_wait 30 python3 -m nose --rednose --verbose"
       env:
         PQCLEAN_ONLY_DIFF: 1
@@ -41,6 +42,7 @@ matrix:
         - ln -s /usr/local/bin/gcc-8 /usr/local/bin/gcc
         - gcc --version
       script:
+        # Use travis-wait to allow slower tests to run
         - "cd test && travis_wait 30 python3 -m nose --rednose --verbose"
 
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -85,7 +85,8 @@ def skip_windows(message="This test is not supported on Windows"):
 def slow_test(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        if 'CI' in os.environ and 'RUN_SLOW' not in os.environ:
+        if ('CI' in os.environ and 'RUN_SLOW' not in os.environ and
+                os.environ.get('TRAVIS_EVENT_TYPE') != 'cron'):
             raise unittest.SkipTest("Slow test skipped on CI run")
         return f(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
Travis doesn't allow setting environment variables on scheduled builds.

I've set up Travis to run a build on master daily, this PR will make sure it handles the slow tests correctly.