### PR TITLE
Fix kyber-90s warning if size_t is not 32 bits

### DIFF
--- a/crypto_kem/kyber1024-90s/avx2/aes256ctr.c
+++ b/crypto_kem/kyber1024-90s/avx2/aes256ctr.c
@@ -174,3 +174,4 @@ void PQCLEAN_KYBER102490S_AVX2_aes256ctr_prf(uint8_t *out,
         }
     }
 }
+

--- a/crypto_kem/kyber1024-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber1024-90s/clean/aes256ctr.c
@@ -91,5 +91,5 @@ void PQCLEAN_KYBER102490S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t
 **************************************************/
 void PQCLEAN_KYBER102490S_CLEAN_aes256xof_squeezeblocks(uint8_t *out, size_t nblocks, aes256xof_ctx *s) {
     aes256_ctr_xof(out, nblocks * 64, s->iv, s->ctr, &s->sk_exp);
-    s->ctr += 4 * nblocks;
+    s->ctr += (uint32_t) (4 * nblocks);
 }

--- a/crypto_kem/kyber512-90s/avx2/aes256ctr.c
+++ b/crypto_kem/kyber512-90s/avx2/aes256ctr.c
@@ -174,3 +174,4 @@ void PQCLEAN_KYBER51290S_AVX2_aes256ctr_prf(uint8_t *out,
         }
     }
 }
+

--- a/crypto_kem/kyber512-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber512-90s/clean/aes256ctr.c
@@ -91,5 +91,5 @@ void PQCLEAN_KYBER51290S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t 
 **************************************************/
 void PQCLEAN_KYBER51290S_CLEAN_aes256xof_squeezeblocks(uint8_t *out, size_t nblocks, aes256xof_ctx *s) {
     aes256_ctr_xof(out, nblocks * 64, s->iv, s->ctr, &s->sk_exp);
-    s->ctr += 4 * nblocks;
+    s->ctr += (uint32_t) (4 * nblocks);
 }

--- a/crypto_kem/kyber768-90s/avx2/aes256ctr.c
+++ b/crypto_kem/kyber768-90s/avx2/aes256ctr.c
@@ -174,3 +174,4 @@ void PQCLEAN_KYBER76890S_AVX2_aes256ctr_prf(uint8_t *out,
         }
     }
 }
+

--- a/crypto_kem/kyber768-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber768-90s/clean/aes256ctr.c
@@ -91,5 +91,5 @@ void PQCLEAN_KYBER76890S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t 
 **************************************************/
 void PQCLEAN_KYBER76890S_CLEAN_aes256xof_squeezeblocks(uint8_t *out, size_t nblocks, aes256xof_ctx *s) {
     aes256_ctr_xof(out, nblocks * 64, s->iv, s->ctr, &s->sk_exp);
-    s->ctr += 4 * nblocks;
+    s->ctr += (uint32_t) (4 * nblocks);
 }


### PR DESCRIPTION
This should fix the kyber-90s warning that's blocking #239 