### PR TITLE
Check NIST KAT test vectors for signatures as well

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ See the section [API](#API) below.
     length-ciphertext: <N>          # KEM only
     length-shared-secret: <N>       # KEM only
     length-signature: <N>           # Signature only
-    nistkat-sha256: sha256sum of 1st NIST KAT test case # KEM only
+    nistkat-sha256: sha256sum of 1st NIST KAT test case # KEM and signature
     testvectors-sha256: sha256sum of output of testvectors # Signature only
     principal-submitter: Eve
     auxiliary-submitters:

--- a/crypto_sign/mqdss-48/META.yml
+++ b/crypto_sign/mqdss-48/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 46
 length-secret-key: 16
 length-signature: 20854
+nistkat-sha256: 0a3754ebeb4bc41118b488c2b46499f6652398e83cb0d6eaf2929dbfd33fc8d7
 testvectors-sha256: 3350a80ccf4316b32ef13060fca8880d6802b7e61150fd36f021d1c52d8edb98
 principal-submitter: Simona Samardjiska
 auxiliary-submitters:

--- a/crypto_sign/mqdss-64/META.yml
+++ b/crypto_sign/mqdss-64/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 64
 length-secret-key: 24
 length-signature: 43728
+nistkat-sha256: 2a50f067babbf4a3eed5197e87820472944d1d79fc03b1d9322a8ad8c245501e
 testvectors-sha256: 1edd33ca64b14f60f153b84dd25c7064cfa9b7dbf1bb5c4296f343377cb0c864
 principal-submitter: Simona Samardjiska
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-128f-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-128f-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 16976
+nistkat-sha256: 4d04dcfa1ed0dcbe0af382fe1925b5031a279811f9fea298d64a9fe8eaaf2165
 testvectors-sha256: f0f84722cf529a108006d84b52966cbebd92146ee33cacdd7d1bba2cdc1944fd
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-128f-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-128f-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 16976
+nistkat-sha256: 82967bdf0188ff7c6c6f5723798d3e3ec17679123f2df9c6b572ec3c0b3ffd65
 testvectors-sha256: b9ea5703411a79c215a2643862bf4924ff62eeec08a0d1e328e39f47417fec8f
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-128s-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-128s-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 8080
+nistkat-sha256: 78c68bae7ab635195b41807bd8a6e89f740d762d5b2a7022550cb34cc79cf3b3
 testvectors-sha256: a7057ca5ce0d7f01d1c1aabe474f8449796b051becbc8b148a78c84893193fcf
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-128s-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-128s-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 8080
+nistkat-sha256: dbded19fb5983657e93d047c61ebb0069ea7f5afb928463a308fa44f792429d4
 testvectors-sha256: fcc816e14d200e212b4b955d3011f5a6b61240c7c0003e17acb1bf396ca5d4ad
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-192f-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-192f-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 35664
+nistkat-sha256: 195f00a8c88110b333c30de6d672265d89a19d1991c107aeebe06759dfde33fc
 testvectors-sha256: a88d3adbeb5c1805a90e506c93f5000b266d1227f1621c0f77adf75bdbe4ba02
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-192f-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-192f-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 35664
+nistkat-sha256: b6050873b334c67aeb7e3e3148f39479ffeab4e8c3b3481983abc44278904984
 testvectors-sha256: d054d5394d578057e8264c5ef8a33627fcf194a25270a1dc6c2d7de86408876d
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-192s-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-192s-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 17064
+nistkat-sha256: c59a79130d012b6c25546e57d6d9bb080e2721a40c71e27077bd5b793d96cbe5
 testvectors-sha256: 5dd40c8ea9a81ad93e0685843ec1cabdcb6eec9f6e64fc01d928ebaf7cf377c6
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-192s-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-192s-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 17064
+nistkat-sha256: 1e0b5aefda28f48fb8c4e81a0294e689211616f0748a9d9daf37be9e76b5141a
 testvectors-sha256: 7e50b92ec85e31260326092a62e84d2f12df84213a494d0f0527125a5e6b7ed7
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-256f-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-256f-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 49216
+nistkat-sha256: c2d6cebdf902e168ad27d8a942b36bc6909ea643e0f2b9ab78fd474dbdc0d373
 testvectors-sha256: b5e3a1c1dbb45751f2a4c9323a5d900b30f38e4c7e2943e234a5b9526de1146c
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-256f-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-256f-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 49216
+nistkat-sha256: a848b318c46f1c0a6932fd5102ca4bab43bb3c4692f97b2ee97c9e9bdbd5de36
 testvectors-sha256: 3cddd379bf490efac9a8aefaa9b59e7f70fe96bb177a8bfc404f99bfc2172aee
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-256s-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-256s-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 29792
+nistkat-sha256: 0a57c7fba38bcf56fde765a89da296ae99fda745f96845adda54b4f8fe76b6c6
 testvectors-sha256: feb4f482dd5ab66dd09f2e5e02175e7109de4385da5704f78cc1dac074368c56
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-256s-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-256s-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 29792
+nistkat-sha256: a65476425ff1a68c5d6f941fecaec6e6c00be10695f6cfff15047875bcd5f490
 testvectors-sha256: 25fcc82aa371d06c8b494c2d0a3ac4920cfb8134bef9962491669ef2c6a0b820
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-128f-robust/META.yml
+++ b/crypto_sign/sphincs-sha256-128f-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 16976
+nistkat-sha256: cf7935fc0277099a7453f6c5dc54e40d5cf34fbe989909940a77a3fbbab6c42e
 testvectors-sha256: 3e7c782b25e405940160468c2d777a5ab6eb9b6cfe318efed257f3270cca8c72
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-128f-simple/META.yml
+++ b/crypto_sign/sphincs-sha256-128f-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 16976
+nistkat-sha256: 4375bc4276fa44654979db0da886ba5cf754011db268fc63fa7584d50f5dfb63
 testvectors-sha256: 5ce16422e028eb7a6198d0a276a1760a6bbcd4ba9457ddbbfd5e08f34985c0ce
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-128s-robust/META.yml
+++ b/crypto_sign/sphincs-sha256-128s-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 8080
+nistkat-sha256: 4ddcad5141217340f9f28afdcf25cc236d7975bcfb41b39660e84568a9a461fe
 testvectors-sha256: 29d6d0dd732078d177779a61b7654bbe59fcf2ecb9bcd2ade8391791a6570a63
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-128s-simple/META.yml
+++ b/crypto_sign/sphincs-sha256-128s-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 8080
+nistkat-sha256: 8ae7a91b321cd18bd855710eea9d13deea1a53bb7858baee5f77d0237d1897eb
 testvectors-sha256: edf1b76246ac560558d7938f8ac7bbf820f1e697ef4f5b5e1962f04fadb84a76
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-192f-robust/META.yml
+++ b/crypto_sign/sphincs-sha256-192f-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 35664
+nistkat-sha256: 9d0898cb264172c31d0fb4901dd56d46728e83e0bf008abccb8b0912c2ebbc52
 testvectors-sha256: ca61e66c0377fd367ab0c920d2190855a64348668a336d300ec7f2c72e721be4
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-192f-simple/META.yml
+++ b/crypto_sign/sphincs-sha256-192f-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 35664
+nistkat-sha256: 306fef951d07b17b27c67ffe9e63185ae5d5fde87619b76872a3ca969299d47c
 testvectors-sha256: b25e0f2560f500d8988809522c72ea3ab0f81be52476a6cdf9d05a890a2d2ce0
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-192s-robust/META.yml
+++ b/crypto_sign/sphincs-sha256-192s-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 17064
+nistkat-sha256: 23374b2ece45c8ec7272473d70eb424894324702616b8456343dbd79f109b675
 testvectors-sha256: 1be5c30de6d0b856b1b51f0ff50a2acf9c3a359ee2178004e153bdfc50a68832
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-192s-simple/META.yml
+++ b/crypto_sign/sphincs-sha256-192s-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 17064
+nistkat-sha256: 02b192ff93bc8977a80e9efc8fa6814ae85c2ad939f7185a959b428c1eb77150
 testvectors-sha256: ee413e410a29274a9647b9440d6a554670e0f9587efaaddedf82e4923f68f80e
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-256f-robust/META.yml
+++ b/crypto_sign/sphincs-sha256-256f-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 49216
+nistkat-sha256: e6fafb97dc3575d5dcd79183a4d7faad4f2c986745c63e61ddae3648559664f7
 testvectors-sha256: 14dd19ba3ff75bad890949050289ab0f178d7baa6dcb8ff6bcd6a873692a5686
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-256f-simple/META.yml
+++ b/crypto_sign/sphincs-sha256-256f-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 49216
+nistkat-sha256: 88fa150041ce9c305a971cef8ec444881afc14c4590637fa4b91c1deb15bb215
 testvectors-sha256: b4755edf8351c51225921af38a724d2bd9ff9f3afe4ae2abbc3a59763ecc897d
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-256s-robust/META.yml
+++ b/crypto_sign/sphincs-sha256-256s-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 29792
+nistkat-sha256: da28ff350ac552f100b35b01ecb494dc02f9dcf542fa2d88439cd427985e9581
 testvectors-sha256: 6a85ec1f64d017fc2ffd88aa7d679de7e0554e00bdea62c7fea5c4c403e3eafa
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-sha256-256s-simple/META.yml
+++ b/crypto_sign/sphincs-sha256-256s-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 29792
+nistkat-sha256: 768d61c537b3abacca3ab468623edafb33d28a33dc5a9859f803679a3020b639
 testvectors-sha256: 796b5101fa5170c92f0186b347716dc0662eac35002a8c4d80ac9283cbef5a02
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-128f-robust/META.yml
+++ b/crypto_sign/sphincs-shake256-128f-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 16976
+nistkat-sha256: e7789df37278d1e147996bd9bf4cda55d5ec5cbe921e64b0766927af4b02decd
 testvectors-sha256: eea7f59958e732c15110d0d06e3c23005d73df2b15a1e7b4ebc0ca2dcf162bb5
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-128f-simple/META.yml
+++ b/crypto_sign/sphincs-shake256-128f-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 16976
+nistkat-sha256: c99700873ca6914944fcef3b649270c86c056dcd11ce6e8f22580b193a136e6f
 testvectors-sha256: a14cb8e4f149493fc5979e465e09ce943e8d669186ff5c7c3d11239fa869def6
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-128s-robust/META.yml
+++ b/crypto_sign/sphincs-shake256-128s-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 8080
+nistkat-sha256: e9c31937277677d1cb387ce76408c76b0128938f3af047f60fb5d073a3c788b3
 testvectors-sha256: f3f56ddff38a75ee07b44c023b9c9133ffe9538bb4b64f8ec8742b21fcaa6a50
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-128s-simple/META.yml
+++ b/crypto_sign/sphincs-shake256-128s-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 8080
+nistkat-sha256: 5d23c9f334e9bd99d5294cf40c6b2c096ee668076e809b44b928ca146d2c5e3a
 testvectors-sha256: ee2af38333f6ba705102ab66689c262b07c1fd9ce1d46180796bcb263bf1a654
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-192f-robust/META.yml
+++ b/crypto_sign/sphincs-shake256-192f-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 35664
+nistkat-sha256: 5cfcf998ad0bedf8e6b961c8891048f456d6422d3b4a26fcb095a913c9efd03e
 testvectors-sha256: de65b2a7b6d5e819f58b6e1a08ec4ef3308a9c36b7c962450105f82263e35e98
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-192f-simple/META.yml
+++ b/crypto_sign/sphincs-shake256-192f-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 35664
+nistkat-sha256: 28528adef75a728d013bb493d85e358a75344c72000792419f1f539c16f24f10
 testvectors-sha256: 14f60a3099cfddf30c46491a98a5f3508739df108425b2eaa5c19383f0ca4b22
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-192s-robust/META.yml
+++ b/crypto_sign/sphincs-shake256-192s-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 17064
+nistkat-sha256: 619ce596575f52ed8fd3e5b0501db21985e505c95f0f595faa4d6a6f0a2fd81c
 testvectors-sha256: 4f80c9cf98c017293c7543f96170f18655e6ef65675300aa302de42562b21f5a
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-192s-simple/META.yml
+++ b/crypto_sign/sphincs-shake256-192s-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 17064
+nistkat-sha256: 31b341c25230f8524e123db8a5dc29e8dd952cd11a63a821ac488b97d5106597
 testvectors-sha256: ea1c38dafdeec8bd6b5a844955b1edffbb1d16f392a647fdae8e6dd148c6396c
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-256f-robust/META.yml
+++ b/crypto_sign/sphincs-shake256-256f-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 49216
+nistkat-sha256: d5410edbaa120cf24f0bcf8cb834fdb08b4b5652809ee17c026d37212f4a4934
 testvectors-sha256: 4757a2ce7aec6daac4ab894336586949f7919c63d55200ec6325eb395efcf1ef
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-256f-simple/META.yml
+++ b/crypto_sign/sphincs-shake256-256f-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 49216
+nistkat-sha256: 5a8959fc0436a66d6d69cc8adb2f24936b763ae324bc97ed139ae92f9f7e03c3
 testvectors-sha256: 1b261fc7394dc847349c07bde922ac028aad94c534f51341f8202670558ed27a
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-256s-robust/META.yml
+++ b/crypto_sign/sphincs-shake256-256s-robust/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 29792
+nistkat-sha256: 09004dba03b2a190a327b5404a4d75c663f025703253b78946d0a99ca1492d6f
 testvectors-sha256: eea62308d71394a888e05128f078c4663dc83e128c34e0300bb16cb839d8698b
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-shake256-256s-simple/META.yml
+++ b/crypto_sign/sphincs-shake256-256s-simple/META.yml
@@ -4,6 +4,7 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 29792
+nistkat-sha256: f704deaf990987c306082bb28258cfb8c6f03b49940c06df582ef3fb86958e8a
 testvectors-sha256: fc518be7778d0363f17a30c50efbe28841f5a795e7375e94d206f115967f30df
 principal-submitter: Andreas Hülsing
 auxiliary-submitters:

--- a/test/crypto_sign/nistkat.c
+++ b/test/crypto_sign/nistkat.c
@@ -80,7 +80,7 @@ int main() {
         fprintf(stderr, "[kat_kem] %s ERROR: crypto_sign failed!\n", CRYPTO_ALGNAME);
         return -2;
     }
-    fprintf(fh, "smlen = %lu\n", smlen);
+    fprintf(fh, "smlen = %zu\n", smlen);
     fprintBstr(fh, "sm = ", sm, smlen);
 
     rc = crypto_sign_open(sm, &mlen1, sm, smlen, public_key);
@@ -90,7 +90,7 @@ int main() {
     }
 
     if ( mlen != mlen1 ) {
-        printf("crypto_sign_open returned bad 'mlen': got <%lu>, expected <%lu>\n", mlen1, mlen);
+        printf("crypto_sign_open returned bad 'mlen': got <%zu>, expected <%zu>\n", mlen1, mlen);
         return -4;
     }
     if (memcmp(m, sm, mlen)) {

--- a/test/crypto_sign/nistkat.c
+++ b/test/crypto_sign/nistkat.c
@@ -1,0 +1,102 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "api.h"
+#include "randombytes.h"
+
+// https://stackoverflow.com/a/1489985/1711232
+#define PASTER(x, y) x##_##y
+#define EVALUATOR(x, y) PASTER(x, y)
+#define NAMESPACE(fun) EVALUATOR(PQCLEAN_NAMESPACE, fun)
+
+#define CRYPTO_PUBLICKEYBYTES NAMESPACE(CRYPTO_PUBLICKEYBYTES)
+#define CRYPTO_SECRETKEYBYTES NAMESPACE(CRYPTO_SECRETKEYBYTES)
+#define CRYPTO_BYTES          NAMESPACE(CRYPTO_BYTES)
+#define CRYPTO_ALGNAME        NAMESPACE(CRYPTO_ALGNAME)
+
+#define crypto_sign_keypair NAMESPACE(crypto_sign_keypair)
+#define crypto_sign NAMESPACE(crypto_sign)
+#define crypto_sign_open NAMESPACE(crypto_sign_open)
+
+void nist_kat_init(unsigned char *entropy_input, unsigned char *personalization_string, int security_strength);
+
+static void fprintBstr(FILE *fp, const char *S, const uint8_t *A, size_t L) {
+    size_t i;
+    fprintf(fp, "%s", S);
+    for (i = 0; i < L; i++) {
+        fprintf(fp, "%02X", A[i]);
+    }
+    if (L == 0) {
+        fprintf(fp, "00");
+    }
+    fprintf(fp, "\n");
+}
+
+int main() {
+
+    uint8_t entropy_input[48];
+    uint8_t seed[48];
+    FILE *fh = stdout;
+    uint8_t public_key[CRYPTO_PUBLICKEYBYTES];
+    uint8_t secret_key[CRYPTO_SECRETKEYBYTES];
+    size_t mlen = 33;
+    size_t smlen, mlen1;
+    uint8_t m[33];
+    uint8_t sm[33 + CRYPTO_BYTES];
+    int rc;
+
+    for (uint8_t i = 0; i < 48; i++) {
+        entropy_input[i] = i;
+    }
+
+    nist_kat_init(entropy_input, NULL, 256);
+
+    fprintf(fh, "count = 0\n");
+    randombytes(seed, 48);
+    fprintBstr(fh, "seed = ", seed, 48);
+
+    fprintf(fh, "mlen = 33\n");
+
+    randombytes(m, mlen);
+    fprintBstr(fh, "msg = ", m, mlen);
+
+    nist_kat_init(seed, NULL, 256);
+
+    rc = crypto_sign_keypair(public_key, secret_key);
+    if (rc != 0) {
+        fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_keypair failed!\n", CRYPTO_ALGNAME);
+        return -1;
+    }
+    fprintBstr(fh, "pk = ", public_key, CRYPTO_PUBLICKEYBYTES);
+    fprintBstr(fh, "sk = ", secret_key, CRYPTO_SECRETKEYBYTES);
+
+    rc = crypto_sign(sm, &smlen, m, mlen, secret_key);
+    if (rc != 0) {
+        fprintf(stderr, "[kat_kem] %s ERROR: crypto_sign failed!\n", CRYPTO_ALGNAME);
+        return -2;
+    }
+    fprintf(fh, "smlen = %lu\n", smlen);
+    fprintBstr(fh, "sm = ", sm, smlen);
+
+    rc = crypto_sign_open(sm, &mlen1, sm, smlen, public_key);
+    if (rc != 0) {
+        fprintf(stderr, "[kat_kem] %s ERROR: crypto_sign_open failed!\n", CRYPTO_ALGNAME);
+        return -3;
+    }
+
+    if ( mlen != mlen1 ) {
+        printf("crypto_sign_open returned bad 'mlen': got <%lu>, expected <%lu>\n", mlen1, mlen);
+        return -4;
+    }
+    if (memcmp(m, sm, mlen)) {
+        printf("crypto_sign_open returned bad 'm' value\n");
+        return -5;
+    }
+    return 0;
+
+}

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -47,6 +47,7 @@ EXPECTED_FIELDS = {
     'claimed-nist-level': {'type': int, 'min': 1, 'max': 5},
     'length-public-key': {'type': int, 'min': 1},
     'length-secret-key': {'type': int, 'min': 1},
+    'nistkat-sha256': {'type': str, 'length': 64},
     'principal-submitter': {'type': str},
     'auxiliary-submitters': {'type': list, 'elements': {'type': str}},
     'implementations': {
@@ -65,7 +66,6 @@ KEM_FIELDS = {
     'claimed-security' : {'type' : str, 'values' : ['IND-CPA', 'IND-CCA2'] },
     'length-ciphertext': {'type': int, 'min': 1},
     'length-shared-secret': {'type': int, 'min': 1},
-    'nistkat-sha256': {'type': str, 'length': 64},
 }
 
 SIGNATURE_FIELDS = {

--- a/test/test_nistkat.py
+++ b/test/test_nistkat.py
@@ -17,8 +17,6 @@ import unittest
 
 def test_nistkat():
     for scheme in pqclean.Scheme.all_schemes():
-        if scheme.type != 'kem':
-            continue
         for implementation in scheme.implementations:
             yield check_nistkat, implementation
 


### PR DESCRIPTION
Resolves #169 

<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->

<!-- If you are not submitting a new scheme, we suggest removing the following lines -->
#### Manually checked properties
<!-- These checkboxes serve for the maintainers of PQClean to verify your submission. Please do not check them yourself. -->

* [ ] No stringification macros
* [ ] Output-parameter pointers in functions are on the left
* [ ] Negative return values on failure of API functions (within restrictions of FO transform).
* [ ] `const` arguments are labeled as `const`
* [ ] variable declarations at the beginning (except in `for (size_t i=...`)
* Optional:
  * [ ] All integer types are of fixed size, using `stdint.h` types (including `uint8_t` instead of `unsigned char`)
  * [ ] Integers used for indexing are of size `size_t`
