### PR TITLE
Only absorb root part of pk in haraka message hashing.

### DIFF
--- a/crypto_sign/sphincs-haraka-128f-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-128f-robust/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 16976
-nistkat-sha256: 4d04dcfa1ed0dcbe0af382fe1925b5031a279811f9fea298d64a9fe8eaaf2165
-testvectors-sha256: f0f84722cf529a108006d84b52966cbebd92146ee33cacdd7d1bba2cdc1944fd
+testvectors-sha256: a86f82106578f5bb8ea54caa913dbe2b0ca13294432e06c615e0cc2f3fba66ac
+nistkat-sha256: 22afe9a2b538742f99fbf02293024de6424726eebddb3cac456534055689a4c3
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-128f-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-128f-robust/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-128f-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-128f-simple/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 16976
-nistkat-sha256: 82967bdf0188ff7c6c6f5723798d3e3ec17679123f2df9c6b572ec3c0b3ffd65
-testvectors-sha256: b9ea5703411a79c215a2643862bf4924ff62eeec08a0d1e328e39f47417fec8f
+testvectors-sha256: db98c3cd0ac0292a2b62e11c52851087d84971277188814bf14cbde7ca60c3e9
+nistkat-sha256: d0161f60f8bdd26fa2f03a881eb517adf7d3e9a44f5cc337cb9c0d8acf82c145
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-128f-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-128f-simple/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-128s-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-128s-robust/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 8080
-nistkat-sha256: 78c68bae7ab635195b41807bd8a6e89f740d762d5b2a7022550cb34cc79cf3b3
-testvectors-sha256: a7057ca5ce0d7f01d1c1aabe474f8449796b051becbc8b148a78c84893193fcf
+testvectors-sha256: b39fd1f6f34923b4c0696b72a1242f5a9e45df48eb28dcb9a53e4ba9955e130c
+nistkat-sha256: de504b1aa6ee3cc6513a0da3511414b5d2472c5bd9efa780239518876c4e9fb2
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-128s-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-128s-robust/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-128s-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-128s-simple/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 1
 length-public-key: 32
 length-secret-key: 64
 length-signature: 8080
-nistkat-sha256: dbded19fb5983657e93d047c61ebb0069ea7f5afb928463a308fa44f792429d4
-testvectors-sha256: fcc816e14d200e212b4b955d3011f5a6b61240c7c0003e17acb1bf396ca5d4ad
+testvectors-sha256: 526b848d03142746354042329e174aedda2acd70269a57017e37edd5b1b8976a
+nistkat-sha256: a83a6512c773b1f305f07a383ececf607ecfbd0e5ad49b4ab444faed019f66c8
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-128s-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-128s-simple/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-192f-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-192f-robust/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 35664
-nistkat-sha256: 195f00a8c88110b333c30de6d672265d89a19d1991c107aeebe06759dfde33fc
-testvectors-sha256: a88d3adbeb5c1805a90e506c93f5000b266d1227f1621c0f77adf75bdbe4ba02
+testvectors-sha256: 28a3b10cfcd0bd8b2b9789f7ceb86f764b3be5f22aacad9d66b51d76077d8bc0
+nistkat-sha256: 1d32cab46df0d4e6678a06a9eae7b187c80eaedf56b1e7d221035d7c6f08ef06
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-192f-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-192f-robust/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-192f-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-192f-simple/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 35664
-nistkat-sha256: b6050873b334c67aeb7e3e3148f39479ffeab4e8c3b3481983abc44278904984
-testvectors-sha256: d054d5394d578057e8264c5ef8a33627fcf194a25270a1dc6c2d7de86408876d
+testvectors-sha256: 2d630dda998eda5fa634867af350a211276ad37f95506c48fdb06dc96f78d348
+nistkat-sha256: 4888059ed11c192b3a07e227e3befc967819d05f85723a7740bbc31eadc37f37
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-192f-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-192f-simple/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-192s-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-192s-robust/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 17064
-nistkat-sha256: c59a79130d012b6c25546e57d6d9bb080e2721a40c71e27077bd5b793d96cbe5
-testvectors-sha256: 5dd40c8ea9a81ad93e0685843ec1cabdcb6eec9f6e64fc01d928ebaf7cf377c6
+testvectors-sha256: 524edf3f752a7f203fb128d9ca3ad530fba09777527f7d7511477dbaaea185ca
+nistkat-sha256: 3bb2c0ea5d4b7c39d1c63b424493ab9b739c64adf511abf7e4107ad750a46273
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-192s-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-192s-robust/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-192s-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-192s-simple/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 3
 length-public-key: 48
 length-secret-key: 96
 length-signature: 17064
-nistkat-sha256: 1e0b5aefda28f48fb8c4e81a0294e689211616f0748a9d9daf37be9e76b5141a
-testvectors-sha256: 7e50b92ec85e31260326092a62e84d2f12df84213a494d0f0527125a5e6b7ed7
+testvectors-sha256: 0228f1872256e698360c0b156e7fffc12d234e50acbf05a4e899d4d8105d2796
+nistkat-sha256: c8e823fe6b03f35a0d9996dea1559e6924b86e2631e945a3ab9bb4e55c22c068
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-192s-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-192s-simple/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-256f-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-256f-robust/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 49216
-nistkat-sha256: c2d6cebdf902e168ad27d8a942b36bc6909ea643e0f2b9ab78fd474dbdc0d373
-testvectors-sha256: b5e3a1c1dbb45751f2a4c9323a5d900b30f38e4c7e2943e234a5b9526de1146c
+testvectors-sha256: 7cc4c9a8720401ed53bc2fa9a0dd9e316dca3a715b3c730d1e0c4822dfdfd0b5
+nistkat-sha256: b31c6a00604e5f1eed1534c0f8ab29ceb0c831397075ca93c43c5a2a73e2649c
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-256f-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-256f-robust/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-256f-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-256f-simple/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 49216
-nistkat-sha256: a848b318c46f1c0a6932fd5102ca4bab43bb3c4692f97b2ee97c9e9bdbd5de36
-testvectors-sha256: 3cddd379bf490efac9a8aefaa9b59e7f70fe96bb177a8bfc404f99bfc2172aee
+testvectors-sha256: dec0d78c3084540ea5c8a4ced594d07b0110d21d4a5564b80c4ea2638030b44d
+nistkat-sha256: 73d4172d95d0e668f7ac535a67f6ab26a963a604391053c9a2ce62cba88f2220
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-256f-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-256f-simple/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-256s-robust/META.yml
+++ b/crypto_sign/sphincs-haraka-256s-robust/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 29792
-nistkat-sha256: 0a57c7fba38bcf56fde765a89da296ae99fda745f96845adda54b4f8fe76b6c6
-testvectors-sha256: feb4f482dd5ab66dd09f2e5e02175e7109de4385da5704f78cc1dac074368c56
+testvectors-sha256: 10ea3f99d8899cc82d3a21f2198e93f32585b1c08022e57c1984b0811336f09f
+nistkat-sha256: a419bdba92da2d07f99c3c3ba4f776b955244a7c3b565816c7fd2151f6c3363f
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-256s-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-256s-robust/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-256s-simple/META.yml
+++ b/crypto_sign/sphincs-haraka-256s-simple/META.yml
@@ -4,8 +4,8 @@ claimed-nist-level: 5
 length-public-key: 64
 length-secret-key: 128
 length-signature: 29792
-nistkat-sha256: a65476425ff1a68c5d6f941fecaec6e6c00be10695f6cfff15047875bcd5f490
-testvectors-sha256: 25fcc82aa371d06c8b494c2d0a3ac4920cfb8134bef9962491669ef2c6a0b820
+testvectors-sha256: cab3bd8c005a4e868052c471ec110359305e986f237f8ce2c7c08ae45c424bbe
+nistkat-sha256: 0b8c7d3d8001eec6ddb317e0301fef4adc4f5b03301e5f4b93d09881b1a5ba7a
 principal-submitters:
   - Andreas Hülsing
 auxiliary-submitters:

--- a/crypto_sign/sphincs-haraka-256s-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-256s-simple/clean/hash_haraka.c
@@ -72,7 +72,7 @@ void PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_hash_message(
 
     PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_haraka_S_inc_init(s_inc);
     PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, R, SPX_N, hash_state_seeded);
-    PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk, SPX_PK_BYTES, hash_state_seeded);
+    PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, pk + SPX_N, SPX_N, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_haraka_S_inc_absorb(s_inc, m, mlen, hash_state_seeded);
     PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_haraka_S_inc_finalize(s_inc);
     PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_haraka_S_inc_squeeze(buf, SPX_DGST_BYTES, s_inc, hash_state_seeded);


### PR DESCRIPTION
<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->
Fix to only absorb root part of the pk in the message hash of Haraka, as required in the NIST specification.

<!-- If you are not submitting a new scheme, we suggest removing the following lines -->
#### Manually checked properties
<!-- These checkboxes serve for the maintainers of PQClean to verify your submission. Please do not check them yourself. -->

* [ ] No stringification macros
* [ ] Output-parameter pointers in functions are on the left
* [ ] Negative return values on failure of API functions (within restrictions of FO transform).
* [ ] `const` arguments are labeled as `const`
* [ ] variable declarations at the beginning (except in `for (size_t i=...`)
* Optional:
  * [ ] All integer types are of fixed size, using `stdint.h` types (including `uint8_t` instead of `unsigned char`)
  * [ ] Integers used for indexing are of size `size_t`
