### PR TITLE
Fix Clang 9.0.0 warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-readability-isolate-declaration,-readability-uppercase-literal-suffix'
+Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/crypto_kem/kyber768/avx2/indcpa.c
+++ b/crypto_kem/kyber768/avx2/indcpa.c
@@ -199,11 +199,7 @@ static void gen_matrix(polyvec *a, const uint8_t *seed, int transposed) {
     PQCLEAN_KYBER768_AVX2_poly_nttunpack(&a[2].vec[0]);
     PQCLEAN_KYBER768_AVX2_poly_nttunpack(&a[2].vec[1]);
 
-    if (transposed) {
-        PQCLEAN_KYBER768_AVX2_kyber_shake128_absorb(&state1x, seed, 2, 2);
-    } else {
-        PQCLEAN_KYBER768_AVX2_kyber_shake128_absorb(&state1x, seed, 2, 2);
-    }
+    PQCLEAN_KYBER768_AVX2_kyber_shake128_absorb(&state1x, seed, 2, 2);
 
     PQCLEAN_KYBER768_AVX2_kyber_shake128_squeezeblocks(buf.x[0], GEN_MATRIX_MAXNBLOCKS, &state1x);
     bufbytes = GEN_MATRIX_MAXNBLOCKS * XOF_BLOCKBYTES;

--- a/crypto_sign/rainbowIIIc-classic/clean/rainbow.c
+++ b/crypto_sign/rainbowIIIc-classic/clean/rainbow.c
@@ -15,8 +15,6 @@
 #include <string.h>
 
 #define MAX_ATTEMPT_FRMAT 128
-#define _MAX_O ((_O1 > _O2) ? _O1 : _O2)
-#define _MAX_O_BYTE ((_O1_BYTE > _O2_BYTE) ? _O1_BYTE : _O2_BYTE)
 
 int PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_rainbow_sign(uint8_t *signature, const sk_t *sk, const uint8_t *_digest) {
     uint8_t mat_l1[_O1 * _O1_BYTE];

--- a/crypto_sign/rainbowIIIc-classic/clean/rainbow_config.h
+++ b/crypto_sign/rainbowIIIc-classic/clean/rainbow_config.h
@@ -9,6 +9,7 @@
 #define _V1 68
 #define _O1 36
 #define _O2 36
+#define _MAX_O 36
 #define _HASH_LEN 48
 
 
@@ -27,6 +28,7 @@
 #define _V2_BYTE (_V2)
 #define _O1_BYTE (_O1)
 #define _O2_BYTE (_O2)
+#define _MAX_O_BYTE (_MAX_O)
 #define _PUB_N_BYTE (_PUB_N)
 #define _PUB_M_BYTE (_PUB_M)
 

--- a/crypto_sign/rainbowIIIc-cyclic-compressed/clean/rainbow.c
+++ b/crypto_sign/rainbowIIIc-cyclic-compressed/clean/rainbow.c
@@ -15,8 +15,6 @@
 #include <string.h>
 
 #define MAX_ATTEMPT_FRMAT 128
-#define _MAX_O ((_O1 > _O2) ? _O1 : _O2)
-#define _MAX_O_BYTE ((_O1_BYTE > _O2_BYTE) ? _O1_BYTE : _O2_BYTE)
 
 int PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_rainbow_sign(uint8_t *signature, const sk_t *sk, const uint8_t *_digest) {
     uint8_t mat_l1[_O1 * _O1_BYTE];

--- a/crypto_sign/rainbowIIIc-cyclic-compressed/clean/rainbow_config.h
+++ b/crypto_sign/rainbowIIIc-cyclic-compressed/clean/rainbow_config.h
@@ -9,6 +9,7 @@
 #define _V1 68
 #define _O1 36
 #define _O2 36
+#define _MAX_O 36
 #define _HASH_LEN 48
 
 
@@ -27,6 +28,7 @@
 #define _V2_BYTE (_V2)
 #define _O1_BYTE (_O1)
 #define _O2_BYTE (_O2)
+#define _MAX_O_BYTE (_MAX_O)
 #define _PUB_N_BYTE (_PUB_N)
 #define _PUB_M_BYTE (_PUB_M)
 

--- a/crypto_sign/rainbowIIIc-cyclic/clean/rainbow.c
+++ b/crypto_sign/rainbowIIIc-cyclic/clean/rainbow.c
@@ -15,8 +15,6 @@
 #include <string.h>
 
 #define MAX_ATTEMPT_FRMAT 128
-#define _MAX_O ((_O1 > _O2) ? _O1 : _O2)
-#define _MAX_O_BYTE ((_O1_BYTE > _O2_BYTE) ? _O1_BYTE : _O2_BYTE)
 
 int PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_rainbow_sign(uint8_t *signature, const sk_t *sk, const uint8_t *_digest) {
     uint8_t mat_l1[_O1 * _O1_BYTE];

--- a/crypto_sign/rainbowIIIc-cyclic/clean/rainbow_config.h
+++ b/crypto_sign/rainbowIIIc-cyclic/clean/rainbow_config.h
@@ -9,6 +9,7 @@
 #define _V1 68
 #define _O1 36
 #define _O2 36
+#define _MAX_O 36
 #define _HASH_LEN 48
 
 
@@ -27,6 +28,7 @@
 #define _V2_BYTE (_V2)
 #define _O1_BYTE (_O1)
 #define _O2_BYTE (_O2)
+#define _MAX_O_BYTE (_MAX_O)
 #define _PUB_N_BYTE (_PUB_N)
 #define _PUB_M_BYTE (_PUB_M)
 

--- a/crypto_sign/rainbowIa-classic/clean/rainbow.c
+++ b/crypto_sign/rainbowIa-classic/clean/rainbow.c
@@ -15,8 +15,6 @@
 #include <string.h>
 
 #define MAX_ATTEMPT_FRMAT 128
-#define _MAX_O ((_O1 > _O2) ? _O1 : _O2)
-#define _MAX_O_BYTE ((_O1_BYTE > _O2_BYTE) ? _O1_BYTE : _O2_BYTE)
 
 int PQCLEAN_RAINBOWIACLASSIC_CLEAN_rainbow_sign(uint8_t *signature, const sk_t *sk, const uint8_t *_digest) {
     uint8_t mat_l1[_O1 * _O1_BYTE];

--- a/crypto_sign/rainbowIa-classic/clean/rainbow_config.h
+++ b/crypto_sign/rainbowIa-classic/clean/rainbow_config.h
@@ -10,6 +10,7 @@
 #define _V1 32
 #define _O1 32
 #define _O2 32
+#define _MAX_O 32
 #define _HASH_LEN 32
 
 
@@ -28,6 +29,7 @@
 #define _V2_BYTE (_V2 / 2)
 #define _O1_BYTE (_O1 / 2)
 #define _O2_BYTE (_O2 / 2)
+#define _MAX_O_BYTE (_MAX_O / 2)
 #define _PUB_N_BYTE (_PUB_N / 2)
 #define _PUB_M_BYTE (_PUB_M / 2)
 

--- a/crypto_sign/rainbowIa-cyclic-compressed/clean/rainbow.c
+++ b/crypto_sign/rainbowIa-cyclic-compressed/clean/rainbow.c
@@ -15,8 +15,6 @@
 #include <string.h>
 
 #define MAX_ATTEMPT_FRMAT 128
-#define _MAX_O ((_O1 > _O2) ? _O1 : _O2)
-#define _MAX_O_BYTE ((_O1_BYTE > _O2_BYTE) ? _O1_BYTE : _O2_BYTE)
 
 int PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_rainbow_sign(uint8_t *signature, const sk_t *sk, const uint8_t *_digest) {
     uint8_t mat_l1[_O1 * _O1_BYTE];

--- a/crypto_sign/rainbowIa-cyclic-compressed/clean/rainbow_config.h
+++ b/crypto_sign/rainbowIa-cyclic-compressed/clean/rainbow_config.h
@@ -10,6 +10,7 @@
 #define _V1 32
 #define _O1 32
 #define _O2 32
+#define _MAX_O 32
 #define _HASH_LEN 32
 
 
@@ -28,6 +29,7 @@
 #define _V2_BYTE (_V2 / 2)
 #define _O1_BYTE (_O1 / 2)
 #define _O2_BYTE (_O2 / 2)
+#define _MAX_O_BYTE (_MAX_O / 2)
 #define _PUB_N_BYTE (_PUB_N / 2)
 #define _PUB_M_BYTE (_PUB_M / 2)
 

--- a/crypto_sign/rainbowIa-cyclic/clean/rainbow.c
+++ b/crypto_sign/rainbowIa-cyclic/clean/rainbow.c
@@ -15,8 +15,6 @@
 #include <string.h>
 
 #define MAX_ATTEMPT_FRMAT 128
-#define _MAX_O ((_O1 > _O2) ? _O1 : _O2)
-#define _MAX_O_BYTE ((_O1_BYTE > _O2_BYTE) ? _O1_BYTE : _O2_BYTE)
 
 int PQCLEAN_RAINBOWIACYCLIC_CLEAN_rainbow_sign(uint8_t *signature, const sk_t *sk, const uint8_t *_digest) {
     uint8_t mat_l1[_O1 * _O1_BYTE];

--- a/crypto_sign/rainbowIa-cyclic/clean/rainbow_config.h
+++ b/crypto_sign/rainbowIa-cyclic/clean/rainbow_config.h
@@ -10,6 +10,7 @@
 #define _V1 32
 #define _O1 32
 #define _O2 32
+#define _MAX_O 32
 #define _HASH_LEN 32
 
 
@@ -28,6 +29,7 @@
 #define _V2_BYTE (_V2 / 2)
 #define _O1_BYTE (_O1 / 2)
 #define _O2_BYTE (_O2 / 2)
+#define _MAX_O_BYTE (_MAX_O / 2)
 #define _PUB_N_BYTE (_PUB_N / 2)
 #define _PUB_M_BYTE (_PUB_M / 2)
 

--- a/crypto_sign/rainbowVc-classic/clean/rainbow.c
+++ b/crypto_sign/rainbowVc-classic/clean/rainbow.c
@@ -15,8 +15,6 @@
 #include <string.h>
 
 #define MAX_ATTEMPT_FRMAT 128
-#define _MAX_O ((_O1 > _O2) ? _O1 : _O2)
-#define _MAX_O_BYTE ((_O1_BYTE > _O2_BYTE) ? _O1_BYTE : _O2_BYTE)
 
 int PQCLEAN_RAINBOWVCCLASSIC_CLEAN_rainbow_sign(uint8_t *signature, const sk_t *sk, const uint8_t *_digest) {
     uint8_t mat_l1[_O1 * _O1_BYTE];

--- a/crypto_sign/rainbowVc-classic/clean/rainbow_config.h
+++ b/crypto_sign/rainbowVc-classic/clean/rainbow_config.h
@@ -9,6 +9,7 @@
 #define _V1 92
 #define _O1 48
 #define _O2 48
+#define _MAX_O 48
 #define _HASH_LEN 64
 
 
@@ -27,6 +28,7 @@
 #define _V2_BYTE (_V2)
 #define _O1_BYTE (_O1)
 #define _O2_BYTE (_O2)
+#define _MAX_O_BYTE (_MAX_O)
 #define _PUB_N_BYTE (_PUB_N)
 #define _PUB_M_BYTE (_PUB_M)
 

--- a/crypto_sign/rainbowVc-cyclic-compressed/clean/rainbow.c
+++ b/crypto_sign/rainbowVc-cyclic-compressed/clean/rainbow.c
@@ -15,8 +15,6 @@
 #include <string.h>
 
 #define MAX_ATTEMPT_FRMAT 128
-#define _MAX_O ((_O1 > _O2) ? _O1 : _O2)
-#define _MAX_O_BYTE ((_O1_BYTE > _O2_BYTE) ? _O1_BYTE : _O2_BYTE)
 
 int PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_rainbow_sign(uint8_t *signature, const sk_t *sk, const uint8_t *_digest) {
     uint8_t mat_l1[_O1 * _O1_BYTE];

--- a/crypto_sign/rainbowVc-cyclic-compressed/clean/rainbow_config.h
+++ b/crypto_sign/rainbowVc-cyclic-compressed/clean/rainbow_config.h
@@ -9,6 +9,7 @@
 #define _V1 92
 #define _O1 48
 #define _O2 48
+#define _MAX_O 48
 #define _HASH_LEN 64
 
 
@@ -27,6 +28,7 @@
 #define _V2_BYTE (_V2)
 #define _O1_BYTE (_O1)
 #define _O2_BYTE (_O2)
+#define _MAX_O_BYTE (_MAX_O)
 #define _PUB_N_BYTE (_PUB_N)
 #define _PUB_M_BYTE (_PUB_M)
 

--- a/crypto_sign/rainbowVc-cyclic/clean/rainbow.c
+++ b/crypto_sign/rainbowVc-cyclic/clean/rainbow.c
@@ -15,8 +15,6 @@
 #include <string.h>
 
 #define MAX_ATTEMPT_FRMAT 128
-#define _MAX_O ((_O1 > _O2) ? _O1 : _O2)
-#define _MAX_O_BYTE ((_O1_BYTE > _O2_BYTE) ? _O1_BYTE : _O2_BYTE)
 
 int PQCLEAN_RAINBOWVCCYCLIC_CLEAN_rainbow_sign(uint8_t *signature, const sk_t *sk, const uint8_t *_digest) {
     uint8_t mat_l1[_O1 * _O1_BYTE];

--- a/crypto_sign/rainbowVc-cyclic/clean/rainbow_config.h
+++ b/crypto_sign/rainbowVc-cyclic/clean/rainbow_config.h
@@ -9,6 +9,7 @@
 #define _V1 92
 #define _O1 48
 #define _O2 48
+#define _MAX_O 48
 #define _HASH_LEN 64
 
 
@@ -27,6 +28,7 @@
 #define _V2_BYTE (_V2)
 #define _O1_BYTE (_O1)
 #define _O2_BYTE (_O2)
+#define _MAX_O_BYTE (_MAX_O)
 #define _PUB_N_BYTE (_PUB_N)
 #define _PUB_M_BYTE (_PUB_M)
 


### PR DESCRIPTION
Clang 9.0.0 [1] and clang-tidy 9.0.0 [2] landed on my system recently and introduced a few warnings:

- [3] `security.insecureAPI.DeprecatedOrUnsafeBufferHandling` disallows the use of `memset` and `memcpy`. We use them a lot and I think in a "safe" way. I've disabled this warning. 
- [4] `bugprone-branch-clone` disallows having two equal branches in an if. We had that in Kyber and Rainbow - removed them as I think it's not necessary there. 
 
[1] https://releases.llvm.org/9.0.0/tools/clang/docs/ReleaseNotes.html
[2] https://releases.llvm.org/9.0.0/tools/clang/tools/extra/docs/ReleaseNotes.html
[3] https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-deprecatedorunsafebufferhandling-c 
[4] https://clang.llvm.org/extra/clang-tidy/checks/bugprone-branch-clone.html