### PR TITLE
Fix Valgrind failures on CircleCI for Kyber-AVX2

### DIFF
--- a/common/keccak4x/Makefile
+++ b/common/keccak4x/Makefile
@@ -1,7 +1,7 @@
 KeccakP-1600-times4-SIMD256.o: KeccakP-1600-times4-SIMD256.c \
   align.h brg_endian.h KeccakP-1600-times4-SnP.h \
   KeccakP-1600-unrolling.macros SIMD256-config.h
-	$(CC) $(CFLAGS) -march=native -c $< -o $@
+	$(CC) $(CFLAGS) -mavx2 -c $< -o $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
CircleCI has AVX512 support and the compiler will generate instructions that Valgrind doesn't handle.
