### PR TITLE
Throw errors when using variable-length arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ _The checking of items on this list is still being developed. Checked items shou
 * [x] No errors/warnings reported by address sanitizer
 * [x] Only dependencies: `fips202.c`, `sha2.c`, `aes.c`, `randombytes.c`
 * [x] API functions return `0` on success
-* [x] No dynamic memory allocations
+* [x] No dynamic memory allocations (including variable-length arrays)
 * [ ] No branching on secret data (dynamically checked using valgrind)
 * [ ] No access to secret memory locations (dynamically checked using valgrind)
 * [x] Separate subdirectories (without symlinks) for each parameter set of each scheme

--- a/crypto_kem/frodokem1344aes/clean/Makefile
+++ b/crypto_kem/frodokem1344aes/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem1344aes_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_aes.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem1344aes/clean/Makefile
+++ b/crypto_kem/frodokem1344aes/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem1344aes_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_aes.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem1344shake/clean/Makefile
+++ b/crypto_kem/frodokem1344shake/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem1344shake_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_shake.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem1344shake/clean/Makefile
+++ b/crypto_kem/frodokem1344shake/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem1344shake_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_shake.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem640aes/clean/Makefile
+++ b/crypto_kem/frodokem640aes/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem640aes_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_aes.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem640aes/clean/Makefile
+++ b/crypto_kem/frodokem640aes/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem640aes_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_aes.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem640shake/clean/Makefile
+++ b/crypto_kem/frodokem640shake/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem640shake_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_shake.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem640shake/clean/Makefile
+++ b/crypto_kem/frodokem640shake/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem640shake_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_shake.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem976aes/clean/Makefile
+++ b/crypto_kem/frodokem976aes/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem976aes_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_aes.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem976aes/clean/Makefile
+++ b/crypto_kem/frodokem976aes/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem976aes_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_aes.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem976shake/clean/Makefile
+++ b/crypto_kem/frodokem976shake/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem976shake_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_shake.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/frodokem976shake/clean/Makefile
+++ b/crypto_kem/frodokem976shake/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libfrodokem976shake_clean.a
 HEADERS=api.h params.h common.h
 OBJECTS=kem.o matrix_shake.o noise.o util.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/kyber768/clean/Makefile
+++ b/crypto_kem/kyber768/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libkyber768_clean.a
 HEADERS=api.h cbd.h indcpa.h ntt.h params.h poly.h polyvec.h reduce.h verify.h
 OBJECTS=cbd.o indcpa.o kem.o ntt.o poly.o polyvec.o precomp.o reduce.o verify.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/kyber768/clean/Makefile
+++ b/crypto_kem/kyber768/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libkyber768_clean.a
 HEADERS=api.h cbd.h indcpa.h ntt.h params.h poly.h polyvec.h reduce.h verify.h
 OBJECTS=cbd.o indcpa.o kem.o ntt.o poly.o polyvec.o precomp.o reduce.o verify.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/ntruhps2048509/clean/Makefile
+++ b/crypto_kem/ntruhps2048509/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libntruhps2048509_clean.a
 HEADERS=api.h crypto_sort.h owcpa.h params.h poly.h sample.h verify.h
 OBJECTS=crypto_sort.o kem.o owcpa.o pack3.o packq.o poly.o sample.o verify.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/ntruhps2048509/clean/Makefile
+++ b/crypto_kem/ntruhps2048509/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libntruhps2048509_clean.a
 HEADERS=api.h crypto_sort.h owcpa.h params.h poly.h sample.h verify.h
 OBJECTS=crypto_sort.o kem.o owcpa.o pack3.o packq.o poly.o sample.o verify.o
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_sign/sphincs-shake256-128f-simple/clean/Makefile
+++ b/crypto_sign/sphincs-shake256-128f-simple/clean/Makefile
@@ -5,7 +5,7 @@ LIB=libsphincs-shake256-128f-simple_clean.a
 HEADERS = params.h address.h wots.h utils.h fors.h api.h  hash.h thash.h
 OBJECTS =          address.o wots.o utils.o fors.o sign.o hash_shake256.o thash_shake256_simple.o
 
-CFLAGS=-O3 -Wall -Wconversion -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_sign/sphincs-shake256-128f-simple/clean/Makefile
+++ b/crypto_sign/sphincs-shake256-128f-simple/clean/Makefile
@@ -5,7 +5,7 @@ LIB=libsphincs-shake256-128f-simple_clean.a
 HEADERS = params.h address.h wots.h utils.h fors.h api.h  hash.h thash.h
 OBJECTS =          address.o wots.o utils.o fors.o sign.o hash_shake256.o thash_shake256_simple.o
 
-CFLAGS=-O3 -Wall -Wconversion -Wextra -Wpedantic -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wconversion -Wextra -Wpedantic -Werror=vla -Werror -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,7 +15,7 @@ COMMON_HEADERS=$(COMMON_DIR)/*.h
 DEST_DIR=../bin
 
 # This -Wall was supported by the European Commission through the ERC Starting Grant 805031 (EPOQUE)
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror -std=c99 \
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -std=c99 \
 	   -Wundef -Wshadow -Wcast-align -Wpointer-arith -Wmissing-prototypes\
 	   -fstrict-aliasing -fno-common -pipe \
 	   -I$(COMMON_DIR) $(EXTRAFLAGS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,7 +15,7 @@ COMMON_HEADERS=$(COMMON_DIR)/*.h
 DEST_DIR=../bin
 
 # This -Wall was supported by the European Commission through the ERC Starting Grant 805031 (EPOQUE)
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Werror=vla -Werror -std=c99 \
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -std=c99 \
 	   -Wundef -Wshadow -Wcast-align -Wpointer-arith -Wmissing-prototypes\
 	   -fstrict-aliasing -fno-common -pipe \
 	   -I$(COMMON_DIR) $(EXTRAFLAGS)


### PR DESCRIPTION
Windows already complains about this in CI, but this will let us catch these issues on Linux as well.