### PR TITLE
Fix documentation for Dilithium `crypto_sign_open`

### DIFF
--- a/crypto_sign/dilithium2/clean/sign.c
+++ b/crypto_sign/dilithium2/clean/sign.c
@@ -367,7 +367,7 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign(uint8_t *sm,
 *              - unsigned long long *mlen: pointer to output length of message
 *              - const unsigned char *sm: pointer to signed message
 *              - unsigned long long smlen: length of signed message
-*              - const unsigned char *sk: pointer to bit-packed public key
+*              - const unsigned char *pk: pointer to bit-packed public key
 *
 * Returns 0 if signed message could be verified correctly and -1 otherwise
 **************************************************/

--- a/crypto_sign/dilithium3/clean/sign.c
+++ b/crypto_sign/dilithium3/clean/sign.c
@@ -367,7 +367,7 @@ int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign(uint8_t *sm,
 *              - unsigned long long *mlen: pointer to output length of message
 *              - const unsigned char *sm: pointer to signed message
 *              - unsigned long long smlen: length of signed message
-*              - const unsigned char *sk: pointer to bit-packed public key
+*              - const unsigned char *pk: pointer to bit-packed public key
 *
 * Returns 0 if signed message could be verified correctly and -1 otherwise
 **************************************************/

--- a/crypto_sign/dilithium4/clean/sign.c
+++ b/crypto_sign/dilithium4/clean/sign.c
@@ -367,7 +367,7 @@ int PQCLEAN_DILITHIUM4_CLEAN_crypto_sign(uint8_t *sm,
 *              - unsigned long long *mlen: pointer to output length of message
 *              - const unsigned char *sm: pointer to signed message
 *              - unsigned long long smlen: length of signed message
-*              - const unsigned char *sk: pointer to bit-packed public key
+*              - const unsigned char *pk: pointer to bit-packed public key
 *
 * Returns 0 if signed message could be verified correctly and -1 otherwise
 **************************************************/


### PR DESCRIPTION
It mentioned `sk` instead of `pk` as specified in the arguments.

Closes #205.

