### PR TITLE
Free SPHINCS+ hash state after use

### DIFF
--- a/common/sha2.c
+++ b/common/sha2.c
@@ -571,6 +571,22 @@ void sha384_inc_blocks(sha384ctx *state, const uint8_t *in, size_t inblocks) {
     sha512_inc_blocks((sha512ctx*) state, in, inblocks);
 }
 
+void sha224_inc_destroy(sha224ctx *state) {
+    (void)state;
+}
+
+void sha256_inc_destroy(sha256ctx *state) {
+    (void)state;
+}
+
+void sha384_inc_destroy(sha384ctx *state) {
+    (void)state;
+}
+
+void sha512_inc_destroy(sha512ctx *state) {
+    (void)state;
+}
+
 void sha256_inc_finalize(uint8_t *out, sha256ctx *state, const uint8_t *in, size_t inlen) {
     uint8_t padded[128];
     uint64_t bytes = load_bigendian_64(state->ctx + 32) + inlen;

--- a/common/sha2.h
+++ b/common/sha2.h
@@ -28,24 +28,28 @@ void sha224_inc_init(sha224ctx *state);
 void sha224_inc_clone_state(sha224ctx *stateout, const sha224ctx *statein);
 void sha224_inc_blocks(sha224ctx *state, const uint8_t *in, size_t inblocks);
 void sha224_inc_finalize(uint8_t *out, sha224ctx *state, const uint8_t *in, size_t inlen);
+void sha224_inc_destroy(sha224ctx *state);
 void sha224(uint8_t *out, const uint8_t *in, size_t inlen);
 
 void sha256_inc_init(sha256ctx *state);
 void sha256_inc_clone_state(sha256ctx *stateout, const sha256ctx *statein);
 void sha256_inc_blocks(sha256ctx *state, const uint8_t *in, size_t inblocks);
 void sha256_inc_finalize(uint8_t *out, sha256ctx *state, const uint8_t *in, size_t inlen);
+void sha256_inc_destroy(sha256ctx *state);
 void sha256(uint8_t *out, const uint8_t *in, size_t inlen);
 
 void sha384_inc_init(sha384ctx *state);
 void sha384_inc_clone_state(sha384ctx *stateout, const sha384ctx *statein);
 void sha384_inc_blocks(sha384ctx *state, const uint8_t *in, size_t inblocks);
 void sha384_inc_finalize(uint8_t *out, sha384ctx *state, const uint8_t *in, size_t inlen);
+void sha384_inc_destroy(sha384ctx *state);
 void sha384(uint8_t *out, const uint8_t *in, size_t inlen);
 
 void sha512_inc_init(sha512ctx *state);
 void sha512_inc_clone_state(sha512ctx *stateout, const sha512ctx *statein);
 void sha512_inc_blocks(sha512ctx *state, const uint8_t *in, size_t inblocks);
 void sha512_inc_finalize(uint8_t *out, sha512ctx *state, const uint8_t *in, size_t inlen);
+void sha512_inc_destroy(sha512ctx *state);
 void sha512(uint8_t *out, const uint8_t *in, size_t inlen);
 
 #endif

--- a/crypto_sign/sphincs-haraka-128f-robust/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-128f-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-128f-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-128f-robust/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-128f-robust/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-128f-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA128FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-128f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-128f-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-128f-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-128f-simple/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-128f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-128f-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA128FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-128s-robust/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-128s-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-128s-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-128s-robust/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-128s-robust/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-128s-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA128SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-128s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-128s-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-128s-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-128s-simple/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-128s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-128s-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA128SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-192f-robust/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-192f-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-192f-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-192f-robust/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-192f-robust/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-192f-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA192FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-192f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-192f-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-192f-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-192f-simple/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-192f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-192f-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA192FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-192s-robust/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-192s-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-192s-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-192s-robust/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-192s-robust/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-192s-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA192SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-192s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-192s-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-192s-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-192s-simple/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-192s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-192s-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA192SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-256f-robust/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-256f-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-256f-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-256f-robust/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-256f-robust/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-256f-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA256FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-256f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-256f-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-256f-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-256f-simple/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-256f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-256f-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA256FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-256s-robust/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-256s-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-256s-robust/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-256s-robust/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-256s-robust/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-256s-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA256SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-haraka-256s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-haraka-256s-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-haraka-256s-simple/clean/hash_haraka.c
+++ b/crypto_sign/sphincs-haraka-256s-simple/clean/hash_haraka.c
@@ -14,6 +14,11 @@ void PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_initialize_hash_function(
     PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_tweak_constants(hash_state_seeded, pub_seed, sk_seed, SPX_N);
 }
 
+void PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-haraka-256s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-haraka-256s-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSHARAKA256SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-128f-robust/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-128f-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-128f-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-128f-robust/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-128f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/clean/thash_sha256_robust.c
@@ -33,7 +33,7 @@ static void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_thash(
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];
     }
-
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf + SPX_N,
                         SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);

--- a/crypto_sign/sphincs-sha256-128f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-128f-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-128f-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-128f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-128f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/clean/thash_sha256_simple.c
@@ -28,6 +28,7 @@ static void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha256-128s-robust/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-128s-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-128s-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-128s-robust/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-128s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/clean/thash_sha256_robust.c
@@ -33,7 +33,7 @@ static void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_thash(
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];
     }
-
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf + SPX_N,
                         SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);

--- a/crypto_sign/sphincs-sha256-128s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-128s-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-128s-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-128s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-128s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/clean/thash_sha256_simple.c
@@ -28,6 +28,7 @@ static void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha256-192f-robust/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-192f-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-192f-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-192f-robust/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-192f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/clean/thash_sha256_robust.c
@@ -33,7 +33,7 @@ static void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_thash(
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];
     }
-
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf + SPX_N,
                         SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);

--- a/crypto_sign/sphincs-sha256-192f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-192f-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-192f-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-192f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-192f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/clean/thash_sha256_simple.c
@@ -28,6 +28,7 @@ static void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha256-192s-robust/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-192s-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-192s-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-192s-robust/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-192s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/clean/thash_sha256_robust.c
@@ -33,7 +33,7 @@ static void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_thash(
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];
     }
-
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf + SPX_N,
                         SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);

--- a/crypto_sign/sphincs-sha256-192s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-192s-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-192s-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-192s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-192s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/clean/thash_sha256_simple.c
@@ -28,6 +28,7 @@ static void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha256-256f-robust/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-256f-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-256f-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-256f-robust/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-256f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/clean/thash_sha256_robust.c
@@ -33,7 +33,7 @@ static void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_thash(
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];
     }
-
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf + SPX_N,
                         SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);

--- a/crypto_sign/sphincs-sha256-256f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-256f-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-256f-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-256f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-256f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/clean/thash_sha256_simple.c
@@ -28,6 +28,7 @@ static void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha256-256s-robust/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-256s-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-256s-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-256s-robust/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-256s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/clean/thash_sha256_robust.c
@@ -33,7 +33,7 @@ static void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_thash(
     for (i = 0; i < inblocks * SPX_N; i++) {
         buf[SPX_N + SPX_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];
     }
-
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf + SPX_N,
                         SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);

--- a/crypto_sign/sphincs-sha256-256s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha256-256s-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-sha256-256s-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/clean/hash_sha256.c
@@ -9,13 +9,24 @@
 #include "sha2.h"
 #include "sha256.h"
 
-/* For SHA256, there is no immediate reason to initialize at the start,
-   so this function is an empty operation. */
+/**
+ * Initialize hash_state_seeded by precomputing the SHA-256 state
+ * after absorbing the given public seed pub_seed.
+ */
 void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed) {
     PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_seed_state(hash_state_seeded, pub_seed);
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
+}
+
+/**
+ * Destroy the hash state instance created in the initialization
+ * function.
+ */
+void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) {
+    sha256_inc_destroy(state);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-256s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-sha256-256s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/clean/thash_sha256_simple.c
@@ -28,6 +28,7 @@ static void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
+    /* Note: finalize is expected to destroy the hash context */
     sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-shake256-128f-robust/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-128f-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-128f-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128f-robust/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-128f-robust/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-128f-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-128f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-128f-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-128f-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128f-simple/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-128f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-128f-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-128s-robust/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-128s-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-128s-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128s-robust/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-128s-robust/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-128s-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-128s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-128s-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-128s-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128s-simple/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-128s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-128s-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-192f-robust/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-192f-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-192f-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192f-robust/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-192f-robust/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-192f-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-192f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-192f-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-192f-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192f-simple/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-192f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-192f-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-192s-robust/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-192s-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-192s-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192s-robust/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-192s-robust/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-192s-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-192s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-192s-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-192s-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192s-simple/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-192s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-192s-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-256f-robust/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-256f-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-256f-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256f-robust/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-256f-robust/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-256f-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-256f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-256f-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-256f-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256f-simple/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-256f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-256f-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-256s-robust/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-256s-robust/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-256s-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256s-robust/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-256s-robust/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-256s-robust/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {

--- a/crypto_sign/sphincs-shake256-256s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake256-256s-simple/clean/hash.h
@@ -10,6 +10,9 @@ void PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_initialize_hash_function(
     hash_state *hash_state_seeded,
     const unsigned char *pub_seed, const unsigned char *sk_seed);
 
+void PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state);
+
 void PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_prf_addr(
     unsigned char *out, const unsigned char *key, const uint32_t addr[8],
     const hash_state *hash_state_seeded);

--- a/crypto_sign/sphincs-shake256-256s-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256s-simple/clean/hash_shake256.c
@@ -18,6 +18,12 @@ void PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_initialize_hash_function(
     (void)sk_seed; /* Suppress an 'unused parameter' warning. */
 }
 
+/** No initialization done at the start - nothing to clean up here. */
+void PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_destroy_hash_function(
+    hash_state *state) { // NOLINT(readability-non-const-parameter)
+    (void)state; /* Suppress an 'unused parameter' warning. */
+}
+
 /*
  * Computes PRF(key, addr), given a secret key of SPX_N bytes and an address
  */

--- a/crypto_sign/sphincs-shake256-256s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake256-256s-simple/clean/sign.c
@@ -104,6 +104,8 @@ int PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_seed_keypair(
         sk + 3 * SPX_N, auth_path, sk, sk + 2 * SPX_N, 0, 0,
         wots_gen_leaf, top_tree_addr, &hash_state_seeded);
 
+    PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
 
     return 0;
@@ -204,6 +206,8 @@ int PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_signature(
         tree = tree >> SPX_TREE_HEIGHT;
     }
 
+    PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
+
     *siglen = SPX_BYTES;
 
     return 0;
@@ -296,6 +300,8 @@ int PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_crypto_sign_verify(
         idx_leaf = (tree & ((1 << SPX_TREE_HEIGHT) - 1));
         tree = tree >> SPX_TREE_HEIGHT;
     }
+
+    PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_destroy_hash_function(&hash_state_seeded);
 
     /* Check if the root node equals the root node in the public key. */
     if (memcmp(root, pub_root, SPX_N) != 0) {


### PR DESCRIPTION
<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->

<!-- If you are not submitting a new scheme, we suggest removing the following lines -->
#### Manually checked properties
<!-- These checkboxes serve for the maintainers of PQClean to verify your submission. Please do not check them yourself. -->

* [ ] No stringification macros
* [ ] Output-parameter pointers in functions are on the left
* [ ] Negative return values on failure of API functions (within restrictions of FO transform).
* [ ] `const` arguments are labeled as `const`
* [ ] variable declarations at the beginning (except in `for (size_t i=...`)
* Optional:
  * [ ] All integer types are of fixed size, using `stdint.h` types (including `uint8_t` instead of `unsigned char`)
  * [ ] Integers used for indexing are of size `size_t`
