### PR TITLE
Add IND-CPA/IND-CCA2 to metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ See the section [API](#API) below.
     name: Name
     type: <kem|signature>
     claimed-nist-level: <N>
+    claimed-security: IND-CPA/IND-CCA2  # KEM only
     length-public-key: <N>          # KEM and signature
     length-secret-key: <N>          # KEM and signature
     length-ciphertext: <N>          # KEM only

--- a/crypto_kem/frodokem1344aes/META.yml
+++ b/crypto_kem/frodokem1344aes/META.yml
@@ -1,6 +1,7 @@
 name: FrodoKEM-1344-AES
 type: kem
 claimed-nist-level: 5
+claimed-security: IND-CCA2
 length-public-key: 21520
 length-secret-key: 43088
 length-ciphertext: 21632

--- a/crypto_kem/frodokem1344shake/META.yml
+++ b/crypto_kem/frodokem1344shake/META.yml
@@ -1,6 +1,7 @@
 name: FrodoKEM-1344-SHAKE
 type: kem
 claimed-nist-level: 5
+claimed-security: IND-CCA2
 length-public-key: 21520
 length-secret-key: 43088
 length-ciphertext: 21632

--- a/crypto_kem/frodokem640aes/META.yml
+++ b/crypto_kem/frodokem640aes/META.yml
@@ -1,6 +1,7 @@
 name: FrodoKEM-640-AES
 type: kem
 claimed-nist-level: 1
+claimed-security: IND-CCA2
 length-public-key: 9616
 length-secret-key: 19888
 length-ciphertext: 9720

--- a/crypto_kem/frodokem640shake/META.yml
+++ b/crypto_kem/frodokem640shake/META.yml
@@ -1,6 +1,7 @@
 name: FrodoKEM-640-SHAKE
 type: kem
 claimed-nist-level: 1
+claimed-security: IND-CCA2
 length-public-key: 9616
 length-secret-key: 19888
 length-ciphertext: 9720

--- a/crypto_kem/frodokem976aes/META.yml
+++ b/crypto_kem/frodokem976aes/META.yml
@@ -1,6 +1,7 @@
 name: FrodoKEM-976-AES
 type: kem
 claimed-nist-level: 3
+claimed-security: IND-CCA2
 length-public-key: 15632
 length-secret-key: 31296
 length-ciphertext: 15744

--- a/crypto_kem/frodokem976shake/META.yml
+++ b/crypto_kem/frodokem976shake/META.yml
@@ -1,6 +1,7 @@
 name: FrodoKEM-976-SHAKE
 type: kem
 claimed-nist-level: 3
+claimed-security: IND-CCA2
 length-public-key: 15632
 length-secret-key: 31296
 length-ciphertext: 15744

--- a/crypto_kem/kyber1024/META.yml
+++ b/crypto_kem/kyber1024/META.yml
@@ -1,6 +1,7 @@
 name: Kyber1024
 type: kem
 claimed-nist-level: 5
+claimed-security: IND-CCA2
 length-public-key: 1568
 length-ciphertext: 1568
 length-secret-key: 3168

--- a/crypto_kem/kyber512/META.yml
+++ b/crypto_kem/kyber512/META.yml
@@ -1,6 +1,7 @@
 name: Kyber512
 type: kem
 claimed-nist-level: 1
+claimed-security: IND-CCA2
 length-public-key: 800
 length-ciphertext: 736
 length-secret-key: 1632

--- a/crypto_kem/kyber768/META.yml
+++ b/crypto_kem/kyber768/META.yml
@@ -1,6 +1,7 @@
 name: Kyber768
 type: kem
 claimed-nist-level: 3
+claimed-security: IND-CCA2
 length-public-key: 1184
 length-ciphertext: 1088
 length-secret-key: 2400

--- a/crypto_kem/ntruhps2048509/META.yml
+++ b/crypto_kem/ntruhps2048509/META.yml
@@ -1,6 +1,7 @@
 name: ntru-hps2048509
 type: kem
 claimed-nist-level: 1
+claimed-security: IND-CCA2
 length-public-key: 699
 length-secret-key: 935
 length-ciphertext: 699

--- a/crypto_kem/ntruhps2048677/META.yml
+++ b/crypto_kem/ntruhps2048677/META.yml
@@ -1,6 +1,7 @@
 name: ntru-hps2048677
 type: kem
 claimed-nist-level: 3
+claimed-security: IND-CCA2
 length-public-key: 930
 length-secret-key: 1234
 length-ciphertext: 930

--- a/crypto_kem/ntruhps4096821/META.yml
+++ b/crypto_kem/ntruhps4096821/META.yml
@@ -1,6 +1,7 @@
 name: ntru-hps4096821
 type: kem
 claimed-nist-level: 5
+claimed-security: IND-CCA2
 length-public-key: 1230
 length-secret-key: 1590
 length-ciphertext: 1230

--- a/crypto_kem/ntruhrss701/META.yml
+++ b/crypto_kem/ntruhrss701/META.yml
@@ -1,6 +1,7 @@
 name: ntru-hrss701
 type: kem
 claimed-nist-level: 3
+claimed-security: IND-CCA2
 length-public-key: 1138
 length-secret-key: 1450
 length-ciphertext: 1138

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -62,6 +62,7 @@ EXPECTED_FIELDS = {
 }
 
 KEM_FIELDS = {
+    'claimed-security' : {'type' : str, 'values' : ['IND-CPA', 'IND-CCA2'] },
     'length-ciphertext': {'type': int, 'min': 1},
     'length-shared-secret': {'type': int, 'min': 1},
     'nistkat-sha256': {'type': str, 'length': 64},
@@ -123,6 +124,10 @@ def check_element(field, element, props):
                 raise ValueError("Value of field '{}' should be length {}"
                                  " but was length {}"
                                  .format(field, props['length'], actual_len))
+        if 'values' in props and element not in props['values']:
+            raise ValueError("'{}' should be in {}"
+                             .format(element, props['values']))
+
 
     if type_ == list:  # recursively check the elements
         for el in element:


### PR DESCRIPTION
This adds IND-CPA/IND-CCA2 to META.yml. 
Currently, all schemes are IND-CCA2, but other schemes are IND-CPA (e.g. NewHope #160) 

Also adapts the metadata test to check if the value is present and contains a valid value. 