### PR TITLE
Rainbow: memcpy -> memmove since buffers may overlap

### DIFF
--- a/crypto_sign/rainbowIIIc-classic/clean/sign.c
+++ b/crypto_sign/rainbowIIIc-classic/clean/sign.c
@@ -44,7 +44,7 @@ int PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_crypto_sign_open(unsigned char *m, size_t *
         rc = PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_rainbow_verify(digest, sm + mlen[0], (const pk_t *)pk);
     }
     if (!rc) {
-        memcpy(m, sm, smlen - _SIGNATURE_BYTE);
+        memmove(m, sm, smlen - _SIGNATURE_BYTE);
     } else { // bad signature
         *mlen = (size_t) -1;
         memset(m, 0, smlen);

--- a/crypto_sign/rainbowIIIc-cyclic-compressed/clean/sign.c
+++ b/crypto_sign/rainbowIIIc-cyclic-compressed/clean/sign.c
@@ -46,7 +46,7 @@ int PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_crypto_sign_open(unsigned char *m,
         rc = PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_rainbow_verify_cyclic(digest, sm + mlen[0], (const cpk_t *)pk);
     }
     if (!rc) {
-        memcpy(m, sm, smlen - _SIGNATURE_BYTE);
+        memmove(m, sm, smlen - _SIGNATURE_BYTE);
     } else { // bad signature
         *mlen = (size_t) -1;
         memset(m, 0, smlen);

--- a/crypto_sign/rainbowIIIc-cyclic/clean/sign.c
+++ b/crypto_sign/rainbowIIIc-cyclic/clean/sign.c
@@ -46,7 +46,7 @@ int PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_crypto_sign_open(unsigned char *m, size_t *m
         rc = PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_rainbow_verify_cyclic(digest, sm + mlen[0], (const cpk_t *)pk);
     }
     if (!rc) {
-        memcpy(m, sm, smlen - _SIGNATURE_BYTE);
+        memmove(m, sm, smlen - _SIGNATURE_BYTE);
     } else { // bad signature
         *mlen = (size_t) -1;
         memset(m, 0, smlen);

--- a/crypto_sign/rainbowIa-classic/clean/sign.c
+++ b/crypto_sign/rainbowIa-classic/clean/sign.c
@@ -44,7 +44,7 @@ int PQCLEAN_RAINBOWIACLASSIC_CLEAN_crypto_sign_open(unsigned char *m, size_t *ml
         rc = PQCLEAN_RAINBOWIACLASSIC_CLEAN_rainbow_verify(digest, sm + mlen[0], (const pk_t *)pk);
     }
     if (!rc) {
-        memcpy(m, sm, smlen - _SIGNATURE_BYTE);
+        memmove(m, sm, smlen - _SIGNATURE_BYTE);
     } else { // bad signature
         *mlen = (size_t) -1;
         memset(m, 0, smlen);

--- a/crypto_sign/rainbowIa-cyclic-compressed/clean/sign.c
+++ b/crypto_sign/rainbowIa-cyclic-compressed/clean/sign.c
@@ -46,7 +46,7 @@ int PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_crypto_sign_open(unsigned char *m, s
         rc = PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_rainbow_verify_cyclic(digest, sm + mlen[0], (const cpk_t *)pk);
     }
     if (!rc) {
-        memcpy(m, sm, smlen - _SIGNATURE_BYTE);
+        memmove(m, sm, smlen - _SIGNATURE_BYTE);
     } else { // bad signature
         *mlen = (size_t) -1;
         memset(m, 0, smlen);

--- a/crypto_sign/rainbowIa-cyclic/clean/sign.c
+++ b/crypto_sign/rainbowIa-cyclic/clean/sign.c
@@ -46,7 +46,7 @@ int PQCLEAN_RAINBOWIACYCLIC_CLEAN_crypto_sign_open(unsigned char *m, size_t *mle
         rc = PQCLEAN_RAINBOWIACYCLIC_CLEAN_rainbow_verify_cyclic(digest, sm + mlen[0], (const cpk_t *)pk);
     }
     if (!rc) {
-        memcpy(m, sm, smlen - _SIGNATURE_BYTE);
+        memmove(m, sm, smlen - _SIGNATURE_BYTE);
     } else { // bad signature
         *mlen = (size_t) -1;
         memset(m, 0, smlen);

--- a/crypto_sign/rainbowVc-classic/clean/sign.c
+++ b/crypto_sign/rainbowVc-classic/clean/sign.c
@@ -44,7 +44,7 @@ int PQCLEAN_RAINBOWVCCLASSIC_CLEAN_crypto_sign_open(unsigned char *m, size_t *ml
         rc = PQCLEAN_RAINBOWVCCLASSIC_CLEAN_rainbow_verify(digest, sm + mlen[0], (const pk_t *)pk);
     }
     if (!rc) {
-        memcpy(m, sm, smlen - _SIGNATURE_BYTE);
+        memmove(m, sm, smlen - _SIGNATURE_BYTE);
     } else { // bad signature
         *mlen = (size_t) -1;
         memset(m, 0, smlen);

--- a/crypto_sign/rainbowVc-cyclic-compressed/clean/sign.c
+++ b/crypto_sign/rainbowVc-cyclic-compressed/clean/sign.c
@@ -46,7 +46,7 @@ int PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_crypto_sign_open(unsigned char *m, s
         rc = PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_rainbow_verify_cyclic(digest, sm + mlen[0], (const cpk_t *)pk);
     }
     if (!rc) {
-        memcpy(m, sm, smlen - _SIGNATURE_BYTE);
+        memmove(m, sm, smlen - _SIGNATURE_BYTE);
     } else { // bad signature
         *mlen = (size_t) -1;
         memset(m, 0, smlen);

--- a/crypto_sign/rainbowVc-cyclic/clean/sign.c
+++ b/crypto_sign/rainbowVc-cyclic/clean/sign.c
@@ -46,7 +46,7 @@ int PQCLEAN_RAINBOWVCCYCLIC_CLEAN_crypto_sign_open(unsigned char *m, size_t *mle
         rc = PQCLEAN_RAINBOWVCCYCLIC_CLEAN_rainbow_verify_cyclic(digest, sm + mlen[0], (const cpk_t *)pk);
     }
     if (!rc) {
-        memcpy(m, sm, smlen - _SIGNATURE_BYTE);
+        memmove(m, sm, smlen - _SIGNATURE_BYTE);
     } else { // bad signature
         *mlen = (size_t) -1;
         memset(m, 0, smlen);


### PR DESCRIPTION
Our tests on master failed (among other reasons) because rainbow had some overlapping buffers passed to `memcpy`: https://circleci.com/gh/PQClean/PQClean/8556 

It's right. This should be a `memmove`. 
