### PR TITLE
Add support for specifying architecture and feature limits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML
 pytest
 pytest-xdist
 pycparser
+py-cpuinfo

--- a/test/Makefile
+++ b/test/Makefile
@@ -69,7 +69,7 @@ $(DEST_DIR)/testvectors_$(SCHEME)_$(IMPLEMENTATION): build-scheme crypto_$(TYPE)
 	mkdir -p $(DEST_DIR)
 	$(CC) $(CFLAGS) -DPQCLEAN_NAMESPACE=PQCLEAN_$(SCHEME_UPPERCASE)_$(IMPLEMENTATION_UPPERCASE) -I$(SCHEME_DIR) crypto_$(TYPE)/testvectors.c $(COMMON_FILES) $(TEST_COMMON_DIR)/notrandombytes.c -o $@ -L$(SCHEME_DIR) -l$(SCHEME)_$(IMPLEMENTATION)
 
-$(DEST_DIR)/printparams_$(SCHEME)_$(IMPLEMENTATION): build-scheme crypto_$(TYPE)/printparams.c
+$(DEST_DIR)/printparams_$(SCHEME)_$(IMPLEMENTATION): crypto_$(TYPE)/printparams.c
 	mkdir -p $(DEST_DIR)
 	$(CC) $(CFLAGS) -DPQCLEAN_NAMESPACE=PQCLEAN_$(SCHEME_UPPERCASE)_$(IMPLEMENTATION_UPPERCASE) -I$(SCHEME_DIR) crypto_$(TYPE)/printparams.c -o $@
 

--- a/test/pqclean.py
+++ b/test/pqclean.py
@@ -126,7 +126,7 @@ class Implementation:
         return '{}{}_'.format(self.scheme.namespace_prefix(),
                               self.name.upper()).replace('-', '')
 
-    def supported_on_current_platform(self):
+    def supported_on_current_platform(self) -> bool:
         if 'supported_platforms' not in self.metadata():
             return True
 
@@ -139,7 +139,7 @@ class Implementation:
 
         CPUINFO = Implementation.CPUINFO
 
-        for platform_ in self.metadata().get('supported_platforms'):
+        for platform_ in self.metadata()['supported_platforms']:
             if platform_['architecture'] == CPUINFO['arch'].lower():
                 # Detect actually running on emulated i386
                 if (platform_['architecture'] == 'x86_64' and

--- a/test/pqclean.py
+++ b/test/pqclean.py
@@ -2,9 +2,7 @@ import glob
 import os
 
 import yaml
-import cpuinfo
-
-CPUINFO = cpuinfo.get_cpu_info()
+import platform
 
 
 class Scheme:
@@ -129,12 +127,18 @@ class Implementation:
                               self.name.upper()).replace('-', '')
 
     def supported_on_current_platform(self):
+        if platform.machine() == 'ppc':
+            return 'supported_platforms' in self.metadata()
+
+        import cpuinfo
+        CPUINFO = cpuinfo.get_cpu_info()
+
         if 'supported_platforms' not in self.metadata():
             return True
-        for platform in self.metadata().get('supported_platforms'):
-            if platform['architecture'] == CPUINFO['arch'].lower():
+        for platform_ in self.metadata().get('supported_platforms'):
+            if platform_['architecture'] == CPUINFO['arch'].lower():
                 if all([flag in CPUINFO['flags']
-                        for flag in platform['required_flags']]):
+                        for flag in platform_['required_flags']]):
                     return True
         return False
 

--- a/test/pqclean.py
+++ b/test/pqclean.py
@@ -1,5 +1,6 @@
 import glob
 import os
+from typing import Optional
 
 import yaml
 import platform
@@ -126,12 +127,30 @@ class Implementation:
         return '{}{}_'.format(self.scheme.namespace_prefix(),
                               self.name.upper()).replace('-', '')
 
+    def supported_on_os(self, os: Optional[str] = None) -> bool:
+        """Check if we support the OS
+
+        If no OS is specified, then we run on the current OS
+        """
+        if os is None:
+            os = platform.system()
+
+        for platform_ in self.metadata().get('supported_platforms', []):
+            if 'operating_systems' in platform_:
+                if os not in platform_['operating_systems']:
+                    return False
+
+        return True
+
     def supported_on_current_platform(self) -> bool:
         if 'supported_platforms' not in self.metadata():
             return True
 
         if platform.machine() == 'ppc':
-            return 'supported_platforms' not in self.metadata()
+            return False
+
+        if not self.supported_on_os():
+            return False
 
         if not hasattr(Implementation, 'CPUINFO'):
             import cpuinfo

--- a/test/test_compile_lib.py
+++ b/test/test_compile_lib.py
@@ -11,8 +11,8 @@ import pqclean
 @pytest.mark.parametrize(
     'implementation,test_dir,impl_dir, init, destr',
     [(impl, *helpers.isolate_test_files(impl.path(), 'test_functest_'))
-     for impl in pqclean.Scheme.all_implementations()],
-    ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
+     for impl in pqclean.Scheme.all_supported_implementations()],
+    ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
 )
 @helpers.filtered_test
 def test_compile_lib(implementation, test_dir, impl_dir, init, destr):

--- a/test/test_dynamic_memory.py
+++ b/test/test_dynamic_memory.py
@@ -11,8 +11,8 @@ import pqclean
 @pytest.mark.parametrize(
     'implementation,test_dir,impl_path, init, destr',
     [(impl, *helpers.isolate_test_files(impl.path(), 'test_functest_'))
-     for impl in pqclean.Scheme.all_implementations()],
-    ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
+     for impl in pqclean.Scheme.all_supported_implementations()],
+    ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
 )
 @helpers.skip_windows()
 @helpers.filtered_test

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -45,8 +45,8 @@ def test_functest(implementation, impl_path, test_dir,
     'implementation,test_dir,impl_path, init, destr',
     [(impl,
       *helpers.isolate_test_files(impl.path(), 'test_functest_sanitizers_'))
-     for impl in pqclean.Scheme.all_implementations()],
-    ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
+     for impl in pqclean.Scheme.all_supported_implementations()],
+    ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
 )
 @helpers.skip_windows()
 @helpers.filtered_test

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -16,8 +16,8 @@ import pqclean
 @pytest.mark.parametrize(
     'implementation,test_dir,impl_path, init, destr',
     [(impl, *helpers.isolate_test_files(impl.path(), 'test_functest_'))
-     for impl in pqclean.Scheme.all_implementations()],
-    ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
+     for impl in pqclean.Scheme.all_supported_implementations()],
+    ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
 )
 @helpers.filtered_test
 def test_functest(implementation, impl_path, test_dir,

--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -13,7 +13,7 @@ additional_flags = [] #['-fix-errors']
 
 @pytest.mark.parametrize(
     'implementation',
-    pqclean.Scheme.all_implementations(),
+    pqclean.Scheme.all_supported_implementations(),
     ids=str,
 )
 @helpers.skip_windows()

--- a/test/test_makefile_dependencies.py
+++ b/test/test_makefile_dependencies.py
@@ -18,7 +18,7 @@ import pqclean
     [(impl,
       *helpers.isolate_test_files(impl.path(), 'test_makefile_deps_'))
      for impl in pqclean.Scheme.all_supported_implementations()],
-    ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
+    ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
 )
 @helpers.filtered_test
 def test_makefile_dependencies(implementation, impl_path, test_dir,

--- a/test/test_makefile_dependencies.py
+++ b/test/test_makefile_dependencies.py
@@ -17,7 +17,7 @@ import pqclean
     'implementation,test_dir,impl_path, init, destr',
     [(impl,
       *helpers.isolate_test_files(impl.path(), 'test_makefile_deps_'))
-     for impl in pqclean.Scheme.all_implementations()],
+     for impl in pqclean.Scheme.all_supported_implementations()],
     ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
 )
 @helpers.filtered_test

--- a/test/test_makefiles_present.py
+++ b/test/test_makefiles_present.py
@@ -17,10 +17,23 @@ import pqclean
     ids=str,
 )
 @helpers.filtered_test
-def test_makefiles_present(implementation):
+def test_makefile_present(implementation):
     p1 = os.path.join(implementation.path(), 'Makefile')
+    assert os.path.isfile(p1)
+
+
+@pytest.mark.parametrize(
+    'implementation',
+    pqclean.Scheme.all_implementations(),
+    ids=str,
+)
+@helpers.filtered_test
+def test_microsoft_nmakefile_present(implementation):
     p2 = os.path.join(implementation.path(), 'Makefile.Microsoft_nmake')
-    assert(os.path.isfile(p1) and os.path.isfile(p2))
+    if implementation.supported_on_os(os='Windows'):
+        assert os.path.isfile(p2)
+    else:
+        assert not os.path.isfile(p2), "Should not have an NMake file"
 
 
 if __name__ == '__main__':

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -61,6 +61,23 @@ EXPECTED_FIELDS = {
             'spec': {
                 'name': {'type': str},
                 'version': {'type': str},
+                'supported_platforms': {
+                    'type': list,
+                    'optional': True,
+                    'elements': {
+                        'type': dict,
+                        'spec': {
+                            'architecture': {
+                                'type': str,
+                                'values': ['x86', 'x86_64', 'aarch64']},
+                            'required_flags': {
+                                'type': list,
+                                'optional': True,
+                                'elements': {'type': str},
+                            },
+                        },
+                    },
+                },
             },
         },
     },

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -75,6 +75,14 @@ EXPECTED_FIELDS = {
                                 'optional': True,
                                 'elements': {'type': str},
                             },
+                            'operating_systems': {
+                                'type': list,
+                                'optional': True,
+                                'elements': {
+                                    'type': str,
+                                    'values': ['Linux', 'Windows', 'Darwin'],
+                                },
+                            },
                         },
                     },
                 },

--- a/test/test_metadata_sizes.py
+++ b/test/test_metadata_sizes.py
@@ -9,7 +9,7 @@ import pqclean
 
 @pytest.mark.parametrize(
     'implementation,test_dir,impl_path, init, destr',
-    [(impl, *helpers.isolate_test_files(impl.path(), 'test_functest_'))
+    [(impl, *helpers.isolate_test_files(impl.path(), 'test_printparams_'))
      for impl in pqclean.Scheme.all_implementations()],
     ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
 )

--- a/test/test_nistkat.py
+++ b/test/test_nistkat.py
@@ -20,8 +20,8 @@ import pqclean
 @pytest.mark.parametrize(
     'implementation,test_dir,impl_path, init, destr',
     [(impl, *helpers.isolate_test_files(impl.path(), 'test_functest_'))
-     for impl in pqclean.Scheme.all_implementations()],
-    ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
+     for impl in pqclean.Scheme.all_supported_implementations()],
+    ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
 )
 @helpers.filtered_test
 def test_nistkat(implementation, impl_path, test_dir, init, destr):

--- a/test/test_symbol_namespace.py
+++ b/test/test_symbol_namespace.py
@@ -16,8 +16,8 @@ import pqclean
     'implementation,test_dir,impl_path,init,destr',
     [(impl,
       *helpers.isolate_test_files(impl.path(), 'test_symbol_ns_'))
-     for impl in pqclean.Scheme.all_implementations()],
-    ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
+     for impl in pqclean.Scheme.all_supported_implementations()],
+    ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
 )
 @helpers.filtered_test
 def test_symbol_namespaces(implementation, impl_path, test_dir, init, destr):

--- a/test/test_testvectors.py
+++ b/test/test_testvectors.py
@@ -5,6 +5,7 @@ the one provided in the META file for every scheme/implementation.
 
 import hashlib
 import os
+import unittest
 
 import pytest
 
@@ -22,6 +23,8 @@ import pqclean
 )
 @helpers.filtered_test
 def test_testvectors(implementation, impl_path, test_dir, init, destr):
+    if not implementation.supported_on_current_platform():
+        raise unittest.SkipTest("Not supported on current platform")
     init()
     dest_dir = os.path.join(test_dir, 'bin')
     helpers.make('testvectors',

--- a/test/test_valgrind.py
+++ b/test/test_valgrind.py
@@ -15,8 +15,8 @@ import pqclean
 @pytest.mark.parametrize(
     'implementation,test_dir,impl_path, init, destr',
     [(impl, *helpers.isolate_test_files(impl.path(), 'test_functest_'))
-     for impl in pqclean.Scheme.all_implementations()],
-    ids=[str(impl) for impl in pqclean.Scheme.all_implementations()],
+     for impl in pqclean.Scheme.all_supported_implementations()],
+    ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
 )
 @helpers.slow_test
 @helpers.filtered_test


### PR DESCRIPTION
This adds support for adding architecture-specific implementations to PQClean.

You would specify them as follows:

```yaml
    - name: avx2
      version: https://github.com/pq-crystals/kyber/commit/46e283ab575ec92dfe82fb12229ae2d9d6246682
      supported_platforms:
          - architecture: x86_64
            required_flags:
                - avx2
```
