### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# A note on the security of the included implementations and schemes
+
+This project contains (reference) implementations of cryptographic libraries.
+We do not make any security claims about the code included in PQClean.
+In the current state, we distribute reference implementations with minor modifications.
+We did not perform any extensive security analyses.
+This code is suitable for experimental or scientific use.
+We recommend careful expert code review before using any of the included implementations in production environments.
+
+See also the [NIST PQC Forum][forum] for discussion about the cryptographic schemes included in PQClean.
+
+[forum]: https://csrc.nist.gov/Projects/Post-Quantum-Cryptography/Email-List


### PR DESCRIPTION
Uses the new Github security-documenting features/"standard" to explain our security non-policy.
