### PR TITLE
Run with ``-Wcast-align=strict`` when available

### DIFF
--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -24,7 +24,7 @@ def test_functest(implementation, impl_path, test_dir,
                   init, destr):
     init()
     dest_dir = os.path.join(test_dir, 'bin')
-    helpers.make('functest',
+    helpers.make('clean-scheme', 'functest',
                  TYPE=implementation.scheme.type,
                  SCHEME=implementation.scheme.name,
                  IMPLEMENTATION=implementation.name,


### PR DESCRIPTION
This warning is not available on Clang or GCC < 8, but it's useful to prevent
problems such as those found in #220.