### PR TITLE
Fix isolation in test_metadata_sizes

### DIFF
--- a/test/test_metadata_sizes.py
+++ b/test/test_metadata_sizes.py
@@ -17,21 +17,22 @@ import pqclean
 def test_metadata_sizes(implementation, impl_path, test_dir, init, destr):
     init()
     metadata = implementation.scheme.metadata()
+    dest_dir = os.path.join(test_dir, 'bin')
     helpers.make('printparams',
                  TYPE=implementation.scheme.type,
                  SCHEME=implementation.scheme.name,
                  IMPLEMENTATION=implementation.name,
                  SCHEME_DIR=impl_path,
-                 working_dir=os.path.join('..', 'test'))
+                 DEST_DIR=dest_dir,
+                 working_dir=os.path.join(test_dir, 'test'))
 
     out = helpers.run_subprocess(
-            [os.path.join('..', 'bin', 'printparams_{}_{}{}'.format(
-                implementation.scheme.name,
-                implementation.name,
-                '.exe' if os.name == 'nt' else ''
-            ))],
-            os.path.join('..', 'bin'),
-        ).replace('\r', '')
+        [os.path.join(dest_dir, 'printparams_{}_{}{}'.format(
+            implementation.scheme.name,
+            implementation.name,
+            '.exe' if os.name == 'nt' else ''
+        ))]
+    ).replace('\r', '')
 
     parsed = json.loads(out)
 


### PR DESCRIPTION
The `printparams` executables were still being written in the wrong folder.