### PR TITLE
Add abstract state duplication for SHA256 incremental hashing API

### DIFF
--- a/common/sha2.c
+++ b/common/sha2.c
@@ -529,7 +529,7 @@ void sha512_inc_init(sha512ctx *state) {
     }
 }
 
-void sha256_inc_dupe_state(sha256ctx *stateout, const sha256ctx *statein) {
+void sha256_inc_clone_state(sha256ctx *stateout, const sha256ctx *statein) {
     memcpy(stateout, statein, sizeof(sha256ctx));
 }
 

--- a/common/sha2.c
+++ b/common/sha2.c
@@ -529,8 +529,20 @@ void sha512_inc_init(sha512ctx *state) {
     }
 }
 
+void sha224_inc_clone_state(sha224ctx *stateout, const sha224ctx *statein) {
+    memcpy(stateout, statein, sizeof(sha224ctx));
+}
+
 void sha256_inc_clone_state(sha256ctx *stateout, const sha256ctx *statein) {
     memcpy(stateout, statein, sizeof(sha256ctx));
+}
+
+void sha384_inc_clone_state(sha384ctx *stateout, const sha384ctx *statein) {
+    memcpy(stateout, statein, sizeof(sha384ctx));
+}
+
+void sha512_inc_clone_state(sha512ctx *stateout, const sha512ctx *statein) {
+    memcpy(stateout, statein, sizeof(sha512ctx));
 }
 
 void sha256_inc_blocks(sha256ctx *state, const uint8_t *in, size_t inblocks) {

--- a/common/sha2.c
+++ b/common/sha2.c
@@ -4,6 +4,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "sha2.h"
 
@@ -526,6 +527,10 @@ void sha512_inc_init(sha512ctx *state) {
     for (size_t i = 64; i < 72; ++i) {
         state->ctx[i] = 0;
     }
+}
+
+void sha256_inc_dupe_state(sha256ctx *stateout, const sha256ctx *statein) {
+    memcpy(stateout, statein, sizeof(sha256ctx));
 }
 
 void sha256_inc_blocks(sha256ctx *state, const uint8_t *in, size_t inblocks) {

--- a/common/sha2.h
+++ b/common/sha2.h
@@ -30,6 +30,7 @@ void sha224_inc_finalize(uint8_t *out, sha224ctx *state, const uint8_t *in, size
 void sha224(uint8_t *out, const uint8_t *in, size_t inlen);
 
 void sha256_inc_init(sha256ctx *state);
+void sha256_inc_dupe_state(sha256ctx *stateout, const sha256ctx *statein);
 void sha256_inc_blocks(sha256ctx *state, const uint8_t *in, size_t inblocks);
 void sha256_inc_finalize(uint8_t *out, sha256ctx *state, const uint8_t *in, size_t inlen);
 void sha256(uint8_t *out, const uint8_t *in, size_t inlen);

--- a/common/sha2.h
+++ b/common/sha2.h
@@ -25,6 +25,7 @@ typedef struct {
 } sha512ctx;
 
 void sha224_inc_init(sha224ctx *state);
+void sha224_inc_clone_state(sha224ctx *stateout, const sha224ctx *statein);
 void sha224_inc_blocks(sha224ctx *state, const uint8_t *in, size_t inblocks);
 void sha224_inc_finalize(uint8_t *out, sha224ctx *state, const uint8_t *in, size_t inlen);
 void sha224(uint8_t *out, const uint8_t *in, size_t inlen);
@@ -36,11 +37,13 @@ void sha256_inc_finalize(uint8_t *out, sha256ctx *state, const uint8_t *in, size
 void sha256(uint8_t *out, const uint8_t *in, size_t inlen);
 
 void sha384_inc_init(sha384ctx *state);
+void sha384_inc_clone_state(sha384ctx *stateout, const sha384ctx *statein);
 void sha384_inc_blocks(sha384ctx *state, const uint8_t *in, size_t inblocks);
 void sha384_inc_finalize(uint8_t *out, sha384ctx *state, const uint8_t *in, size_t inlen);
 void sha384(uint8_t *out, const uint8_t *in, size_t inlen);
 
 void sha512_inc_init(sha512ctx *state);
+void sha512_inc_clone_state(sha512ctx *stateout, const sha512ctx *statein);
 void sha512_inc_blocks(sha512ctx *state, const uint8_t *in, size_t inblocks);
 void sha512_inc_finalize(uint8_t *out, sha512ctx *state, const uint8_t *in, size_t inlen);
 void sha512(uint8_t *out, const uint8_t *in, size_t inlen);

--- a/common/sha2.h
+++ b/common/sha2.h
@@ -30,7 +30,7 @@ void sha224_inc_finalize(uint8_t *out, sha224ctx *state, const uint8_t *in, size
 void sha224(uint8_t *out, const uint8_t *in, size_t inlen);
 
 void sha256_inc_init(sha256ctx *state);
-void sha256_inc_dupe_state(sha256ctx *stateout, const sha256ctx *statein);
+void sha256_inc_clone_state(sha256ctx *stateout, const sha256ctx *statein);
 void sha256_inc_blocks(sha256ctx *state, const uint8_t *in, size_t inblocks);
 void sha256_inc_finalize(uint8_t *out, sha256ctx *state, const uint8_t *in, size_t inlen);
 void sha256(uint8_t *out, const uint8_t *in, size_t inlen);

--- a/crypto_sign/sphincs-sha256-128f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-128f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-128f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-128f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-128s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-128s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-128s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-128s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-192f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-192f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-192f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-192f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-192s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-192s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-192s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-192s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-256f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-256f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-256f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-256f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-256s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-256s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_mgf1(bitmask, inblocks * SPX_N, buf, SPX_N + SPX_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-256s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    memcpy(&sha2_state, hash_state_seeded, sizeof(sha256ctx));
+    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);

--- a/crypto_sign/sphincs-sha256-256s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_dupe_state(&sha2_state, hash_state_seeded);
+    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);


### PR DESCRIPTION
The SPHINCS+ SHA-256 variants do an operation where they make a copy of the hash context (state) by doing a memcpy.  This doesn't work if the hash context is mapped onto an abstract pointer object, for example when mapping it on to an `EVP_MD_CTX` object in the OpenSSL EVP API like we do in liboqs (https://github.com/open-quantum-safe/liboqs/blob/ds-sphincs/src/crypto/sha2/sha2_ossl.c, https://github.com/open-quantum-safe/liboqs/blob/ds-sphincs/src/common/pqclean_shims/sha2.h).  This patch introduces an abstract state duplication operation for the SHA256 incremental hashing API and changes SPHINCS+-SHA256* to use it.