### PR TITLE
Also run duplicate consistency checks on windows

### DIFF
--- a/test/test_duplicate_consistency.py
+++ b/test/test_duplicate_consistency.py
@@ -47,7 +47,6 @@ def file_get_contents(filename):
         return f.read()
 
 
-@helpers.skip_windows()
 @helpers.filtered_test
 def test_duplicate_consistency(implementation, source, file):
     target_path = os.path.join(source.path(), file)


### PR DESCRIPTION
These have been windows-compatible for a while now, due to the test having
been ported to difflib.