### PR TITLE
Fix clang-tidy complaint about comparison

### DIFF
--- a/common/fips202.c
+++ b/common/fips202.c
@@ -441,7 +441,7 @@ static void keccak_inc_absorb(uint64_t *s_inc, uint32_t r, const uint8_t *m,
 
     /* Recall that s_inc[25] is the non-absorbed bytes xored into the state */
     while (mlen + s_inc[25] >= r) {
-        for (i = 0; i < r - s_inc[25]; i++) {
+        for (i = 0; i < r - (uint32_t)s_inc[25]; i++) {
             /* Take the i'th byte from message
                xor with the s_inc[25] + i'th byte of the state; little-endian */
             s_inc[(s_inc[25] + i) >> 3] ^= (uint64_t)m[i] << (8 * ((s_inc[25] + i) & 0x07));


### PR DESCRIPTION
the `uint64_t` result of the subtraction is being compared with a possibly 32-bit `size_t`