### PR TITLE
naming conflicts

### DIFF
--- a/common/nistkatrng.c
+++ b/common/nistkatrng.c
@@ -48,7 +48,9 @@ void nist_kat_init(uint8_t *entropy_input, const uint8_t *personalization_string
     DRBG_ctx.reseed_counter = 1;
 }
 
-int randombytes(uint8_t *buf, size_t xlen) {
+//multiple definitions of randombytes, so rename it?
+//int randombytes(uint8_t *buf, size_t xlen) {
+int randombytes_nist_kat(uint8_t *buf, size_t xlen) {
     uint8_t block[16];
     int i = 0;
 

--- a/common/notrandombytes.c
+++ b/common/notrandombytes.c
@@ -57,7 +57,7 @@ static void surf(void) {
     }
 }
 
-int randombytes(uint8_t *buf, size_t xlen) {
+int notrandombytes(uint8_t *buf, size_t xlen) {
     while (xlen > 0) {
         if (!outleft) {
             if (!++in[0]) {


### PR DESCRIPTION
<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->
notrandombytes.c  has function randombytes, causing naming conflict

randombytes is defined in multiple places (maybe it's for testing purposes), but it causes errors running code straight out of the box

<!-- If you are not submitting a new scheme, we suggest removing the following lines -->