### PR TITLE
Fix display of test results summary on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,9 @@ version: 2.1
           python3 -m pytest --verbose --junitxml=test-results/pytest/results.xml --numprocesses=auto
         no_output_timeout: 2h
     - store_test_results:
-        path: test-results
+        path: test/test-results
     - store_artifacts:
-        path: test-results
+        path: test/test-results
 
 jobs:
   arm64-gcc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,8 @@ version: 2.1
         no_output_timeout: 2h
     - store_test_results:
         path: test-results
+    - store_artifacts:
+        path: test-results
 
 jobs:
   arm64-gcc:

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 norecursedirs = .git *
 empty_parameter_set_mark = fail_at_collect
+junit_log_passing_tests = False


### PR DESCRIPTION
The results of the tests were not being displayed in a nice way because `results.xml` was over 15 MB in size. This reduces that by not logging the output of succeeded tests.