### PR TITLE
Ignore pointless clang-tidy warning.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-readability-isolate-declaration'
+Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-readability-isolate-declaration,-readability-uppercase-literal-suffix'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
It wants you to write type suffixes for integers using uppercase. Let's
just disable this warning.

https://clang.llvm.org/extra/clang-tidy/checks/readability-uppercase-literal-suffix.html