### PR TITLE
Check and fix consistency of scheme names

### DIFF
--- a/crypto_kem/ledakemlt12/META.yml
+++ b/crypto_kem/ledakemlt12/META.yml
@@ -1,4 +1,4 @@
-name: LEDAcryptKEMLT12
+name: LEDAKEMLT12
 type: kem
 claimed-nist-level: 1
 claimed-security: IND-CCA2

--- a/crypto_kem/ledakemlt32/META.yml
+++ b/crypto_kem/ledakemlt32/META.yml
@@ -1,4 +1,4 @@
-name: LEDAcryptKEMLT32
+name: LEDAKEMLT32
 type: kem
 claimed-nist-level: 3
 claimed-security: IND-CCA2

--- a/crypto_kem/ledakemlt52/META.yml
+++ b/crypto_kem/ledakemlt52/META.yml
@@ -1,4 +1,4 @@
-name: LEDAcryptKEMLT52
+name: LEDAKEMLT52
 type: kem
 claimed-nist-level: 5
 claimed-security: IND-CCA2

--- a/crypto_kem/newhope1024cca/META.yml
+++ b/crypto_kem/newhope1024cca/META.yml
@@ -1,4 +1,4 @@
-name: NewHope1024CCA
+name: NewHope1024-CCAKEM
 type: kem
 claimed-nist-level: 5
 claimed-security: IND-CCA2

--- a/crypto_kem/newhope1024cpa/META.yml
+++ b/crypto_kem/newhope1024cpa/META.yml
@@ -1,4 +1,4 @@
-name: NewHope1024CPA
+name: NewHope1024-CPAKEM
 type: kem
 claimed-nist-level: 5
 claimed-security: IND-CPA

--- a/crypto_kem/newhope512cca/META.yml
+++ b/crypto_kem/newhope512cca/META.yml
@@ -1,4 +1,4 @@
-name: NewHope512CCA
+name: NewHope512-CCAKEM
 type: kem
 claimed-nist-level: 1
 claimed-security: IND-CCA2

--- a/crypto_kem/newhope512cpa/META.yml
+++ b/crypto_kem/newhope512cpa/META.yml
@@ -1,4 +1,4 @@
-name: NewHope512CPA
+name: NewHope512-CPAKEM
 type: kem
 claimed-nist-level: 1
 claimed-security: IND-CPA

--- a/crypto_kem/ntruhps2048509/META.yml
+++ b/crypto_kem/ntruhps2048509/META.yml
@@ -1,4 +1,4 @@
-name: ntru-hps2048509
+name: NTRU-HPS2048509
 type: kem
 claimed-nist-level: 1
 claimed-security: IND-CCA2

--- a/crypto_kem/ntruhps2048677/META.yml
+++ b/crypto_kem/ntruhps2048677/META.yml
@@ -1,4 +1,4 @@
-name: ntru-hps2048677
+name: NTRU-HPS2048677
 type: kem
 claimed-nist-level: 3
 claimed-security: IND-CCA2

--- a/crypto_kem/ntruhps4096821/META.yml
+++ b/crypto_kem/ntruhps4096821/META.yml
@@ -1,4 +1,4 @@
-name: ntru-hps4096821
+name: NTRU-HPS4096821
 type: kem
 claimed-nist-level: 5
 claimed-security: IND-CCA2

--- a/crypto_kem/ntruhrss701/META.yml
+++ b/crypto_kem/ntruhrss701/META.yml
@@ -1,4 +1,4 @@
-name: ntru-hrss701
+name: NTRU-HRSS701
 type: kem
 claimed-nist-level: 3
 claimed-security: IND-CCA2

--- a/crypto_sign/dilithium2/META.yml
+++ b/crypto_sign/dilithium2/META.yml
@@ -1,4 +1,4 @@
-name: DilithiumII
+name: Dilithium2
 type: signature
 claimed-nist-level: 1
 length-public-key: 1184

--- a/crypto_sign/dilithium3/META.yml
+++ b/crypto_sign/dilithium3/META.yml
@@ -1,4 +1,4 @@
-name: DilithiumIII
+name: Dilithium3
 type: signature
 claimed-nist-level: 2
 length-public-key: 1472

--- a/crypto_sign/dilithium4/META.yml
+++ b/crypto_sign/dilithium4/META.yml
@@ -1,4 +1,4 @@
-name: DilithiumIV
+name: Dilithium4
 type: signature
 claimed-nist-level: 3
 length-public-key: 1760

--- a/test/crypto_kem/printparams.c
+++ b/test/crypto_kem/printparams.c
@@ -10,5 +10,6 @@ int main() {
     printf("\t\"CRYPTO_SECRETKEYBYTES\": %u,\n",  NAMESPACE(CRYPTO_SECRETKEYBYTES));
     printf("\t\"CRYPTO_PUBLICKEYBYTES\": %u,\n",  NAMESPACE(CRYPTO_PUBLICKEYBYTES));
     printf("\t\"CRYPTO_CIPHERTEXTBYTES\": %u,\n", NAMESPACE(CRYPTO_CIPHERTEXTBYTES));
-    printf("\t\"CRYPTO_BYTES\": %u\n}\n",         NAMESPACE(CRYPTO_BYTES));
+    printf("\t\"CRYPTO_BYTES\": %u,\n",           NAMESPACE(CRYPTO_BYTES));
+    printf("\t\"CRYPTO_ALGNAME\": \"%s\"\n}\n",   NAMESPACE(CRYPTO_ALGNAME));
 }

--- a/test/crypto_sign/printparams.c
+++ b/test/crypto_sign/printparams.c
@@ -9,5 +9,6 @@ int main() {
     printf("{\n");
     printf("\t\"CRYPTO_SECRETKEYBYTES\": %u,\n",  NAMESPACE(CRYPTO_SECRETKEYBYTES));
     printf("\t\"CRYPTO_PUBLICKEYBYTES\": %u,\n",  NAMESPACE(CRYPTO_PUBLICKEYBYTES));
-    printf("\t\"CRYPTO_BYTES\": %u\n}\n",         NAMESPACE(CRYPTO_BYTES));
+    printf("\t\"CRYPTO_BYTES\": %u,\n",           NAMESPACE(CRYPTO_BYTES));
+    printf("\t\"CRYPTO_ALGNAME\": \"%s\"\n}\n",   NAMESPACE(CRYPTO_ALGNAME));
 }

--- a/test/test_metadata_sizes.py
+++ b/test/test_metadata_sizes.py
@@ -37,6 +37,7 @@ def test_metadata_sizes(implementation, impl_path, test_dir, init, destr):
 
     assert parsed['CRYPTO_SECRETKEYBYTES'] == metadata['length-secret-key']
     assert parsed['CRYPTO_PUBLICKEYBYTES'] == metadata['length-public-key']
+    assert parsed['CRYPTO_ALGNAME'] == metadata['name']
 
     if implementation.scheme.type == 'kem':
         assert (


### PR DESCRIPTION
This adds checking that the scheme name in `META.yml` is consistent with what is defined as `CRYPTO_ALGNAME` in `api.h`. 

It also fixes it for the schemes that had inconsistent names here (by changing it to one defined in `api.h`). 