### PR TITLE
Enable optimizers on Windows

### DIFF
--- a/crypto_kem/firesaber/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/firesaber/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfiresaber_clean.lib
 OBJECTS=cbd.obj kem.obj pack_unpack.obj poly.obj poly_mul.obj SABER_indcpa.obj verify.obj 
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem1344aes/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem1344aes/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem1344aes_clean.lib
 OBJECTS=kem.obj matrix_aes.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem1344aes/opt/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem1344aes/opt/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem1344aes_opt.lib
 OBJECTS=kem.obj matrix_aes.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem1344shake/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem1344shake/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem1344shake_clean.lib
 OBJECTS=kem.obj matrix_shake.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem1344shake/opt/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem1344shake/opt/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem1344shake_opt.lib
 OBJECTS=kem.obj matrix_shake.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem640aes/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem640aes/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem640aes_clean.lib
 OBJECTS=kem.obj matrix_aes.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem640aes/opt/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem640aes/opt/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem640aes_opt.lib
 OBJECTS=kem.obj matrix_aes.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem640shake/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem640shake/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem640shake_clean.lib
 OBJECTS=kem.obj matrix_shake.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem640shake/opt/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem640shake/opt/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem640shake_opt.lib
 OBJECTS=kem.obj matrix_shake.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem976aes/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem976aes/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem976aes_clean.lib
 OBJECTS=kem.obj matrix_aes.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem976aes/opt/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem976aes/opt/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem976aes_opt.lib
 OBJECTS=kem.obj matrix_aes.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem976shake/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem976shake/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem976shake_clean.lib
 OBJECTS=kem.obj matrix_shake.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/frodokem976shake/opt/Makefile.Microsoft_nmake
+++ b/crypto_kem/frodokem976shake/opt/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libfrodokem976shake_opt.lib
 OBJECTS=kem.obj matrix_shake.obj noise.obj util.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/kyber1024-90s/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/kyber1024-90s/clean/Makefile.Microsoft_nmake
@@ -8,7 +8,7 @@ OBJECTS=cbd.obj indcpa.obj kem.obj ntt.obj poly.obj polyvec.obj reduce.obj verif
 # unsigned type; this has nonetheless been standard and portable for as
 # long as there has been a C standard, and we need it for constant-time
 # computations. Thus, we disable that spurious warning.
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX /wd4146
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX /wd4146
 
 all: $(LIBRARY)
 

--- a/crypto_kem/kyber1024/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/kyber1024/clean/Makefile.Microsoft_nmake
@@ -8,7 +8,7 @@ OBJECTS=cbd.obj indcpa.obj kem.obj ntt.obj poly.obj polyvec.obj reduce.obj verif
 # unsigned type; this has nonetheless been standard and portable for as
 # long as there has been a C standard, and we need it for constant-time
 # computations. Thus, we disable that spurious warning.
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX /wd4146
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX /wd4146
 
 all: $(LIBRARY)
 

--- a/crypto_kem/kyber512-90s/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/kyber512-90s/clean/Makefile.Microsoft_nmake
@@ -8,7 +8,7 @@ OBJECTS=cbd.obj indcpa.obj kem.obj ntt.obj poly.obj polyvec.obj reduce.obj verif
 # unsigned type; this has nonetheless been standard and portable for as
 # long as there has been a C standard, and we need it for constant-time
 # computations. Thus, we disable that spurious warning.
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX /wd4146
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX /wd4146
 
 all: $(LIBRARY)
 

--- a/crypto_kem/kyber512/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/kyber512/clean/Makefile.Microsoft_nmake
@@ -8,7 +8,7 @@ OBJECTS=cbd.obj indcpa.obj kem.obj ntt.obj poly.obj polyvec.obj reduce.obj verif
 # unsigned type; this has nonetheless been standard and portable for as
 # long as there has been a C standard, and we need it for constant-time
 # computations. Thus, we disable that spurious warning.
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX /wd4146
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX /wd4146
 
 all: $(LIBRARY)
 

--- a/crypto_kem/kyber768-90s/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/kyber768-90s/clean/Makefile.Microsoft_nmake
@@ -8,7 +8,7 @@ OBJECTS=cbd.obj indcpa.obj kem.obj ntt.obj poly.obj polyvec.obj reduce.obj verif
 # unsigned type; this has nonetheless been standard and portable for as
 # long as there has been a C standard, and we need it for constant-time
 # computations. Thus, we disable that spurious warning.
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX /wd4146
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX /wd4146
 
 all: $(LIBRARY)
 

--- a/crypto_kem/kyber768/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/kyber768/clean/Makefile.Microsoft_nmake
@@ -8,7 +8,7 @@ OBJECTS=cbd.obj indcpa.obj kem.obj ntt.obj poly.obj polyvec.obj reduce.obj verif
 # unsigned type; this has nonetheless been standard and portable for as
 # long as there has been a C standard, and we need it for constant-time
 # computations. Thus, we disable that spurious warning.
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX /wd4146
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX /wd4146
 
 all: $(LIBRARY)
 

--- a/crypto_kem/ledakemlt12/leaktime/Makefile.Microsoft_nmake
+++ b/crypto_kem/ledakemlt12/leaktime/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libledakemlt12_leaktime.lib
 OBJECTS=bf_decoding.obj dfr_test.obj gf2x_arith_mod_xPplusOne.obj gf2x_arith.obj H_Q_matrices_generation.obj kem.obj niederreiter.obj rng.obj sort.obj utils.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/ledakemlt32/leaktime/Makefile.Microsoft_nmake
+++ b/crypto_kem/ledakemlt32/leaktime/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libledakemlt32_leaktime.lib
 OBJECTS=bf_decoding.obj dfr_test.obj gf2x_arith_mod_xPplusOne.obj gf2x_arith.obj H_Q_matrices_generation.obj kem.obj niederreiter.obj rng.obj sort.obj utils.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/ledakemlt52/leaktime/Makefile.Microsoft_nmake
+++ b/crypto_kem/ledakemlt52/leaktime/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libledakemlt52_leaktime.lib
 OBJECTS=bf_decoding.obj dfr_test.obj gf2x_arith_mod_xPplusOne.obj gf2x_arith.obj H_Q_matrices_generation.obj kem.obj niederreiter.obj rng.obj sort.obj utils.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/lightsaber/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/lightsaber/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=liblightsaber_clean.lib
 OBJECTS=cbd.obj kem.obj pack_unpack.obj poly.obj poly_mul.obj SABER_indcpa.obj verify.obj 
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/newhope1024cca/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/newhope1024cca/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libnewhope1024cca_clean.lib
 OBJECTS=cpapke.obj kem.obj ntt.obj poly.obj precomp.obj reduce.obj verify.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/newhope1024cpa/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/newhope1024cpa/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libnewhope1024cpa_clean.lib
 OBJECTS=cpapke.obj kem.obj ntt.obj poly.obj precomp.obj reduce.obj verify.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/newhope512cca/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/newhope512cca/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libnewhope512cca_clean.lib
 OBJECTS=cpapke.obj kem.obj ntt.obj poly.obj precomp.obj reduce.obj verify.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/newhope512cpa/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/newhope512cpa/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libnewhope512cpa_clean.lib
 OBJECTS=cpapke.obj kem.obj ntt.obj poly.obj precomp.obj reduce.obj verify.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/ntruhps2048509/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/ntruhps2048509/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libntruhps2048509_clean.lib
 OBJECTS=crypto_sort.obj kem.obj owcpa.obj pack3.obj packq.obj poly.obj sample.obj verify.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/ntruhps2048677/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/ntruhps2048677/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libntruhps2048677_clean.lib
 OBJECTS=crypto_sort.obj kem.obj owcpa.obj pack3.obj packq.obj poly.obj sample.obj verify.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/ntruhps4096821/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/ntruhps4096821/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libntruhps4096821_clean.lib
 OBJECTS=crypto_sort.obj kem.obj owcpa.obj pack3.obj packq.obj poly.obj sample.obj verify.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/ntruhrss701/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/ntruhrss701/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libntruhrss701_clean.lib
 OBJECTS=kem.obj owcpa.obj pack3.obj packq.obj poly.obj sample.obj verify.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_kem/saber/clean/Makefile.Microsoft_nmake
+++ b/crypto_kem/saber/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsaber_clean.lib
 OBJECTS=cbd.obj kem.obj pack_unpack.obj poly.obj poly_mul.obj SABER_indcpa.obj verify.obj 
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/dilithium2/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/dilithium2/clean/Makefile.Microsoft_nmake
@@ -3,7 +3,7 @@
 
 LIBRARY=libdilithium2_clean.lib
 OBJECTS=sign.obj polyvec.obj poly.obj packing.obj ntt.obj reduce.obj rounding.obj symmetric.obj
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/dilithium3/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/dilithium3/clean/Makefile.Microsoft_nmake
@@ -3,7 +3,7 @@
 
 LIBRARY=libdilithium3_clean.lib
 OBJECTS=sign.obj polyvec.obj poly.obj packing.obj ntt.obj reduce.obj rounding.obj symmetric.obj
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/dilithium4/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/dilithium4/clean/Makefile.Microsoft_nmake
@@ -3,7 +3,7 @@
 
 LIBRARY=libdilithium4_clean.lib
 OBJECTS=sign.obj polyvec.obj poly.obj packing.obj ntt.obj reduce.obj rounding.obj symmetric.obj
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/falcon-1024/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/falcon-1024/clean/Makefile.Microsoft_nmake
@@ -8,7 +8,7 @@ OBJECTS=codec.obj common.obj fft.obj fpr.obj keygen.obj pqclean.obj rng.obj sign
 # unsigned type; this has nonetheless been standard and portable for as
 # long as there has been a C standard, and we do that a lot, especially
 # for constant-time computations. Thus, we disable that spurious warning.
-CFLAGS=/nologo /I ..\..\..\common /W4 /wd4146 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /wd4146 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/falcon-512/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/falcon-512/clean/Makefile.Microsoft_nmake
@@ -8,7 +8,7 @@ OBJECTS=codec.obj common.obj fft.obj fpr.obj keygen.obj pqclean.obj rng.obj sign
 # unsigned type; this has nonetheless been standard and portable for as
 # long as there has been a C standard, and we do that a lot, especially
 # for constant-time computations. Thus, we disable that spurious warning.
-CFLAGS=/nologo /I ..\..\..\common /W4 /wd4146 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /wd4146 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/mqdss-48/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/mqdss-48/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libmqdss-48_clean.lib
 OBJECTS=gf31.obj mq.obj sign.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/mqdss-64/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/mqdss-64/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libmqdss-64_clean.lib
 OBJECTS=gf31.obj mq.obj sign.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/rainbowIIIc-classic/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/rainbowIIIc-classic/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=librainbowIIIc-classic_clean.lib
 OBJECTS =  blas_comm.obj parallel_matrix_op.obj rainbow.obj rainbow_keypair.obj rainbow_keypair_computation.obj sign.obj utils_hash.obj utils_prng.obj blas.obj gf.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/rainbowIIIc-cyclic-compressed/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/rainbowIIIc-cyclic-compressed/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=librainbowIIIc-cyclic-compressed_clean.lib
 OBJECTS =  blas_comm.obj parallel_matrix_op.obj rainbow.obj rainbow_keypair.obj rainbow_keypair_computation.obj sign.obj utils_hash.obj utils_prng.obj blas.obj gf.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/rainbowIIIc-cyclic/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/rainbowIIIc-cyclic/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=librainbowIIIc-cyclic_clean.lib
 OBJECTS =  blas_comm.obj parallel_matrix_op.obj rainbow.obj rainbow_keypair.obj rainbow_keypair_computation.obj sign.obj utils_hash.obj utils_prng.obj blas.obj gf.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/rainbowIa-classic/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/rainbowIa-classic/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=librainbowIa-classic_clean.lib
 OBJECTS =  blas_comm.obj parallel_matrix_op.obj rainbow.obj rainbow_keypair.obj rainbow_keypair_computation.obj sign.obj utils_hash.obj utils_prng.obj blas.obj gf.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/rainbowIa-cyclic-compressed/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/rainbowIa-cyclic-compressed/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=librainbowIa-cyclic-compressed_clean.lib
 OBJECTS =  blas_comm.obj parallel_matrix_op.obj rainbow.obj rainbow_keypair.obj rainbow_keypair_computation.obj sign.obj utils_hash.obj utils_prng.obj blas.obj gf.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/rainbowIa-cyclic/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/rainbowIa-cyclic/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=librainbowIa-cyclic_clean.lib
 OBJECTS =  blas_comm.obj parallel_matrix_op.obj rainbow.obj rainbow_keypair.obj rainbow_keypair_computation.obj sign.obj utils_hash.obj utils_prng.obj blas.obj gf.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/rainbowVc-classic/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/rainbowVc-classic/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=librainbowVc-classic_clean.lib
 OBJECTS =  blas_comm.obj parallel_matrix_op.obj rainbow.obj rainbow_keypair.obj rainbow_keypair_computation.obj sign.obj utils_hash.obj utils_prng.obj blas.obj gf.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/rainbowVc-cyclic-compressed/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/rainbowVc-cyclic-compressed/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=librainbowVc-cyclic-compressed_clean.lib
 OBJECTS =  blas_comm.obj parallel_matrix_op.obj rainbow.obj rainbow_keypair.obj rainbow_keypair_computation.obj sign.obj utils_hash.obj utils_prng.obj blas.obj gf.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/rainbowVc-cyclic/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/rainbowVc-cyclic/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=librainbowVc-cyclic_clean.lib
 OBJECTS =  blas_comm.obj parallel_matrix_op.obj rainbow.obj rainbow_keypair.obj rainbow_keypair_computation.obj sign.obj utils_hash.obj utils_prng.obj blas.obj gf.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-128f-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-128f-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-128f-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-128f-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-128f-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-128f-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-128s-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-128s-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-128s-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-128s-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-128s-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-128s-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-192f-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-192f-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-192f-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-192f-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-192f-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-192f-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-192s-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-192s-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-192s-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-192s-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-192s-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-192s-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-256f-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-256f-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-256f-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-256f-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-256f-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-256f-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-256s-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-256s-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-256s-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-haraka-256s-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-256s-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-haraka-256s-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj haraka.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-128f-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128f-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-128f-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-128f-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128f-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-128f-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-128s-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128s-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-128s-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-128s-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128s-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-128s-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-192f-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192f-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-192f-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-192f-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192f-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-192f-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-192s-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192s-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-192s-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-192s-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192s-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-192s-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-256f-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256f-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-256f-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-256f-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256f-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-256f-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-256s-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256s-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-256s-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-sha256-256s-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256s-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-sha256-256s-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj sha256.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-128f-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128f-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-128f-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-128f-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128f-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-128f-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-128s-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128s-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-128s-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-128s-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128s-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-128s-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-192f-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192f-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-192f-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-192f-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192f-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-192f-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-192s-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192s-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-192s-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-192s-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192s-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-192s-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-256f-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256f-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-256f-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-256f-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256f-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-256f-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-256s-robust/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256s-robust/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-256s-robust_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/crypto_sign/sphincs-shake256-256s-simple/clean/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256s-simple/clean/Makefile.Microsoft_nmake
@@ -4,7 +4,7 @@
 LIBRARY=libsphincs-shake256-256s-simple_clean.lib
 OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj
 
-CFLAGS=/nologo /I ..\..\..\common /W4 /WX
+CFLAGS=/nologo /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
 

--- a/test/Makefile.Microsoft_nmake
+++ b/test/Makefile.Microsoft_nmake
@@ -18,7 +18,7 @@ COMMON_OBJECTS_NOPATH=aes.obj fips202.obj sha2.obj sp800-185.obj
 
 DEST_DIR=..\bin
 
-CFLAGS=/nologo /I $(COMMON_DIR) /W4 /WX
+CFLAGS=/nologo /O2 /I $(COMMON_DIR) /W4 /WX
 
 all: $(DEST_DIR)\functest_$(SCHEME)_$(IMPLEMENTATION).EXE $(DEST_DIR)\testvectors_$(SCHEME)_$(IMPLEMENTATION).EXE
 


### PR DESCRIPTION
Enable `/O2` on Windows, which hopefully reduces the runtime of the tests.