### PR TITLE
Put all common primitives on the heap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,12 @@ See the section [API](#API) below.
     astyle --project crypto_kem/yourschemename/clean/*.[ch]
     ```
     4. You may run the tests in the `tests/` folder. See the `README` for how to run the test suite.
-    5. Migrate your use of AES, SHA-2, and SHA-3 to the API in the `common` directory. Note that if you use the AES API, you must use the `aes128_keyexp` routine (or 192 or 256) to expand the key into a key schedule object, then use `aes128_ctx_release` to release the key schedule object once you're finished with it.
+    5. Migrate your use of AES, SHA-2, and SHA-3 to the API in the `common` directory.
+    Note that if you use the AES API, you must use the `aes128_keyexp` routine (or 192 or 256) to expand the key into a key schedule object,
+    then use `aes128_ctx_release` to release the key schedule object once you're finished with it.
+    For the SHAKE API, use the appropriate `_ctx_release` functions.
+    For fixed-output functions SHA-2 and SHA-3, the `_finalize` function will free the state.
+    If you need to make copies of any of the states of these primitives, use the appropriate functions.
 
 5. Create `Makefile` and `Makefile.Microsoft_nmake` files to compile your scheme as static library.
     * We suggest you copy these from `crypto_kem/kyber768/clean` and modify them to suit your scheme.

--- a/common/aes.c
+++ b/common/aes.c
@@ -577,6 +577,11 @@ static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, 
 void aes128_keyexp(aes128ctx *r, const unsigned char *key) {
     uint64_t skey[22];
 
+    r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES128_STATESIZE);
+    if (r->sk_exp == NULL) {
+        exit(111);
+    }
+
     br_aes_ct64_keysched(skey, key, 16);
     br_aes_ct64_skey_expand(r->sk_exp, skey, 10);
 }
@@ -584,6 +589,10 @@ void aes128_keyexp(aes128ctx *r, const unsigned char *key) {
 
 void aes192_keyexp(aes192ctx *r, const unsigned char *key) {
     uint64_t skey[26];
+    r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES192_STATESIZE);
+    if (r->sk_exp == NULL) {
+        exit(111);
+    }
 
     br_aes_ct64_keysched(skey, key, 24);
     br_aes_ct64_skey_expand(r->sk_exp, skey, 12);
@@ -592,6 +601,10 @@ void aes192_keyexp(aes192ctx *r, const unsigned char *key) {
 
 void aes256_keyexp(aes256ctx *r, const unsigned char *key) {
     uint64_t skey[30];
+    r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES256_STATESIZE);
+    if (r->sk_exp == NULL) {
+        exit(111);
+    }
 
     br_aes_ct64_keysched(skey, key, 32);
     br_aes_ct64_skey_expand(r->sk_exp, skey, 14);
@@ -623,17 +636,14 @@ void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, cons
 }
 
 void aes128_ctx_release(aes128ctx *r) {
-    // no-op for PQClean's basic AES operation
-    (void) r;
+    free(r->sk_exp);
 }
 
 void aes192_ctx_release(aes192ctx *r) {
-    // no-op for PQClean's basic AES operation
-    (void) r;
+    free(r->sk_exp);
 }
 
 void aes256_ctx_release(aes256ctx *r) {
-    // no-op for PQClean's basic AES operation
-    (void) r;
+    free(r->sk_exp);
 }
 

--- a/common/aes.h
+++ b/common/aes.h
@@ -10,29 +10,36 @@
 #define AESCTR_NONCEBYTES 12
 #define AES_BLOCKBYTES 16
 
+// We've put these states on the heap to make sure ctx_release is used.
+#define PQC_AES128_STATESIZE 88
 typedef struct {
-    uint64_t sk_exp[88];
+    uint64_t* sk_exp;
 } aes128ctx;
 
+#define PQC_AES192_STATESIZE 104
 typedef struct {
-    uint64_t sk_exp[104];
+    uint64_t*  sk_exp;
 } aes192ctx;
 
+#define PQC_AES256_STATESIZE 120
 typedef struct {
-    uint64_t sk_exp[120];
+    uint64_t* sk_exp;
 } aes256ctx;
 
 
 
+/** Initializes the context **/
 void aes128_keyexp(aes128ctx *r, const unsigned char *key);
 
 void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes128ctx *ctx);
 
 void aes128_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes128ctx *ctx);
 
+/** Frees the context **/
 void aes128_ctx_release(aes128ctx *r);
 
 
+/** Initializes the context **/
 void aes192_keyexp(aes192ctx *r, const unsigned char *key);
 
 void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes192ctx *ctx);
@@ -42,12 +49,14 @@ void aes192_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, cons
 void aes192_ctx_release(aes192ctx *r);
 
 
+/** Initializes the context **/
 void aes256_keyexp(aes256ctx *r, const unsigned char *key);
 
 void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes256ctx *ctx);
 
 void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes256ctx *ctx);
 
+/** Frees the context **/
 void aes256_ctx_release(aes256ctx *r);
 
 

--- a/common/fips202.c
+++ b/common/fips202.c
@@ -7,6 +7,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "fips202.h"
 
@@ -521,6 +523,10 @@ static void keccak_inc_squeeze(uint8_t *h, size_t outlen,
 }
 
 void shake128_inc_init(shake128incctx *state) {
+    state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (state->ctx == NULL) {
+        exit(111);
+    }
     keccak_inc_init(state->ctx);
 }
 
@@ -536,7 +542,23 @@ void shake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state)
     keccak_inc_squeeze(output, outlen, state->ctx, SHAKE128_RATE);
 }
 
+void shake128_inc_ctx_clone(shake128incctx *dest, const shake128incctx *src) {
+    dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (dest->ctx == NULL) {
+        exit(111);
+    }
+    memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
+}
+
+void shake128_inc_ctx_release(shake128incctx *state) {
+    free(state->ctx);
+}
+
 void shake256_inc_init(shake256incctx *state) {
+    state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (state->ctx == NULL) {
+        exit(111);
+    }
     keccak_inc_init(state->ctx);
 }
 
@@ -552,6 +574,18 @@ void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state)
     keccak_inc_squeeze(output, outlen, state->ctx, SHAKE256_RATE);
 }
 
+void shake256_inc_ctx_clone(shake256incctx *dest, const shake256incctx *src) {
+    dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (dest->ctx == NULL) {
+        exit(111);
+    }
+    memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
+}
+
+void shake256_inc_ctx_release(shake256incctx *state) {
+    free(state->ctx);
+}
+
 
 /*************************************************
  * Name:        shake128_absorb
@@ -565,6 +599,10 @@ void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state)
  *              - size_t inlen: length of input in bytes
  **************************************************/
 void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen) {
+    state->ctx = malloc(PQC_SHAKECTX_BYTES);
+    if (state->ctx == NULL) {
+        exit(111);
+    }
     keccak_absorb(state->ctx, SHAKE128_RATE, input, inlen, 0x1F);
 }
 
@@ -584,6 +622,19 @@ void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
     keccak_squeezeblocks(output, nblocks, state->ctx, SHAKE128_RATE);
 }
 
+void shake128_ctx_clone(shake128ctx *dest, const shake128ctx *src) {
+    dest->ctx = malloc(PQC_SHAKECTX_BYTES);
+    if (dest->ctx == NULL) {
+        exit(111);
+    }
+    memcpy(dest->ctx, src->ctx, PQC_SHAKECTX_BYTES);
+}
+
+/** Release the allocated state. Call only once. */
+void shake128_ctx_release(shake128ctx *state) {
+    free(state->ctx);
+}
+
 /*************************************************
  * Name:        shake256_absorb
  *
@@ -596,6 +647,10 @@ void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
  *              - size_t inlen: length of input in bytes
  **************************************************/
 void shake256_absorb(shake256ctx *state, const uint8_t *input, size_t inlen) {
+    state->ctx = malloc(PQC_SHAKECTX_BYTES);
+    if (state->ctx == NULL) {
+        exit(111);
+    }
     keccak_absorb(state->ctx, SHAKE256_RATE, input, inlen, 0x1F);
 }
 
@@ -613,6 +668,19 @@ void shake256_absorb(shake256ctx *state, const uint8_t *input, size_t inlen) {
  **************************************************/
 void shake256_squeezeblocks(uint8_t *output, size_t nblocks, shake256ctx *state) {
     keccak_squeezeblocks(output, nblocks, state->ctx, SHAKE256_RATE);
+}
+
+void shake256_ctx_clone(shake256ctx *dest, const shake256ctx *src) {
+    dest->ctx = malloc(PQC_SHAKECTX_BYTES);
+    if (dest->ctx == NULL) {
+        exit(111);
+    }
+    memcpy(dest->ctx, src->ctx, PQC_SHAKECTX_BYTES);
+}
+
+/** Release the allocated state. Call only once. */
+void shake256_ctx_release(shake256ctx *state) {
+    free(state->ctx);
 }
 
 /*************************************************
@@ -643,6 +711,7 @@ void shake128(uint8_t *output, size_t outlen,
             output[i] = t[i];
         }
     }
+    shake128_ctx_release(&s);
 }
 
 /*************************************************
@@ -673,10 +742,23 @@ void shake256(uint8_t *output, size_t outlen,
             output[i] = t[i];
         }
     }
+    shake256_ctx_release(&s);
 }
 
 void sha3_256_inc_init(sha3_256incctx *state) {
+    state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (state->ctx == NULL) {
+        exit(111);
+    }
     keccak_inc_init(state->ctx);
+}
+
+void sha3_256_inc_ctx_clone(sha3_256incctx *dest, const sha3_256incctx *src) {
+    dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (dest->ctx == NULL) {
+        exit(111);
+    }
+    memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
 }
 
 void sha3_256_inc_absorb(sha3_256incctx *state, const uint8_t *input, size_t inlen) {
@@ -688,6 +770,8 @@ void sha3_256_inc_finalize(uint8_t *output, sha3_256incctx *state) {
     keccak_inc_finalize(state->ctx, SHA3_256_RATE, 0x06);
 
     keccak_squeezeblocks(t, 1, state->ctx, SHA3_256_RATE);
+
+    free(state->ctx);
 
     for (size_t i = 0; i < 32; i++) {
         output[i] = t[i];
@@ -719,7 +803,19 @@ void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen) {
 }
 
 void sha3_384_inc_init(sha3_384incctx *state) {
+    state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (state->ctx == NULL) {
+        exit(111);
+    }
     keccak_inc_init(state->ctx);
+}
+
+void sha3_384_inc_ctx_clone(sha3_384incctx *dest, const sha3_384incctx *src) {
+    dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (dest->ctx == NULL) {
+        exit(111);
+    }
+    memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
 }
 
 void sha3_384_inc_absorb(sha3_384incctx *state, const uint8_t *input, size_t inlen) {
@@ -731,6 +827,8 @@ void sha3_384_inc_finalize(uint8_t *output, sha3_384incctx *state) {
     keccak_inc_finalize(state->ctx, SHA3_384_RATE, 0x06);
 
     keccak_squeezeblocks(t, 1, state->ctx, SHA3_384_RATE);
+
+    free(state->ctx);
 
     for (size_t i = 0; i < 48; i++) {
         output[i] = t[i];
@@ -762,7 +860,19 @@ void sha3_384(uint8_t *output, const uint8_t *input, size_t inlen) {
 }
 
 void sha3_512_inc_init(sha3_512incctx *state) {
+    state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (state->ctx == NULL) {
+        exit(111);
+    }
     keccak_inc_init(state->ctx);
+}
+
+void sha3_512_inc_ctx_clone(sha3_512incctx *dest, const sha3_512incctx *src) {
+    dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+    if (dest->ctx == NULL) {
+        exit(111);
+    }
+    memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
 }
 
 void sha3_512_inc_absorb(sha3_512incctx *state, const uint8_t *input, size_t inlen) {
@@ -774,6 +884,8 @@ void sha3_512_inc_finalize(uint8_t *output, sha3_512incctx *state) {
     keccak_inc_finalize(state->ctx, SHA3_512_RATE, 0x06);
 
     keccak_squeezeblocks(t, 1, state->ctx, SHA3_512_RATE);
+
+    free(state->ctx);
 
     for (size_t i = 0; i < 64; i++) {
         output[i] = t[i];

--- a/common/fips202.c
+++ b/common/fips202.c
@@ -761,6 +761,10 @@ void sha3_256_inc_ctx_clone(sha3_256incctx *dest, const sha3_256incctx *src) {
     memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
 }
 
+void sha3_256_inc_ctx_release(sha3_256incctx *state) {
+    free(state->ctx);
+}
+
 void sha3_256_inc_absorb(sha3_256incctx *state, const uint8_t *input, size_t inlen) {
     keccak_inc_absorb(state->ctx, SHA3_256_RATE, input, inlen);
 }
@@ -771,7 +775,7 @@ void sha3_256_inc_finalize(uint8_t *output, sha3_256incctx *state) {
 
     keccak_squeezeblocks(t, 1, state->ctx, SHA3_256_RATE);
 
-    free(state->ctx);
+    sha3_256_inc_ctx_release(state);
 
     for (size_t i = 0; i < 32; i++) {
         output[i] = t[i];
@@ -822,13 +826,17 @@ void sha3_384_inc_absorb(sha3_384incctx *state, const uint8_t *input, size_t inl
     keccak_inc_absorb(state->ctx, SHA3_384_RATE, input, inlen);
 }
 
+void sha3_384_inc_ctx_release(sha3_384incctx *state) {
+    free(state->ctx);
+}
+
 void sha3_384_inc_finalize(uint8_t *output, sha3_384incctx *state) {
     uint8_t t[SHA3_384_RATE];
     keccak_inc_finalize(state->ctx, SHA3_384_RATE, 0x06);
 
     keccak_squeezeblocks(t, 1, state->ctx, SHA3_384_RATE);
 
-    free(state->ctx);
+    sha3_384_inc_ctx_release(state);
 
     for (size_t i = 0; i < 48; i++) {
         output[i] = t[i];
@@ -879,13 +887,17 @@ void sha3_512_inc_absorb(sha3_512incctx *state, const uint8_t *input, size_t inl
     keccak_inc_absorb(state->ctx, SHA3_512_RATE, input, inlen);
 }
 
+void sha3_512_inc_ctx_release(sha3_512incctx *state) {
+    free(state->ctx);
+}
+
 void sha3_512_inc_finalize(uint8_t *output, sha3_512incctx *state) {
     uint8_t t[SHA3_512_RATE];
     keccak_inc_finalize(state->ctx, SHA3_512_RATE, 0x06);
 
     keccak_squeezeblocks(t, 1, state->ctx, SHA3_512_RATE);
 
-    free(state->ctx);
+    sha3_512_inc_ctx_release(state);
 
     for (size_t i = 0; i < 64; i++) {
         output[i] = t[i];

--- a/common/fips202.h
+++ b/common/fips202.h
@@ -89,7 +89,6 @@ void shake128_inc_ctx_release(shake128incctx *state);
  * This function does not support being called multiple times
  * with the same state.
  */
-void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen);
 void shake256_absorb(shake256ctx *state, const uint8_t *input, size_t inlen);
 /* Squeeze output out of the sponge.
  *

--- a/common/fips202.h
+++ b/common/fips202.h
@@ -11,57 +11,67 @@
 #define SHA3_512_RATE 72
 
 
+#define PQC_SHAKEINCCTX_BYTES (sizeof(uint64_t)*26)
+#define PQC_SHAKECTX_BYTES (sizeof(uint64_t)*25)
+
 // Context for incremental API
 typedef struct {
-    uint64_t ctx[26];
+    uint64_t* ctx;
 } shake128incctx;
 
 // Context for non-incremental API
 typedef struct {
-    uint64_t ctx[25];
+    uint64_t* ctx;
 } shake128ctx;
 
 // Context for incremental API
 typedef struct {
-    uint64_t ctx[26];
+    uint64_t* ctx;
 } shake256incctx;
 
 // Context for non-incremental API
 typedef struct {
-    uint64_t ctx[25];
+    uint64_t* ctx;
 } shake256ctx;
 
 // Context for incremental API
 typedef struct {
-    uint64_t ctx[26];
+    uint64_t* ctx;
 } sha3_256incctx;
 
 // Context for incremental API
 typedef struct {
-    uint64_t ctx[26];
+    uint64_t* ctx;
 } sha3_384incctx;
 
 // Context for incremental API
 typedef struct {
-    uint64_t ctx[26];
+    uint64_t* ctx;
 } sha3_512incctx;
 
 void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen);
-
 void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state);
+void shake128_ctx_release(shake128ctx *state);
+void shake128_ctx_clone(shake128ctx *dst, const shake128ctx *src);
 
 void shake128_inc_init(shake128incctx *state);
 void shake128_inc_absorb(shake128incctx *state, const uint8_t *input, size_t inlen);
 void shake128_inc_finalize(shake128incctx *state);
 void shake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state);
+void shake128_inc_ctx_clone(shake128incctx* dest, const shake128incctx *src);
+void shake128_inc_ctx_release(shake128incctx *state);
 
 void shake256_absorb(shake256ctx *state, const uint8_t *input, size_t inlen);
 void shake256_squeezeblocks(uint8_t *output, size_t nblocks, shake256ctx *state);
+void shake256_ctx_release(shake256ctx *state);
+void shake256_ctx_clone(shake256ctx *dst, const shake256ctx *src);
 
 void shake256_inc_init(shake256incctx *state);
 void shake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen);
 void shake256_inc_finalize(shake256incctx *state);
 void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state);
+void shake256_inc_ctx_clone(shake256incctx* dest, const shake256incctx *src);
+void shake256_inc_ctx_release(shake256incctx *state);
 
 void shake128(uint8_t *output, size_t outlen,
               const uint8_t *input, size_t inlen);
@@ -70,18 +80,21 @@ void shake256(uint8_t *output, size_t outlen,
               const uint8_t *input, size_t inlen);
 
 void sha3_256_inc_init(sha3_256incctx *state);
+void sha3_256_inc_ctx_clone(sha3_256incctx *dest, const sha3_256incctx *src);
 void sha3_256_inc_absorb(sha3_256incctx *state, const uint8_t *input, size_t inlen);
 void sha3_256_inc_finalize(uint8_t *output, sha3_256incctx *state);
 
 void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen);
 
 void sha3_384_inc_init(sha3_384incctx *state);
+void sha3_384_inc_ctx_clone(sha3_384incctx *dest, const sha3_384incctx *src);
 void sha3_384_inc_absorb(sha3_384incctx *state, const uint8_t *input, size_t inlen);
 void sha3_384_inc_finalize(uint8_t *output, sha3_384incctx *state);
 
 void sha3_384(uint8_t *output, const uint8_t *input, size_t inlen);
 
 void sha3_512_inc_init(sha3_512incctx *state);
+void sha3_512_inc_ctx_clone(sha3_512incctx *dest, const sha3_512incctx *src);
 void sha3_512_inc_absorb(sha3_512incctx *state, const uint8_t *input, size_t inlen);
 void sha3_512_inc_finalize(uint8_t *output, sha3_512incctx *state);
 

--- a/common/fips202.h
+++ b/common/fips202.h
@@ -49,55 +49,120 @@ typedef struct {
     uint64_t* ctx;
 } sha3_512incctx;
 
+/* Initialize the state and absorb the provided input.
+ *
+ * This function does not support being called multiple times
+ * with the same state.
+ */
 void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen);
+/* Squeeze output out of the sponge.
+ *
+ * Supports being called multiple times
+ */
 void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state);
+/* Free the state */
 void shake128_ctx_release(shake128ctx *state);
+/* Copy the state. */
 void shake128_ctx_clone(shake128ctx *dst, const shake128ctx *src);
 
+/* Initialize incremental hashing API */
 void shake128_inc_init(shake128incctx *state);
+/* Absorb more information into the XOF.
+ *
+ * Can be called multiple times.
+ */
 void shake128_inc_absorb(shake128incctx *state, const uint8_t *input, size_t inlen);
+/* Finalize the XOF for squeezing */
 void shake128_inc_finalize(shake128incctx *state);
+/* Squeeze output out of the sponge.
+ *
+ * Supports being called multiple times
+ */
 void shake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state);
+/* Copy the context of the SHAKE128 XOF */
 void shake128_inc_ctx_clone(shake128incctx* dest, const shake128incctx *src);
+/* Free the context of the SHAKE128 XOF */
 void shake128_inc_ctx_release(shake128incctx *state);
 
+/* Initialize the state and absorb the provided input.
+ *
+ * This function does not support being called multiple times
+ * with the same state.
+ */
+void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen);
 void shake256_absorb(shake256ctx *state, const uint8_t *input, size_t inlen);
+/* Squeeze output out of the sponge.
+ *
+ * Supports being called multiple times
+ */
 void shake256_squeezeblocks(uint8_t *output, size_t nblocks, shake256ctx *state);
+/* Free the context held by this XOF */
 void shake256_ctx_release(shake256ctx *state);
+/* Copy the context held by this XOF */
 void shake256_ctx_clone(shake256ctx *dst, const shake256ctx *src);
 
+/* Initialize incremental hashing API */
 void shake256_inc_init(shake256incctx *state);
 void shake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen);
+/* Prepares for squeeze phase */
 void shake256_inc_finalize(shake256incctx *state);
+/* Squeeze output out of the sponge.
+ *
+ * Supports being called multiple times
+ */
 void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state);
+/* Copy the state */
 void shake256_inc_ctx_clone(shake256incctx* dest, const shake256incctx *src);
+/* Free the state */
 void shake256_inc_ctx_release(shake256incctx *state);
 
+/* One-stop SHAKE128 call */
 void shake128(uint8_t *output, size_t outlen,
               const uint8_t *input, size_t inlen);
 
+/* One-stop SHAKE256 call */
 void shake256(uint8_t *output, size_t outlen,
               const uint8_t *input, size_t inlen);
 
+/* Initialize the incremental hashing state */
 void sha3_256_inc_init(sha3_256incctx *state);
-void sha3_256_inc_ctx_clone(sha3_256incctx *dest, const sha3_256incctx *src);
+/* Absorb blocks into SHA3 */
 void sha3_256_inc_absorb(sha3_256incctx *state, const uint8_t *input, size_t inlen);
+/* Obtain the output of the function and free `state` */
 void sha3_256_inc_finalize(uint8_t *output, sha3_256incctx *state);
+/* Copy the context */
+void sha3_256_inc_ctx_clone(sha3_256incctx *dest, const sha3_256incctx *src);
+/* Release the state, don't use if `_finalize` has been used */
+void sha3_256_inc_ctx_release(sha3_256incctx *state);
 
 void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen);
 
+/* Initialize the incremental hashing state */
 void sha3_384_inc_init(sha3_384incctx *state);
-void sha3_384_inc_ctx_clone(sha3_384incctx *dest, const sha3_384incctx *src);
+/* Absorb blocks into SHA3 */
 void sha3_384_inc_absorb(sha3_384incctx *state, const uint8_t *input, size_t inlen);
+/* Obtain the output of the function and free `state` */
 void sha3_384_inc_finalize(uint8_t *output, sha3_384incctx *state);
+/* Copy the context */
+void sha3_384_inc_ctx_clone(sha3_384incctx *dest, const sha3_384incctx *src);
+/* Release the state, don't use if `_finalize` has been used */
+void sha3_384_inc_ctx_release(sha3_384incctx *state);
 
+/* One-stop SHA3-384 shop */
 void sha3_384(uint8_t *output, const uint8_t *input, size_t inlen);
 
+/* Initialize the incremental hashing state */
 void sha3_512_inc_init(sha3_512incctx *state);
-void sha3_512_inc_ctx_clone(sha3_512incctx *dest, const sha3_512incctx *src);
+/* Absorb blocks into SHA3 */
 void sha3_512_inc_absorb(sha3_512incctx *state, const uint8_t *input, size_t inlen);
+/* Obtain the output of the function and free `state` */
 void sha3_512_inc_finalize(uint8_t *output, sha3_512incctx *state);
+/* Copy the context */
+void sha3_512_inc_ctx_clone(sha3_512incctx *dest, const sha3_512incctx *src);
+/* Release the state, don't use if `_finalize` has been used */
+void sha3_512_inc_ctx_release(sha3_512incctx *state);
 
+/* One-stop SHA3-512 shop */
 void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen);
 
 #endif

--- a/common/fips202.h
+++ b/common/fips202.h
@@ -63,7 +63,7 @@ void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
 /* Free the state */
 void shake128_ctx_release(shake128ctx *state);
 /* Copy the state. */
-void shake128_ctx_clone(shake128ctx *dst, const shake128ctx *src);
+void shake128_ctx_clone(shake128ctx *dest, const shake128ctx *src);
 
 /* Initialize incremental hashing API */
 void shake128_inc_init(shake128incctx *state);
@@ -98,7 +98,7 @@ void shake256_squeezeblocks(uint8_t *output, size_t nblocks, shake256ctx *state)
 /* Free the context held by this XOF */
 void shake256_ctx_release(shake256ctx *state);
 /* Copy the context held by this XOF */
-void shake256_ctx_clone(shake256ctx *dst, const shake256ctx *src);
+void shake256_ctx_clone(shake256ctx *dest, const shake256ctx *src);
 
 /* Initialize incremental hashing API */
 void shake256_inc_init(shake256incctx *state);

--- a/common/sha2.h
+++ b/common/sha2.h
@@ -8,36 +8,41 @@
     must be exactly 64 bytes each.
     Use the 'finalize' functions for any remaining bytes (possibly over 64). */
 
+#define PQC_SHA256CTX_BYTES 40
 /* Structure for the incremental API */
 typedef struct {
-    uint8_t ctx[40];
+    uint8_t *ctx;
 } sha224ctx;
 
 /* Structure for the incremental API */
 typedef struct {
-    uint8_t ctx[40];
+    uint8_t *ctx;
 } sha256ctx;
 
+#define PQC_SHA512CTX_BYTES 72
 /* Structure for the incremental API */
 typedef struct {
-    uint8_t ctx[72];
+    uint8_t *ctx;
 } sha384ctx;
 
 /* Structure for the incremental API */
 typedef struct {
-    uint8_t ctx[72];
+    uint8_t *ctx;
 } sha512ctx;
 
 /* ====== SHA224 API ==== */
+
 /**
- * Initialize the incremental hashing API
+ * Initialize the incremental hashing API.
+ *
+ * Can't be called multiple times.
  */
 void sha224_inc_init(sha224ctx *state);
 
 /**
  * Copy the hashing state
  */
-void sha224_inc_clone_state(sha224ctx *stateout, const sha224ctx *statein);
+void sha224_inc_ctx_clone(sha224ctx *stateout, const sha224ctx *statein);
 
 /**
  * Absorb blocks
@@ -48,13 +53,15 @@ void sha224_inc_blocks(sha224ctx *state, const uint8_t *in, size_t inblocks);
  * Finalize and obtain the digest
  *
  * If applicable, this function will free the memory associated with the sha224ctx.
+ *
+ * If not calling this function, call `sha224_inc_ctx_release`
  */
 void sha224_inc_finalize(uint8_t *out, sha224ctx *state, const uint8_t *in, size_t inlen);
 
 /**
  * Destroy the state. Make sure to use this, as this API may not always be stack-based.
  */
-void sha224_inc_destroy(sha224ctx *state);
+void sha224_inc_ctx_release(sha224ctx *state);
 
 /**
  * All-in-one sha224 function
@@ -71,7 +78,7 @@ void sha256_inc_init(sha256ctx *state);
 /**
  * Copy the hashing state
  */
-void sha256_inc_clone_state(sha256ctx *stateout, const sha256ctx *statein);
+void sha256_inc_ctx_clone(sha256ctx *stateout, const sha256ctx *statein);
 
 /**
  * Absorb blocks
@@ -88,7 +95,7 @@ void sha256_inc_finalize(uint8_t *out, sha256ctx *state, const uint8_t *in, size
 /**
  * Destroy the state. Make sure to use this, as this API may not always be stack-based.
  */
-void sha256_inc_destroy(sha256ctx *state);
+void sha256_inc_ctx_release(sha256ctx *state);
 
 /**
  * All-in-one sha256 function
@@ -105,7 +112,7 @@ void sha384_inc_init(sha384ctx *state);
 /**
  * Copy the hashing state
  */
-void sha384_inc_clone_state(sha384ctx *stateout, const sha384ctx *statein);
+void sha384_inc_ctx_clone(sha384ctx *stateout, const sha384ctx *statein);
 
 /**
  * Absorb blocks
@@ -120,9 +127,9 @@ void sha384_inc_blocks(sha384ctx *state, const uint8_t *in, size_t inblocks);
 void sha384_inc_finalize(uint8_t *out, sha384ctx *state, const uint8_t *in, size_t inlen);
 
 /**
- * Destroy the state. Make sure to use this, as this API may not always be stack-based.
+ * Destroy the state. Make sure to use this if not calling finalize, as this API may not always be stack-based.
  */
-void sha384_inc_destroy(sha384ctx *state);
+void sha384_inc_ctx_release(sha384ctx *state);
 
 /**
  * All-in-one sha384 function
@@ -140,7 +147,7 @@ void sha512_inc_init(sha512ctx *state);
 /**
  * Copy the hashing state
  */
-void sha512_inc_clone_state(sha512ctx *stateout, const sha512ctx *statein);
+void sha512_inc_ctx_clone(sha512ctx *stateout, const sha512ctx *statein);
 
 /**
  * Absorb blocks
@@ -155,9 +162,9 @@ void sha512_inc_blocks(sha512ctx *state, const uint8_t *in, size_t inblocks);
 void sha512_inc_finalize(uint8_t *out, sha512ctx *state, const uint8_t *in, size_t inlen);
 
 /**
- * Destroy the state. Make sure to use this, as this API may not always be stack-based.
+ * Destroy the state. Make sure to use this if not calling finalize, as this API may not always be stack-based.
  */
-void sha512_inc_destroy(sha512ctx *state);
+void sha512_inc_ctx_release(sha512ctx *state);
 
 /**
  * All-in-one sha512 function

--- a/common/sp800-185.c
+++ b/common/sp800-185.c
@@ -53,6 +53,14 @@ void cshake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state
     shake128_inc_squeeze(output, outlen, state);
 }
 
+void cshake128_inc_ctx_release(shake128incctx *state) {
+    shake128_inc_ctx_release(state);
+}
+
+void cshake128_inc_ctx_clone(shake128incctx *dest, const shake128incctx *src) {
+    shake128_inc_ctx_clone(dest, src);
+}
+
 void cshake256_inc_init(shake256incctx *state, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen) {
     uint8_t encbuf[sizeof(size_t)+1];
 
@@ -87,6 +95,14 @@ void cshake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state
     shake256_inc_squeeze(output, outlen, state);
 }
 
+void cshake256_inc_ctx_release(shake256incctx *state) {
+    shake256_inc_ctx_release(state);
+}
+
+void cshake256_inc_ctx_clone(shake256incctx *dest, const shake256incctx *src) {
+    shake256_inc_ctx_clone(dest, src);
+}
+
 /*************************************************
  * Name:        cshake128
  *
@@ -110,6 +126,7 @@ void cshake128(uint8_t *output, size_t outlen,
     cshake128_inc_absorb(&state, input, inlen);
     cshake128_inc_finalize(&state);
     cshake128_inc_squeeze(output, outlen, &state);
+    cshake128_inc_ctx_release(&state);
 }
 
 /*************************************************
@@ -135,4 +152,5 @@ void cshake256(uint8_t *output, size_t outlen,
     cshake256_inc_absorb(&state, input, inlen);
     cshake256_inc_finalize(&state);
     cshake256_inc_squeeze(output, outlen, &state);
+    cshake256_inc_ctx_release(&state);
 }

--- a/common/sp800-185.h
+++ b/common/sp800-185.h
@@ -10,6 +10,8 @@ void cshake128_inc_init(shake128incctx *state, const uint8_t *name, size_t namel
 void cshake128_inc_absorb(shake128incctx *state, const uint8_t *input, size_t inlen);
 void cshake128_inc_finalize(shake128incctx *state);
 void cshake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state);
+void cshake128_inc_ctx_release(shake128incctx *state);
+void cshake128_inc_ctx_clone(shake128incctx *dest, const shake128incctx *src);
 
 void cshake128(uint8_t *output, size_t outlen, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen, const uint8_t *input, size_t inlen);
 
@@ -17,6 +19,8 @@ void cshake256_inc_init(shake256incctx *state, const uint8_t *name, size_t namel
 void cshake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen);
 void cshake256_inc_finalize(shake256incctx *state);
 void cshake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state);
+void cshake256_inc_ctx_release(shake256incctx *state);
+void cshake256_inc_ctx_clone(shake256incctx *dest, const shake256incctx *src);
 
 void cshake256(uint8_t *output, size_t outlen, const uint8_t *name, size_t namelen, const uint8_t* cstm, size_t cstmlen, const uint8_t *input, size_t inlen);
 

--- a/crypto_kem/babybear-ephem/clean/threebears.c
+++ b/crypto_kem/babybear-ephem/clean/threebears.c
@@ -38,6 +38,7 @@ static void uniform(gf_t matrix, const uint8_t *seed, uint8_t iv) {
     cshake256_inc_absorb(&ctx, &iv, 1);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(c, sizeof(c), &ctx);
+    cshake256_inc_ctx_release(&ctx);
     PQCLEAN_BABYBEAREPHEM_CLEAN_expand(matrix, c);
 }
 
@@ -56,13 +57,14 @@ static void noise(gf_t x, const shake256incctx *ctx, uint8_t iv) {
     uint8_t c[DIGITS];
     shake256incctx ctx2;
 
-    memcpy(&ctx2, ctx, sizeof(ctx2));
+    cshake256_inc_ctx_clone(&ctx2, ctx);
     cshake256_inc_absorb(&ctx2, &iv, 1);
     cshake256_inc_finalize(&ctx2);
     cshake256_inc_squeeze(c, DIGITS, &ctx2);
     for (size_t i = 0; i < DIGITS; i++) {
         x[i] = (limb_t)(psi(c[i]) + PQCLEAN_BABYBEAREPHEM_CLEAN_modulus(i));
     }
+    cshake256_inc_ctx_release(&ctx2);
 }
 
 /* Expand public key from private key */
@@ -74,9 +76,10 @@ void PQCLEAN_BABYBEAREPHEM_CLEAN_get_pubkey(uint8_t *pk, const uint8_t *sk) {
     threebears_hash_init(&ctx, HASH_PURPOSE_KEYGEN);
     cshake256_inc_absorb(&ctx, sk, PRIVATE_KEY_BYTES);
 
-    memcpy(&ctx2, &ctx, sizeof(ctx2));
+    cshake256_inc_ctx_clone(&ctx2, &ctx);
     cshake256_inc_finalize(&ctx2);
     cshake256_inc_squeeze(pk, MATRIX_SEED_BYTES, &ctx2);
+    cshake256_inc_ctx_release(&ctx2);
 
     for (uint8_t i = 0; i < DIM; i++) {
         noise(sk_expanded[i], &ctx, i);
@@ -89,6 +92,7 @@ void PQCLEAN_BABYBEAREPHEM_CLEAN_get_pubkey(uint8_t *pk, const uint8_t *sk) {
         }
         PQCLEAN_BABYBEAREPHEM_CLEAN_contract(&pk[MATRIX_SEED_BYTES + i * GF_BYTES], c);
     }
+    cshake256_inc_ctx_release(&ctx);
 }
 
 /* Encapsulate a shared secret and return it */
@@ -135,6 +139,8 @@ void PQCLEAN_BABYBEAREPHEM_CLEAN_encapsulate(
 
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(tbi, ENC_SEED_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
+
     threebears_hash_init(&ctx, HASH_PURPOSE_ENCAPS);
     cshake256_inc_absorb(&ctx, pk, MATRIX_SEED_BYTES);
     cshake256_inc_absorb(&ctx, tbi, ENC_SEED_BYTES);
@@ -152,6 +158,7 @@ void PQCLEAN_BABYBEAREPHEM_CLEAN_encapsulate(
 
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(shared_secret, SHARED_SECRET_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 }
 
 /* Decapsulate a shared secret and return it */
@@ -199,6 +206,7 @@ void PQCLEAN_BABYBEAREPHEM_CLEAN_decapsulate(
     /* Recalculate matrix seed */
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(matrix_seed, MATRIX_SEED_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 
     /* Re-run the key derivation from encaps */
     threebears_hash_init(&ctx, HASH_PURPOSE_ENCAPS);
@@ -207,4 +215,5 @@ void PQCLEAN_BABYBEAREPHEM_CLEAN_decapsulate(
     cshake256_inc_absorb(&ctx, &lpr_data[(ENC_BITS * LPR_BITS + 7) / 8], IV_BYTES);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(shared_secret, SHARED_SECRET_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 }

--- a/crypto_kem/babybear/clean/threebears.c
+++ b/crypto_kem/babybear/clean/threebears.c
@@ -38,6 +38,7 @@ static void uniform(gf_t matrix, const uint8_t *seed, uint8_t iv) {
     cshake256_inc_absorb(&ctx, &iv, 1);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(c, sizeof(c), &ctx);
+    cshake256_inc_ctx_release(&ctx);
     PQCLEAN_BABYBEAR_CLEAN_expand(matrix, c);
 }
 
@@ -56,13 +57,14 @@ static void noise(gf_t x, const shake256incctx *ctx, uint8_t iv) {
     uint8_t c[DIGITS];
     shake256incctx ctx2;
 
-    memcpy(&ctx2, ctx, sizeof(ctx2));
+    cshake256_inc_ctx_clone(&ctx2, ctx);
     cshake256_inc_absorb(&ctx2, &iv, 1);
     cshake256_inc_finalize(&ctx2);
     cshake256_inc_squeeze(c, DIGITS, &ctx2);
     for (size_t i = 0; i < DIGITS; i++) {
         x[i] = (limb_t)(psi(c[i]) + PQCLEAN_BABYBEAR_CLEAN_modulus(i));
     }
+    cshake256_inc_ctx_release(&ctx2);
 }
 
 /* Expand public key from private key */
@@ -74,9 +76,10 @@ void PQCLEAN_BABYBEAR_CLEAN_get_pubkey(uint8_t *pk, const uint8_t *sk) {
     threebears_hash_init(&ctx, HASH_PURPOSE_KEYGEN);
     cshake256_inc_absorb(&ctx, sk, PRIVATE_KEY_BYTES);
 
-    memcpy(&ctx2, &ctx, sizeof(ctx2));
+    cshake256_inc_ctx_clone(&ctx2, &ctx);
     cshake256_inc_finalize(&ctx2);
     cshake256_inc_squeeze(pk, MATRIX_SEED_BYTES, &ctx2);
+    cshake256_inc_ctx_release(&ctx2);
 
     for (uint8_t i = 0; i < DIM; i++) {
         noise(sk_expanded[i], &ctx, i);
@@ -89,6 +92,7 @@ void PQCLEAN_BABYBEAR_CLEAN_get_pubkey(uint8_t *pk, const uint8_t *sk) {
         }
         PQCLEAN_BABYBEAR_CLEAN_contract(&pk[MATRIX_SEED_BYTES + i * GF_BYTES], c);
     }
+    cshake256_inc_ctx_release(&ctx);
 }
 
 /* Encapsulate a shared secret and return it */
@@ -147,6 +151,7 @@ void PQCLEAN_BABYBEAR_CLEAN_encapsulate(
 
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(shared_secret, SHARED_SECRET_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 }
 
 /* Decapsulate a shared secret and return it */
@@ -210,6 +215,7 @@ void PQCLEAN_BABYBEAR_CLEAN_decapsulate(
     cshake256_inc_absorb(&ctx, &sep, 1);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(prfk, PRF_KEY_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 
     /* Calculate PRF */
     threebears_hash_init(&ctx, HASH_PURPOSE_PRF);
@@ -217,6 +223,7 @@ void PQCLEAN_BABYBEAR_CLEAN_decapsulate(
     cshake256_inc_absorb(&ctx, capsule, CAPSULE_BYTES);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(prfout, SHARED_SECRET_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 
     for (size_t i = 0; i < SHARED_SECRET_BYTES; i++) {
         shared_secret[i] = (uint8_t)((shared_secret[i] & ok) | (prfout[i] & ~ok));

--- a/crypto_kem/kyber1024-90s/avx2/aes256ctr.c
+++ b/crypto_kem/kyber1024-90s/avx2/aes256ctr.c
@@ -174,4 +174,3 @@ void PQCLEAN_KYBER102490S_AVX2_aes256ctr_prf(uint8_t *out,
         }
     }
 }
-

--- a/crypto_kem/kyber1024-90s/avx2/symmetric.h
+++ b/crypto_kem/kyber1024-90s/avx2/symmetric.h
@@ -11,6 +11,7 @@
 #define hash_g(OUT, IN, INBYTES) sha512((OUT), (IN), (INBYTES))
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER102490S_AVX2_aes256ctr_init((STATE), (IN), (Y) + ((uint16_t)(X) << 8))
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) PQCLEAN_KYBER102490S_AVX2_aes256ctr_squeezeblocks((OUT), (OUTBLOCKS), (STATE))
+#define xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER102490S_AVX2_aes256ctr_prf((OUT), (OUTBYTES), (KEY), (NONCE))
 #define kdf(OUT, IN, INBYTES) sha256((OUT), (IN), (INBYTES))
 

--- a/crypto_kem/kyber1024-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber1024-90s/clean/aes256ctr.c
@@ -93,3 +93,8 @@ void PQCLEAN_KYBER102490S_CLEAN_aes256xof_squeezeblocks(uint8_t *out, size_t nbl
     aes256_ctr_xof(out, nblocks * 64, s->iv, s->ctr, &s->sk_exp);
     s->ctr += (uint32_t) (4 * nblocks);
 }
+
+/** Free the AES ctx **/
+void PQCLEAN_KYBER102490S_CLEAN_aes256xof_ctx_release(aes256xof_ctx *s) {
+    aes256_ctx_release(&s->sk_exp);
+}

--- a/crypto_kem/kyber1024-90s/clean/aes256ctr.h
+++ b/crypto_kem/kyber1024-90s/clean/aes256ctr.h
@@ -15,5 +15,6 @@ typedef struct {
 void PQCLEAN_KYBER102490S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const uint8_t *key, uint8_t nonce);
 void PQCLEAN_KYBER102490S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t *key, uint8_t x, uint8_t y);
 void PQCLEAN_KYBER102490S_CLEAN_aes256xof_squeezeblocks(uint8_t *out, size_t nblocks, aes256xof_ctx *s);
+void PQCLEAN_KYBER102490S_CLEAN_aes256xof_ctx_release(aes256xof_ctx *s);
 
 #endif

--- a/crypto_kem/kyber1024-90s/clean/indcpa.c
+++ b/crypto_kem/kyber1024-90s/clean/indcpa.c
@@ -169,6 +169,7 @@ static void gen_matrix(polyvec *a, const uint8_t *seed, int transposed) {
             }
         }
     }
+    xof_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_kem/kyber1024-90s/clean/symmetric.h
+++ b/crypto_kem/kyber1024-90s/clean/symmetric.h
@@ -11,6 +11,7 @@
 #define hash_g(OUT, IN, INBYTES) sha512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER102490S_CLEAN_aes256xof_absorb(STATE, IN, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) PQCLEAN_KYBER102490S_CLEAN_aes256xof_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define xof_ctx_release(STATE) PQCLEAN_KYBER102490S_CLEAN_aes256xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER102490S_CLEAN_aes256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) sha256(OUT, IN, INBYTES)
 

--- a/crypto_kem/kyber1024/avx2/symmetric.h
+++ b/crypto_kem/kyber1024/avx2/symmetric.h
@@ -17,6 +17,7 @@ void PQCLEAN_KYBER1024_AVX2_shake256_prf(uint8_t *output, size_t outlen, const u
 #define hash_g(OUT, IN, INBYTES) sha3_512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER1024_AVX2_kyber_shake128_absorb(STATE, IN, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER1024_AVX2_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) shake256(OUT, KYBER_SSBYTES, IN, INBYTES)
 

--- a/crypto_kem/kyber1024/clean/indcpa.c
+++ b/crypto_kem/kyber1024/clean/indcpa.c
@@ -169,6 +169,7 @@ static void gen_matrix(polyvec *a, const uint8_t *seed, int transposed) {
             }
         }
     }
+    xof_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_kem/kyber1024/clean/symmetric.h
+++ b/crypto_kem/kyber1024/clean/symmetric.h
@@ -18,6 +18,7 @@ void PQCLEAN_KYBER1024_CLEAN_shake256_prf(uint8_t *output, size_t outlen, const 
 #define hash_g(OUT, IN, INBYTES) sha3_512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER1024_CLEAN_kyber_shake128_absorb(STATE, IN, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) PQCLEAN_KYBER1024_CLEAN_kyber_shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER1024_CLEAN_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) shake256(OUT, KYBER_SSBYTES, IN, INBYTES)
 

--- a/crypto_kem/kyber512-90s/avx2/aes256ctr.c
+++ b/crypto_kem/kyber512-90s/avx2/aes256ctr.c
@@ -174,4 +174,3 @@ void PQCLEAN_KYBER51290S_AVX2_aes256ctr_prf(uint8_t *out,
         }
     }
 }
-

--- a/crypto_kem/kyber512-90s/avx2/symmetric.h
+++ b/crypto_kem/kyber512-90s/avx2/symmetric.h
@@ -11,6 +11,7 @@
 #define hash_g(OUT, IN, INBYTES) sha512((OUT), (IN), (INBYTES))
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER51290S_AVX2_aes256ctr_init((STATE), (IN), (Y) + ((uint16_t)(X) << 8))
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) PQCLEAN_KYBER51290S_AVX2_aes256ctr_squeezeblocks((OUT), (OUTBLOCKS), (STATE))
+#define xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER51290S_AVX2_aes256ctr_prf((OUT), (OUTBYTES), (KEY), (NONCE))
 #define kdf(OUT, IN, INBYTES) sha256((OUT), (IN), (INBYTES))
 

--- a/crypto_kem/kyber512-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber512-90s/clean/aes256ctr.c
@@ -93,3 +93,8 @@ void PQCLEAN_KYBER51290S_CLEAN_aes256xof_squeezeblocks(uint8_t *out, size_t nblo
     aes256_ctr_xof(out, nblocks * 64, s->iv, s->ctr, &s->sk_exp);
     s->ctr += (uint32_t) (4 * nblocks);
 }
+
+/** Free the AES ctx **/
+void PQCLEAN_KYBER51290S_CLEAN_aes256xof_ctx_release(aes256xof_ctx *s) {
+    aes256_ctx_release(&s->sk_exp);
+}

--- a/crypto_kem/kyber512-90s/clean/aes256ctr.h
+++ b/crypto_kem/kyber512-90s/clean/aes256ctr.h
@@ -15,5 +15,6 @@ typedef struct {
 void PQCLEAN_KYBER51290S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const uint8_t *key, uint8_t nonce);
 void PQCLEAN_KYBER51290S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t *key, uint8_t x, uint8_t y);
 void PQCLEAN_KYBER51290S_CLEAN_aes256xof_squeezeblocks(uint8_t *out, size_t nblocks, aes256xof_ctx *s);
+void PQCLEAN_KYBER51290S_CLEAN_aes256xof_ctx_release(aes256xof_ctx *s);
 
 #endif

--- a/crypto_kem/kyber512-90s/clean/indcpa.c
+++ b/crypto_kem/kyber512-90s/clean/indcpa.c
@@ -169,6 +169,7 @@ static void gen_matrix(polyvec *a, const uint8_t *seed, int transposed) {
             }
         }
     }
+    xof_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_kem/kyber512-90s/clean/symmetric.h
+++ b/crypto_kem/kyber512-90s/clean/symmetric.h
@@ -11,6 +11,7 @@
 #define hash_g(OUT, IN, INBYTES) sha512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER51290S_CLEAN_aes256xof_absorb(STATE, IN, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) PQCLEAN_KYBER51290S_CLEAN_aes256xof_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define xof_ctx_release(STATE) PQCLEAN_KYBER51290S_CLEAN_aes256xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER51290S_CLEAN_aes256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) sha256(OUT, IN, INBYTES)
 

--- a/crypto_kem/kyber512/avx2/symmetric.h
+++ b/crypto_kem/kyber512/avx2/symmetric.h
@@ -17,6 +17,7 @@ void PQCLEAN_KYBER512_AVX2_shake256_prf(uint8_t *output, size_t outlen, const ui
 #define hash_g(OUT, IN, INBYTES) sha3_512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER512_AVX2_kyber_shake128_absorb(STATE, IN, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER512_AVX2_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) shake256(OUT, KYBER_SSBYTES, IN, INBYTES)
 

--- a/crypto_kem/kyber512/clean/indcpa.c
+++ b/crypto_kem/kyber512/clean/indcpa.c
@@ -169,6 +169,7 @@ static void gen_matrix(polyvec *a, const uint8_t *seed, int transposed) {
             }
         }
     }
+    xof_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_kem/kyber512/clean/symmetric.h
+++ b/crypto_kem/kyber512/clean/symmetric.h
@@ -18,6 +18,7 @@ void PQCLEAN_KYBER512_CLEAN_shake256_prf(uint8_t *output, size_t outlen, const u
 #define hash_g(OUT, IN, INBYTES) sha3_512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER512_CLEAN_kyber_shake128_absorb(STATE, IN, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) PQCLEAN_KYBER512_CLEAN_kyber_shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER512_CLEAN_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) shake256(OUT, KYBER_SSBYTES, IN, INBYTES)
 

--- a/crypto_kem/kyber768-90s/avx2/aes256ctr.c
+++ b/crypto_kem/kyber768-90s/avx2/aes256ctr.c
@@ -174,4 +174,3 @@ void PQCLEAN_KYBER76890S_AVX2_aes256ctr_prf(uint8_t *out,
         }
     }
 }
-

--- a/crypto_kem/kyber768-90s/avx2/symmetric.h
+++ b/crypto_kem/kyber768-90s/avx2/symmetric.h
@@ -11,6 +11,7 @@
 #define hash_g(OUT, IN, INBYTES) sha512((OUT), (IN), (INBYTES))
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER76890S_AVX2_aes256ctr_init((STATE), (IN), (Y) + ((uint16_t)(X) << 8))
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) PQCLEAN_KYBER76890S_AVX2_aes256ctr_squeezeblocks((OUT), (OUTBLOCKS), (STATE))
+#define xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER76890S_AVX2_aes256ctr_prf((OUT), (OUTBYTES), (KEY), (NONCE))
 #define kdf(OUT, IN, INBYTES) sha256((OUT), (IN), (INBYTES))
 

--- a/crypto_kem/kyber768-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber768-90s/clean/aes256ctr.c
@@ -93,3 +93,8 @@ void PQCLEAN_KYBER76890S_CLEAN_aes256xof_squeezeblocks(uint8_t *out, size_t nblo
     aes256_ctr_xof(out, nblocks * 64, s->iv, s->ctr, &s->sk_exp);
     s->ctr += (uint32_t) (4 * nblocks);
 }
+
+/** Free the AES ctx **/
+void PQCLEAN_KYBER76890S_CLEAN_aes256xof_ctx_release(aes256xof_ctx *s) {
+    aes256_ctx_release(&s->sk_exp);
+}

--- a/crypto_kem/kyber768-90s/clean/aes256ctr.h
+++ b/crypto_kem/kyber768-90s/clean/aes256ctr.h
@@ -15,5 +15,6 @@ typedef struct {
 void PQCLEAN_KYBER76890S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const uint8_t *key, uint8_t nonce);
 void PQCLEAN_KYBER76890S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t *key, uint8_t x, uint8_t y);
 void PQCLEAN_KYBER76890S_CLEAN_aes256xof_squeezeblocks(uint8_t *out, size_t nblocks, aes256xof_ctx *s);
+void PQCLEAN_KYBER76890S_CLEAN_aes256xof_ctx_release(aes256xof_ctx *s);
 
 #endif

--- a/crypto_kem/kyber768-90s/clean/indcpa.c
+++ b/crypto_kem/kyber768-90s/clean/indcpa.c
@@ -169,6 +169,7 @@ static void gen_matrix(polyvec *a, const uint8_t *seed, int transposed) {
             }
         }
     }
+    xof_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_kem/kyber768-90s/clean/symmetric.h
+++ b/crypto_kem/kyber768-90s/clean/symmetric.h
@@ -11,6 +11,7 @@
 #define hash_g(OUT, IN, INBYTES) sha512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER76890S_CLEAN_aes256xof_absorb(STATE, IN, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) PQCLEAN_KYBER76890S_CLEAN_aes256xof_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define xof_ctx_release(STATE) PQCLEAN_KYBER76890S_CLEAN_aes256xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER76890S_CLEAN_aes256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) sha256(OUT, IN, INBYTES)
 

--- a/crypto_kem/kyber768/avx2/symmetric.h
+++ b/crypto_kem/kyber768/avx2/symmetric.h
@@ -17,6 +17,7 @@ void PQCLEAN_KYBER768_AVX2_shake256_prf(uint8_t *output, size_t outlen, const ui
 #define hash_g(OUT, IN, INBYTES) sha3_512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER768_AVX2_kyber_shake128_absorb(STATE, IN, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER768_AVX2_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) shake256(OUT, KYBER_SSBYTES, IN, INBYTES)
 

--- a/crypto_kem/kyber768/clean/indcpa.c
+++ b/crypto_kem/kyber768/clean/indcpa.c
@@ -169,6 +169,7 @@ static void gen_matrix(polyvec *a, const uint8_t *seed, int transposed) {
             }
         }
     }
+    xof_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_kem/kyber768/clean/symmetric.h
+++ b/crypto_kem/kyber768/clean/symmetric.h
@@ -18,6 +18,7 @@ void PQCLEAN_KYBER768_CLEAN_shake256_prf(uint8_t *output, size_t outlen, const u
 #define hash_g(OUT, IN, INBYTES) sha3_512(OUT, IN, INBYTES)
 #define xof_absorb(STATE, IN, X, Y) PQCLEAN_KYBER768_CLEAN_kyber_shake128_absorb(STATE, IN, X, Y)
 #define xof_squeezeblocks(OUT, OUTBLOCKS, STATE) PQCLEAN_KYBER768_CLEAN_kyber_shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define xof_ctx_release(STATE)
 #define prf(OUT, OUTBYTES, KEY, NONCE) PQCLEAN_KYBER768_CLEAN_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define kdf(OUT, IN, INBYTES) shake256(OUT, KYBER_SSBYTES, IN, INBYTES)
 

--- a/crypto_kem/mamabear/clean/threebears.c
+++ b/crypto_kem/mamabear/clean/threebears.c
@@ -38,6 +38,7 @@ static void uniform(gf_t matrix, const uint8_t *seed, uint8_t iv) {
     cshake256_inc_absorb(&ctx, &iv, 1);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(c, sizeof(c), &ctx);
+    cshake256_inc_ctx_release(&ctx);
     PQCLEAN_MAMABEAR_CLEAN_expand(matrix, c);
 }
 
@@ -56,13 +57,14 @@ static void noise(gf_t x, const shake256incctx *ctx, uint8_t iv) {
     uint8_t c[DIGITS];
     shake256incctx ctx2;
 
-    memcpy(&ctx2, ctx, sizeof(ctx2));
+    cshake256_inc_ctx_clone(&ctx2, ctx);
     cshake256_inc_absorb(&ctx2, &iv, 1);
     cshake256_inc_finalize(&ctx2);
     cshake256_inc_squeeze(c, DIGITS, &ctx2);
     for (size_t i = 0; i < DIGITS; i++) {
         x[i] = (limb_t)(psi(c[i]) + PQCLEAN_MAMABEAR_CLEAN_modulus(i));
     }
+    cshake256_inc_ctx_release(&ctx2);
 }
 
 /* Expand public key from private key */
@@ -74,9 +76,10 @@ void PQCLEAN_MAMABEAR_CLEAN_get_pubkey(uint8_t *pk, const uint8_t *sk) {
     threebears_hash_init(&ctx, HASH_PURPOSE_KEYGEN);
     cshake256_inc_absorb(&ctx, sk, PRIVATE_KEY_BYTES);
 
-    memcpy(&ctx2, &ctx, sizeof(ctx2));
+    cshake256_inc_ctx_clone(&ctx2, &ctx);
     cshake256_inc_finalize(&ctx2);
     cshake256_inc_squeeze(pk, MATRIX_SEED_BYTES, &ctx2);
+    cshake256_inc_ctx_release(&ctx2);
 
     for (uint8_t i = 0; i < DIM; i++) {
         noise(sk_expanded[i], &ctx, i);
@@ -89,6 +92,7 @@ void PQCLEAN_MAMABEAR_CLEAN_get_pubkey(uint8_t *pk, const uint8_t *sk) {
         }
         PQCLEAN_MAMABEAR_CLEAN_contract(&pk[MATRIX_SEED_BYTES + i * GF_BYTES], c);
     }
+    cshake256_inc_ctx_release(&ctx);
 }
 
 /* Encapsulate a shared secret and return it */
@@ -147,6 +151,7 @@ void PQCLEAN_MAMABEAR_CLEAN_encapsulate(
 
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(shared_secret, SHARED_SECRET_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 }
 
 /* Decapsulate a shared secret and return it */
@@ -210,6 +215,7 @@ void PQCLEAN_MAMABEAR_CLEAN_decapsulate(
     cshake256_inc_absorb(&ctx, &sep, 1);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(prfk, PRF_KEY_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 
     /* Calculate PRF */
     threebears_hash_init(&ctx, HASH_PURPOSE_PRF);
@@ -217,6 +223,7 @@ void PQCLEAN_MAMABEAR_CLEAN_decapsulate(
     cshake256_inc_absorb(&ctx, capsule, CAPSULE_BYTES);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(prfout, SHARED_SECRET_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 
     for (size_t i = 0; i < SHARED_SECRET_BYTES; i++) {
         shared_secret[i] = (uint8_t)((shared_secret[i] & ok) | (prfout[i] & ~ok));

--- a/crypto_kem/mceliece8192128f/sse/Makefile
+++ b/crypto_kem/mceliece8192128f/sse/Makefile
@@ -10,7 +10,7 @@ SOURCES = aes256ctr.c benes.c bm.c controlbits.c decrypt.c encrypt.c fft.c \
 HEADERS = aes256ctr.h api.h benes.h bm.h controlbits.h crypto_hash.h \
 		  decrypt.h encrypt.h fft.h fft_tr.h gf.h params.h \
 		  pk_gen.h sk_gen.h transpose.h util.h vec128.h \
-		  consts.inc scalars_2x.inc scalars_4x.inc powers.data
+		  consts.inc scalars_2x.inc scalars_4x.inc powers.inc
 
 OBJECTS = aes256ctr.o benes.o bm.o controlbits.o decrypt.o encrypt.o fft.o \
 		  fft_tr.o gf.o operations.o pk_gen.o sk_gen.o util.o vec128.o \

--- a/crypto_kem/papabear-ephem/clean/threebears.c
+++ b/crypto_kem/papabear-ephem/clean/threebears.c
@@ -38,6 +38,7 @@ static void uniform(gf_t matrix, const uint8_t *seed, uint8_t iv) {
     cshake256_inc_absorb(&ctx, &iv, 1);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(c, sizeof(c), &ctx);
+    cshake256_inc_ctx_release(&ctx);
     PQCLEAN_PAPABEAREPHEM_CLEAN_expand(matrix, c);
 }
 
@@ -56,13 +57,14 @@ static void noise(gf_t x, const shake256incctx *ctx, uint8_t iv) {
     uint8_t c[DIGITS];
     shake256incctx ctx2;
 
-    memcpy(&ctx2, ctx, sizeof(ctx2));
+    cshake256_inc_ctx_clone(&ctx2, ctx);
     cshake256_inc_absorb(&ctx2, &iv, 1);
     cshake256_inc_finalize(&ctx2);
     cshake256_inc_squeeze(c, DIGITS, &ctx2);
     for (size_t i = 0; i < DIGITS; i++) {
         x[i] = (limb_t)(psi(c[i]) + PQCLEAN_PAPABEAREPHEM_CLEAN_modulus(i));
     }
+    cshake256_inc_ctx_release(&ctx2);
 }
 
 /* Expand public key from private key */
@@ -74,9 +76,10 @@ void PQCLEAN_PAPABEAREPHEM_CLEAN_get_pubkey(uint8_t *pk, const uint8_t *sk) {
     threebears_hash_init(&ctx, HASH_PURPOSE_KEYGEN);
     cshake256_inc_absorb(&ctx, sk, PRIVATE_KEY_BYTES);
 
-    memcpy(&ctx2, &ctx, sizeof(ctx2));
+    cshake256_inc_ctx_clone(&ctx2, &ctx);
     cshake256_inc_finalize(&ctx2);
     cshake256_inc_squeeze(pk, MATRIX_SEED_BYTES, &ctx2);
+    cshake256_inc_ctx_release(&ctx2);
 
     for (uint8_t i = 0; i < DIM; i++) {
         noise(sk_expanded[i], &ctx, i);
@@ -89,6 +92,7 @@ void PQCLEAN_PAPABEAREPHEM_CLEAN_get_pubkey(uint8_t *pk, const uint8_t *sk) {
         }
         PQCLEAN_PAPABEAREPHEM_CLEAN_contract(&pk[MATRIX_SEED_BYTES + i * GF_BYTES], c);
     }
+    cshake256_inc_ctx_release(&ctx);
 }
 
 /* Encapsulate a shared secret and return it */
@@ -135,6 +139,8 @@ void PQCLEAN_PAPABEAREPHEM_CLEAN_encapsulate(
 
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(tbi, ENC_SEED_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
+
     threebears_hash_init(&ctx, HASH_PURPOSE_ENCAPS);
     cshake256_inc_absorb(&ctx, pk, MATRIX_SEED_BYTES);
     cshake256_inc_absorb(&ctx, tbi, ENC_SEED_BYTES);
@@ -152,6 +158,7 @@ void PQCLEAN_PAPABEAREPHEM_CLEAN_encapsulate(
 
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(shared_secret, SHARED_SECRET_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 }
 
 /* Decapsulate a shared secret and return it */
@@ -199,6 +206,7 @@ void PQCLEAN_PAPABEAREPHEM_CLEAN_decapsulate(
     /* Recalculate matrix seed */
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(matrix_seed, MATRIX_SEED_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 
     /* Re-run the key derivation from encaps */
     threebears_hash_init(&ctx, HASH_PURPOSE_ENCAPS);
@@ -207,4 +215,5 @@ void PQCLEAN_PAPABEAREPHEM_CLEAN_decapsulate(
     cshake256_inc_absorb(&ctx, &lpr_data[(ENC_BITS * LPR_BITS + 7) / 8], IV_BYTES);
     cshake256_inc_finalize(&ctx);
     cshake256_inc_squeeze(shared_secret, SHARED_SECRET_BYTES, &ctx);
+    cshake256_inc_ctx_release(&ctx);
 }

--- a/crypto_sign/dilithium2/avx2/poly.c
+++ b/crypto_sign/dilithium2/avx2/poly.c
@@ -356,6 +356,7 @@ void PQCLEAN_DILITHIUM2_AVX2_poly_uniform(poly *a,
         stream128_squeezeblocks(buf + off, 1, &state);
         ctr += rej_uniform_ref(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream128_ctx_release(&state);
 }
 
 void PQCLEAN_DILITHIUM2_AVX2_poly_uniform_4x(poly *a0,
@@ -481,6 +482,7 @@ void PQCLEAN_DILITHIUM2_AVX2_poly_uniform_eta(
         stream128_squeezeblocks(buf, 1, &state);
         ctr += rej_eta_ref(a->coeffs + ctr, N - ctr, buf, STREAM128_BLOCKBYTES);
     }
+    stream128_ctx_release(&state);
 }
 
 void PQCLEAN_DILITHIUM2_AVX2_poly_uniform_eta_4x(
@@ -618,6 +620,7 @@ void PQCLEAN_DILITHIUM2_AVX2_poly_uniform_gamma1m1(
         stream256_squeezeblocks(buf + off, 1, &state);
         ctr += rej_gamma1m1_ref(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream256_ctx_release(&state);
 }
 
 void PQCLEAN_DILITHIUM2_AVX2_poly_uniform_gamma1m1_4x(poly *a0,

--- a/crypto_sign/dilithium2/avx2/symmetric.h
+++ b/crypto_sign/dilithium2/avx2/symmetric.h
@@ -10,8 +10,10 @@
 #define crh(OUT, IN, INBYTES) shake256(OUT, CRHBYTES, IN, INBYTES)
 #define stream128_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM2_AVX2_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_ctx_release(STATE) shake128_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM2_AVX2_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_ctx_release(STATE) shake256_ctx_release(STATE)
 
 #define STREAM128_BLOCKBYTES SHAKE128_RATE
 #define STREAM256_BLOCKBYTES SHAKE256_RATE

--- a/crypto_sign/dilithium2/clean/poly.c
+++ b/crypto_sign/dilithium2/clean/poly.c
@@ -315,6 +315,7 @@ void PQCLEAN_DILITHIUM2_CLEAN_poly_uniform(poly *a,
         stream128_squeezeblocks(buf + off, 1, &state);
         ctr += rej_uniform(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream128_ctx_release(&state);
 }
 
 /*************************************************
@@ -385,6 +386,7 @@ void PQCLEAN_DILITHIUM2_CLEAN_poly_uniform_eta(poly *a,
         stream128_squeezeblocks(buf, 1, &state);
         ctr += rej_eta(a->coeffs + ctr, N - ctr, buf, STREAM128_BLOCKBYTES);
     }
+    stream128_ctx_release(&state);
 }
 
 /*************************************************
@@ -472,6 +474,7 @@ void PQCLEAN_DILITHIUM2_CLEAN_poly_uniform_gamma1m1(poly *a,
         stream256_squeezeblocks(buf + off, 1, &state);
         ctr += rej_gamma1m1(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream256_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_sign/dilithium2/clean/symmetric.h
+++ b/crypto_sign/dilithium2/clean/symmetric.h
@@ -10,8 +10,10 @@
 #define crh(OUT, IN, INBYTES) shake256(OUT, CRHBYTES, IN, INBYTES)
 #define stream128_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM2_CLEAN_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_ctx_release(STATE) shake128_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM2_CLEAN_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_ctx_release(STATE) shake256_ctx_release(STATE)
 
 #define STREAM128_BLOCKBYTES SHAKE128_RATE
 #define STREAM256_BLOCKBYTES SHAKE256_RATE

--- a/crypto_sign/dilithium3/avx2/poly.c
+++ b/crypto_sign/dilithium3/avx2/poly.c
@@ -356,6 +356,7 @@ void PQCLEAN_DILITHIUM3_AVX2_poly_uniform(poly *a,
         stream128_squeezeblocks(buf + off, 1, &state);
         ctr += rej_uniform_ref(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream128_ctx_release(&state);
 }
 
 void PQCLEAN_DILITHIUM3_AVX2_poly_uniform_4x(poly *a0,
@@ -481,6 +482,7 @@ void PQCLEAN_DILITHIUM3_AVX2_poly_uniform_eta(
         stream128_squeezeblocks(buf, 1, &state);
         ctr += rej_eta_ref(a->coeffs + ctr, N - ctr, buf, STREAM128_BLOCKBYTES);
     }
+    stream128_ctx_release(&state);
 }
 
 void PQCLEAN_DILITHIUM3_AVX2_poly_uniform_eta_4x(
@@ -618,6 +620,7 @@ void PQCLEAN_DILITHIUM3_AVX2_poly_uniform_gamma1m1(
         stream256_squeezeblocks(buf + off, 1, &state);
         ctr += rej_gamma1m1_ref(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream256_ctx_release(&state);
 }
 
 void PQCLEAN_DILITHIUM3_AVX2_poly_uniform_gamma1m1_4x(poly *a0,

--- a/crypto_sign/dilithium3/avx2/symmetric.h
+++ b/crypto_sign/dilithium3/avx2/symmetric.h
@@ -10,8 +10,10 @@
 #define crh(OUT, IN, INBYTES) shake256(OUT, CRHBYTES, IN, INBYTES)
 #define stream128_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM3_AVX2_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_ctx_release(STATE) shake128_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM3_AVX2_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_ctx_release(STATE) shake256_ctx_release(STATE)
 
 #define STREAM128_BLOCKBYTES SHAKE128_RATE
 #define STREAM256_BLOCKBYTES SHAKE256_RATE

--- a/crypto_sign/dilithium3/clean/poly.c
+++ b/crypto_sign/dilithium3/clean/poly.c
@@ -315,6 +315,7 @@ void PQCLEAN_DILITHIUM3_CLEAN_poly_uniform(poly *a,
         stream128_squeezeblocks(buf + off, 1, &state);
         ctr += rej_uniform(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream128_ctx_release(&state);
 }
 
 /*************************************************
@@ -385,6 +386,7 @@ void PQCLEAN_DILITHIUM3_CLEAN_poly_uniform_eta(poly *a,
         stream128_squeezeblocks(buf, 1, &state);
         ctr += rej_eta(a->coeffs + ctr, N - ctr, buf, STREAM128_BLOCKBYTES);
     }
+    stream128_ctx_release(&state);
 }
 
 /*************************************************
@@ -472,6 +474,7 @@ void PQCLEAN_DILITHIUM3_CLEAN_poly_uniform_gamma1m1(poly *a,
         stream256_squeezeblocks(buf + off, 1, &state);
         ctr += rej_gamma1m1(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream256_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_sign/dilithium3/clean/symmetric.h
+++ b/crypto_sign/dilithium3/clean/symmetric.h
@@ -10,8 +10,10 @@
 #define crh(OUT, IN, INBYTES) shake256(OUT, CRHBYTES, IN, INBYTES)
 #define stream128_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM3_CLEAN_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_ctx_release(STATE) shake128_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM3_CLEAN_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_ctx_release(STATE) shake256_ctx_release(STATE)
 
 #define STREAM128_BLOCKBYTES SHAKE128_RATE
 #define STREAM256_BLOCKBYTES SHAKE256_RATE

--- a/crypto_sign/dilithium4/avx2/poly.c
+++ b/crypto_sign/dilithium4/avx2/poly.c
@@ -356,6 +356,7 @@ void PQCLEAN_DILITHIUM4_AVX2_poly_uniform(poly *a,
         stream128_squeezeblocks(buf + off, 1, &state);
         ctr += rej_uniform_ref(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream128_ctx_release(&state);
 }
 
 void PQCLEAN_DILITHIUM4_AVX2_poly_uniform_4x(poly *a0,
@@ -481,6 +482,7 @@ void PQCLEAN_DILITHIUM4_AVX2_poly_uniform_eta(
         stream128_squeezeblocks(buf, 1, &state);
         ctr += rej_eta_ref(a->coeffs + ctr, N - ctr, buf, STREAM128_BLOCKBYTES);
     }
+    stream128_ctx_release(&state);
 }
 
 void PQCLEAN_DILITHIUM4_AVX2_poly_uniform_eta_4x(
@@ -618,6 +620,7 @@ void PQCLEAN_DILITHIUM4_AVX2_poly_uniform_gamma1m1(
         stream256_squeezeblocks(buf + off, 1, &state);
         ctr += rej_gamma1m1_ref(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream256_ctx_release(&state);
 }
 
 void PQCLEAN_DILITHIUM4_AVX2_poly_uniform_gamma1m1_4x(poly *a0,

--- a/crypto_sign/dilithium4/avx2/symmetric.h
+++ b/crypto_sign/dilithium4/avx2/symmetric.h
@@ -10,8 +10,10 @@
 #define crh(OUT, IN, INBYTES) shake256(OUT, CRHBYTES, IN, INBYTES)
 #define stream128_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM4_AVX2_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_ctx_release(STATE) shake128_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM4_AVX2_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_ctx_release(STATE) shake256_ctx_release(STATE)
 
 #define STREAM128_BLOCKBYTES SHAKE128_RATE
 #define STREAM256_BLOCKBYTES SHAKE256_RATE

--- a/crypto_sign/dilithium4/clean/poly.c
+++ b/crypto_sign/dilithium4/clean/poly.c
@@ -315,6 +315,7 @@ void PQCLEAN_DILITHIUM4_CLEAN_poly_uniform(poly *a,
         stream128_squeezeblocks(buf + off, 1, &state);
         ctr += rej_uniform(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream128_ctx_release(&state);
 }
 
 /*************************************************
@@ -385,6 +386,7 @@ void PQCLEAN_DILITHIUM4_CLEAN_poly_uniform_eta(poly *a,
         stream128_squeezeblocks(buf, 1, &state);
         ctr += rej_eta(a->coeffs + ctr, N - ctr, buf, STREAM128_BLOCKBYTES);
     }
+    stream128_ctx_release(&state);
 }
 
 /*************************************************
@@ -472,6 +474,7 @@ void PQCLEAN_DILITHIUM4_CLEAN_poly_uniform_gamma1m1(poly *a,
         stream256_squeezeblocks(buf + off, 1, &state);
         ctr += rej_gamma1m1(a->coeffs + ctr, N - ctr, buf, buflen);
     }
+    stream256_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_sign/dilithium4/clean/symmetric.h
+++ b/crypto_sign/dilithium4/clean/symmetric.h
@@ -10,8 +10,10 @@
 #define crh(OUT, IN, INBYTES) shake256(OUT, CRHBYTES, IN, INBYTES)
 #define stream128_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM4_CLEAN_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_ctx_release(STATE) shake128_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) PQCLEAN_DILITHIUM4_CLEAN_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_ctx_release(STATE) shake256_ctx_release(STATE)
 
 #define STREAM128_BLOCKBYTES SHAKE128_RATE
 #define STREAM256_BLOCKBYTES SHAKE256_RATE

--- a/crypto_sign/falcon-1024/clean/inner.h
+++ b/crypto_sign/falcon-1024/clean/inner.h
@@ -122,6 +122,7 @@ set_fpu_cw(unsigned x) {
 #define inner_shake256_inject(sc, in, len)    shake256_inc_absorb(sc, in, len)
 #define inner_shake256_flip(sc)               shake256_inc_finalize(sc)
 #define inner_shake256_extract(sc, out, len)  shake256_inc_squeeze(out, len, sc)
+#define inner_shake256_ctx_release(sc)        shake256_inc_ctx_release(sc)
 
 
 /* ==================================================================== */

--- a/crypto_sign/falcon-1024/clean/pqclean.c
+++ b/crypto_sign/falcon-1024/clean/pqclean.c
@@ -62,6 +62,7 @@ PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(
     inner_shake256_inject(&rng, seed, sizeof seed);
     inner_shake256_flip(&rng);
     PQCLEAN_FALCON1024_CLEAN_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
+    inner_shake256_ctx_release(&rng);
 
     /*
      * Encode private key.
@@ -186,6 +187,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
     inner_shake256_inject(&sc, m, mlen);
     inner_shake256_flip(&sc);
     PQCLEAN_FALCON1024_CLEAN_hash_to_point_ct(&sc, r.hm, 10, tmp.b);
+    inner_shake256_ctx_release(&sc);
 
     /*
      * Initialize a RNG.
@@ -207,6 +209,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
             return 0;
         }
     }
+    inner_shake256_ctx_release(&sc);
 }
 
 /*
@@ -258,6 +261,7 @@ do_verify(
     inner_shake256_inject(&sc, m, mlen);
     inner_shake256_flip(&sc);
     PQCLEAN_FALCON1024_CLEAN_hash_to_point_ct(&sc, hm, 10, tmp.b);
+    inner_shake256_ctx_release(&sc);
 
     /*
      * Verify signature.

--- a/crypto_sign/falcon-1024/clean/pqclean.c
+++ b/crypto_sign/falcon-1024/clean/pqclean.c
@@ -205,11 +205,11 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
         PQCLEAN_FALCON1024_CLEAN_sign_dyn(r.sig, &sc, f, g, F, G, r.hm, 10, tmp.b);
         v = PQCLEAN_FALCON1024_CLEAN_comp_encode(sigbuf, *sigbuflen, r.sig, 10);
         if (v != 0) {
+            inner_shake256_ctx_release(&sc);
             *sigbuflen = v;
             return 0;
         }
     }
-    inner_shake256_ctx_release(&sc);
 }
 
 /*

--- a/crypto_sign/falcon-512/clean/inner.h
+++ b/crypto_sign/falcon-512/clean/inner.h
@@ -122,6 +122,7 @@ set_fpu_cw(unsigned x) {
 #define inner_shake256_inject(sc, in, len)    shake256_inc_absorb(sc, in, len)
 #define inner_shake256_flip(sc)               shake256_inc_finalize(sc)
 #define inner_shake256_extract(sc, out, len)  shake256_inc_squeeze(out, len, sc)
+#define inner_shake256_ctx_release(sc)        shake256_inc_ctx_release(sc)
 
 
 /* ==================================================================== */

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -187,7 +187,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
     inner_shake256_inject(&sc, m, mlen);
     inner_shake256_flip(&sc);
     PQCLEAN_FALCON512_CLEAN_hash_to_point_ct(&sc, r.hm, 9, tmp.b);
-    innner_shake256_ctx_release(&sc);
+    inner_shake256_ctx_release(&sc);
 
     /*
      * Initialize a RNG.

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -62,6 +62,7 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(
     inner_shake256_inject(&rng, seed, sizeof seed);
     inner_shake256_flip(&rng);
     PQCLEAN_FALCON512_CLEAN_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
+    inner_shake256_ctx_release(&rng);
 
     /*
      * Encode private key.
@@ -186,6 +187,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
     inner_shake256_inject(&sc, m, mlen);
     inner_shake256_flip(&sc);
     PQCLEAN_FALCON512_CLEAN_hash_to_point_ct(&sc, r.hm, 9, tmp.b);
+    innner_shake256_ctx_release(&sc);
 
     /*
      * Initialize a RNG.
@@ -207,6 +209,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
             return 0;
         }
     }
+    inner_shake256_ctx_release(&sc);
 }
 
 /*
@@ -258,6 +261,7 @@ do_verify(
     inner_shake256_inject(&sc, m, mlen);
     inner_shake256_flip(&sc);
     PQCLEAN_FALCON512_CLEAN_hash_to_point_ct(&sc, hm, 9, tmp.b);
+    inner_shake256_ctx_release(&sc);
 
     /*
      * Verify signature.

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -205,11 +205,11 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
         PQCLEAN_FALCON512_CLEAN_sign_dyn(r.sig, &sc, f, g, F, G, r.hm, 9, tmp.b);
         v = PQCLEAN_FALCON512_CLEAN_comp_encode(sigbuf, *sigbuflen, r.sig, 9);
         if (v != 0) {
+            inner_shake256_ctx_release(&sc);
             *sigbuflen = v;
             return 0;
         }
     }
-    inner_shake256_ctx_release(&sc);
 }
 
 /*

--- a/crypto_sign/mqdss-48/clean/gf31.c
+++ b/crypto_sign/mqdss-48/clean/gf31.c
@@ -63,6 +63,7 @@ void PQCLEAN_MQDSS48_CLEAN_gf31_nrand(gf31 *out, int len, const unsigned char *s
             }
         }
     }
+    shake256_ctx_release(&shakestate);
 }
 
 /* Given a seed, samples len gf31 elements, transposed into unsigned range,
@@ -84,6 +85,7 @@ void PQCLEAN_MQDSS48_CLEAN_gf31_nrand_schar(signed char *out, int len, const uns
             }
         }
     }
+    shake256_ctx_release(&shakestate);
 }
 
 /* Unpacks an array of packed GF31 elements to one element per gf31.

--- a/crypto_sign/mqdss-48/clean/sign.c
+++ b/crypto_sign/mqdss-48/clean/sign.c
@@ -120,6 +120,7 @@ int PQCLEAN_MQDSS48_CLEAN_crypto_sign_signature(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(sig, HASH_BYTES, &state); // Compute R.
+    shake256_inc_ctx_release(&state);
 
     memcpy(pk, skbuf, SEED_BYTES);
     PQCLEAN_MQDSS48_CLEAN_gf31_nrand(sk_gf31, N, skbuf + SEED_BYTES, SEED_BYTES);
@@ -133,6 +134,7 @@ int PQCLEAN_MQDSS48_CLEAN_crypto_sign_signature(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(D, HASH_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     sig += HASH_BYTES;  // Compensate for prefixed R.
 
@@ -193,6 +195,8 @@ int PQCLEAN_MQDSS48_CLEAN_crypto_sign_signature(
         PQCLEAN_MQDSS48_CLEAN_vgf31_shorten_unique(t1 + i * N, t1 + i * N);
         PQCLEAN_MQDSS48_CLEAN_vgf31_shorten_unique(e1 + i * N, e1 + i * N);
     }
+    shake256_ctx_release(&shakestate);
+
     PQCLEAN_MQDSS48_CLEAN_gf31_npack(t1packed, t1, N * ROUNDS);
     PQCLEAN_MQDSS48_CLEAN_gf31_npack(e1packed, e1, M * ROUNDS);
 
@@ -264,6 +268,7 @@ int PQCLEAN_MQDSS48_CLEAN_crypto_sign_verify(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(D, HASH_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     sig += HASH_BYTES;
 
@@ -328,6 +333,7 @@ int PQCLEAN_MQDSS48_CLEAN_crypto_sign_verify(
         memcpy(c + HASH_BYTES * (2 * i + (1 - b)), sig + NPACKED_BYTES, HASH_BYTES);
         sig += NPACKED_BYTES + 2 * HASH_BYTES;
     }
+    shake256_ctx_release(&shakestate);
 
     H(c, c, HASH_BYTES * ROUNDS * 2);
     if (memcmp(c, sigma0, HASH_BYTES) != 0) {

--- a/crypto_sign/mqdss-64/clean/gf31.c
+++ b/crypto_sign/mqdss-64/clean/gf31.c
@@ -63,6 +63,7 @@ void PQCLEAN_MQDSS64_CLEAN_gf31_nrand(gf31 *out, int len, const unsigned char *s
             }
         }
     }
+    shake256_ctx_release(&shakestate);
 }
 
 /* Given a seed, samples len gf31 elements, transposed into unsigned range,
@@ -84,6 +85,7 @@ void PQCLEAN_MQDSS64_CLEAN_gf31_nrand_schar(signed char *out, int len, const uns
             }
         }
     }
+    shake256_ctx_release(&shakestate);
 }
 
 /* Unpacks an array of packed GF31 elements to one element per gf31.

--- a/crypto_sign/mqdss-64/clean/sign.c
+++ b/crypto_sign/mqdss-64/clean/sign.c
@@ -120,6 +120,7 @@ int PQCLEAN_MQDSS64_CLEAN_crypto_sign_signature(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(sig, HASH_BYTES, &state); // Compute R.
+    shake256_inc_ctx_release(&state);
 
     memcpy(pk, skbuf, SEED_BYTES);
     PQCLEAN_MQDSS64_CLEAN_gf31_nrand(sk_gf31, N, skbuf + SEED_BYTES, SEED_BYTES);
@@ -133,6 +134,7 @@ int PQCLEAN_MQDSS64_CLEAN_crypto_sign_signature(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(D, HASH_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     sig += HASH_BYTES;  // Compensate for prefixed R.
 
@@ -193,6 +195,8 @@ int PQCLEAN_MQDSS64_CLEAN_crypto_sign_signature(
         PQCLEAN_MQDSS64_CLEAN_vgf31_shorten_unique(t1 + i * N, t1 + i * N);
         PQCLEAN_MQDSS64_CLEAN_vgf31_shorten_unique(e1 + i * N, e1 + i * N);
     }
+    shake256_ctx_release(&shakestate);
+
     PQCLEAN_MQDSS64_CLEAN_gf31_npack(t1packed, t1, N * ROUNDS);
     PQCLEAN_MQDSS64_CLEAN_gf31_npack(e1packed, e1, M * ROUNDS);
 
@@ -264,6 +268,7 @@ int PQCLEAN_MQDSS64_CLEAN_crypto_sign_verify(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(D, HASH_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     sig += HASH_BYTES;
 
@@ -328,6 +333,7 @@ int PQCLEAN_MQDSS64_CLEAN_crypto_sign_verify(
         memcpy(c + HASH_BYTES * (2 * i + (1 - b)), sig + NPACKED_BYTES, HASH_BYTES);
         sig += NPACKED_BYTES + 2 * HASH_BYTES;
     }
+    shake256_ctx_release(&shakestate);
 
     H(c, c, HASH_BYTES * ROUNDS * 2);
     if (memcmp(c, sigma0, HASH_BYTES) != 0) {

--- a/crypto_sign/rainbowIIIc-classic/clean/utils_prng.c
+++ b/crypto_sign/rainbowIIIc-classic/clean/utils_prng.c
@@ -32,6 +32,7 @@ static void prng_update(const unsigned char *provided_data,
             temp[i] ^= provided_data[i];
         }
     }
+    aes256_ctx_release(&ctx);
     memcpy(Key, temp, 32);
     memcpy(V, temp + 32, 16);
 }
@@ -72,6 +73,7 @@ static int randombytes_with_state(prng_t *state,
             xlen = 0;
         }
     }
+    aes256_ctx_release(&ctx);
     prng_update(NULL, state->Key, state->V);
     return 0;
 }

--- a/crypto_sign/rainbowIIIc-cyclic-compressed/clean/utils_prng.c
+++ b/crypto_sign/rainbowIIIc-cyclic-compressed/clean/utils_prng.c
@@ -32,6 +32,7 @@ static void prng_update(const unsigned char *provided_data,
             temp[i] ^= provided_data[i];
         }
     }
+    aes256_ctx_release(&ctx);
     memcpy(Key, temp, 32);
     memcpy(V, temp + 32, 16);
 }
@@ -72,6 +73,7 @@ static int randombytes_with_state(prng_t *state,
             xlen = 0;
         }
     }
+    aes256_ctx_release(&ctx);
     prng_update(NULL, state->Key, state->V);
     return 0;
 }

--- a/crypto_sign/rainbowIIIc-cyclic/clean/utils_prng.c
+++ b/crypto_sign/rainbowIIIc-cyclic/clean/utils_prng.c
@@ -32,6 +32,7 @@ static void prng_update(const unsigned char *provided_data,
             temp[i] ^= provided_data[i];
         }
     }
+    aes256_ctx_release(&ctx);
     memcpy(Key, temp, 32);
     memcpy(V, temp + 32, 16);
 }
@@ -72,6 +73,7 @@ static int randombytes_with_state(prng_t *state,
             xlen = 0;
         }
     }
+    aes256_ctx_release(&ctx);
     prng_update(NULL, state->Key, state->V);
     return 0;
 }

--- a/crypto_sign/rainbowIa-classic/clean/utils_prng.c
+++ b/crypto_sign/rainbowIa-classic/clean/utils_prng.c
@@ -32,6 +32,7 @@ static void prng_update(const unsigned char *provided_data,
             temp[i] ^= provided_data[i];
         }
     }
+    aes256_ctx_release(&ctx);
     memcpy(Key, temp, 32);
     memcpy(V, temp + 32, 16);
 }
@@ -72,6 +73,7 @@ static int randombytes_with_state(prng_t *state,
             xlen = 0;
         }
     }
+    aes256_ctx_release(&ctx);
     prng_update(NULL, state->Key, state->V);
     return 0;
 }

--- a/crypto_sign/rainbowIa-cyclic-compressed/clean/utils_prng.c
+++ b/crypto_sign/rainbowIa-cyclic-compressed/clean/utils_prng.c
@@ -32,6 +32,7 @@ static void prng_update(const unsigned char *provided_data,
             temp[i] ^= provided_data[i];
         }
     }
+    aes256_ctx_release(&ctx);
     memcpy(Key, temp, 32);
     memcpy(V, temp + 32, 16);
 }
@@ -72,6 +73,7 @@ static int randombytes_with_state(prng_t *state,
             xlen = 0;
         }
     }
+    aes256_ctx_release(&ctx);
     prng_update(NULL, state->Key, state->V);
     return 0;
 }

--- a/crypto_sign/rainbowIa-cyclic/clean/utils_prng.c
+++ b/crypto_sign/rainbowIa-cyclic/clean/utils_prng.c
@@ -32,6 +32,7 @@ static void prng_update(const unsigned char *provided_data,
             temp[i] ^= provided_data[i];
         }
     }
+    aes256_ctx_release(&ctx);
     memcpy(Key, temp, 32);
     memcpy(V, temp + 32, 16);
 }
@@ -72,6 +73,7 @@ static int randombytes_with_state(prng_t *state,
             xlen = 0;
         }
     }
+    aes256_ctx_release(&ctx);
     prng_update(NULL, state->Key, state->V);
     return 0;
 }

--- a/crypto_sign/rainbowVc-classic/clean/utils_prng.c
+++ b/crypto_sign/rainbowVc-classic/clean/utils_prng.c
@@ -32,6 +32,7 @@ static void prng_update(const unsigned char *provided_data,
             temp[i] ^= provided_data[i];
         }
     }
+    aes256_ctx_release(&ctx);
     memcpy(Key, temp, 32);
     memcpy(V, temp + 32, 16);
 }
@@ -72,6 +73,7 @@ static int randombytes_with_state(prng_t *state,
             xlen = 0;
         }
     }
+    aes256_ctx_release(&ctx);
     prng_update(NULL, state->Key, state->V);
     return 0;
 }

--- a/crypto_sign/rainbowVc-cyclic-compressed/clean/utils_prng.c
+++ b/crypto_sign/rainbowVc-cyclic-compressed/clean/utils_prng.c
@@ -32,6 +32,7 @@ static void prng_update(const unsigned char *provided_data,
             temp[i] ^= provided_data[i];
         }
     }
+    aes256_ctx_release(&ctx);
     memcpy(Key, temp, 32);
     memcpy(V, temp + 32, 16);
 }
@@ -72,6 +73,7 @@ static int randombytes_with_state(prng_t *state,
             xlen = 0;
         }
     }
+    aes256_ctx_release(&ctx);
     prng_update(NULL, state->Key, state->V);
     return 0;
 }

--- a/crypto_sign/rainbowVc-cyclic/clean/utils_prng.c
+++ b/crypto_sign/rainbowVc-cyclic/clean/utils_prng.c
@@ -32,6 +32,7 @@ static void prng_update(const unsigned char *provided_data,
             temp[i] ^= provided_data[i];
         }
     }
+    aes256_ctx_release(&ctx);
     memcpy(Key, temp, 32);
     memcpy(V, temp + 32, 16);
 }
@@ -72,6 +73,7 @@ static int randombytes_with_state(prng_t *state,
             xlen = 0;
         }
     }
+    aes256_ctx_release(&ctx);
     prng_update(NULL, state->Key, state->V);
     return 0;
 }

--- a/crypto_sign/sphincs-sha256-128f-robust/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_N - PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-128f-robust/avx2/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/avx2/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void thash(
     PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_N, buf, PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-128f-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-128f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_N, buf, PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256128FROBUST_CLEAN_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-128f-simple/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_N - PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-128f-simple/avx2/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/avx2/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_N);

--- a/crypto_sign/sphincs-sha256-128f-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-128f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256128FSIMPLE_CLEAN_N);

--- a/crypto_sign/sphincs-sha256-128s-robust/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_N - PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-128s-robust/avx2/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/avx2/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void thash(
     PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_N, buf, PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-128s-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-128s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_N, buf, PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256128SROBUST_CLEAN_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-128s-simple/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_N - PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-128s-simple/avx2/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/avx2/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_N);

--- a/crypto_sign/sphincs-sha256-128s-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-128s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256128SSIMPLE_CLEAN_N);

--- a/crypto_sign/sphincs-sha256-192f-robust/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_N - PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-192f-robust/avx2/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/avx2/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void thash(
     PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_N, buf, PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-192f-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-192f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_N, buf, PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256192FROBUST_CLEAN_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-192f-simple/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_N - PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-192f-simple/avx2/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/avx2/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_N);

--- a/crypto_sign/sphincs-sha256-192f-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-192f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256192FSIMPLE_CLEAN_N);

--- a/crypto_sign/sphincs-sha256-192s-robust/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_N - PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-192s-robust/avx2/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/avx2/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void thash(
     PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_N, buf, PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-192s-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-192s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_N, buf, PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256192SROBUST_CLEAN_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-192s-simple/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_N - PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-192s-simple/avx2/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/avx2/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_N);

--- a/crypto_sign/sphincs-sha256-192s-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-192s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256192SSIMPLE_CLEAN_N);

--- a/crypto_sign/sphincs-sha256-256f-robust/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_N - PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-256f-robust/avx2/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/avx2/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void thash(
     PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_N, buf, PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-256f-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-256f-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_N, buf, PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256256FROBUST_CLEAN_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-256f-simple/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_N - PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-256f-simple/avx2/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/avx2/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_N);

--- a/crypto_sign/sphincs-sha256-256f-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-256f-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256256FSIMPLE_CLEAN_N);

--- a/crypto_sign/sphincs-sha256-256s-robust/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_N - PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-256s-robust/avx2/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/avx2/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void thash(
     PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_N, buf, PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_N + PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-256s-robust/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-256s-robust/clean/thash_sha256_robust.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/clean/thash_sha256_robust.c
@@ -28,7 +28,7 @@ static void PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_thash(
     PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_mgf1(bitmask, inblocks * PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_N, buf, PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_SHA256_ADDR_BYTES);
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     for (i = 0; i < inblocks * PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_N; i++) {
         buf[PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_N + PQCLEAN_SPHINCSSHA256256SROBUST_CLEAN_SHA256_ADDR_BYTES + i] = in[i] ^ bitmask[i];

--- a/crypto_sign/sphincs-sha256-256s-simple/avx2/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/avx2/hash_sha256.c
@@ -25,7 +25,7 @@ void PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_initialize_hash_function(
  * Cleans up the hash function states
  */
 void PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(&hash_state_seeded->x1);
+    sha256_inc_ctx_release(&hash_state_seeded->x1);
 }
 
 /*
@@ -87,8 +87,6 @@ void PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_gen_message_random(
         mlen -= PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_N;
         sha256_inc_finalize(buf + PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_SHA256_BLOCK_BYTES, &state, m, mlen);
     }
-    // Clean up SHA2 state.
-    sha256_inc_destroy(&state);
 
     for (i = 0; i < PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_N; i++) {
         buf[i] = 0x5c ^ sk_prf[i];
@@ -148,8 +146,6 @@ void PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_hash_message(
         mlen -= PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_INBLOCKS * PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_SHA256_BLOCK_BYTES - PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_N - PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_PK_BYTES;
         sha256_inc_finalize(seed, &state, m, mlen);
     }
-    // Clean up SHA2 state
-    sha256_inc_destroy(&state);
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */

--- a/crypto_sign/sphincs-sha256-256s-simple/avx2/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/avx2/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, &hash_state_seeded->x1);
+    sha256_inc_ctx_clone(&sha2_state, &hash_state_seeded->x1);
 
     PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_N);

--- a/crypto_sign/sphincs-sha256-256s-simple/clean/hash_sha256.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/clean/hash_sha256.c
@@ -20,7 +20,7 @@ void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_initialize_hash_function(
 
 /* Clean up hash state */
 void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_destroy_hash_function(hash_state *hash_state_seeded) {
-    sha256_inc_destroy(hash_state_seeded);
+    sha256_inc_ctx_release(hash_state_seeded);
 }
 
 /*

--- a/crypto_sign/sphincs-sha256-256s-simple/clean/thash_sha256_simple.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/clean/thash_sha256_simple.c
@@ -23,7 +23,7 @@ static void PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_thash(
     (void)pub_seed; /* Suppress an 'unused parameter' warning. */
 
     /* Retrieve precomputed state containing pub_seed */
-    sha256_inc_clone_state(&sha2_state, hash_state_seeded);
+    sha256_inc_ctx_clone(&sha2_state, hash_state_seeded);
 
     PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_compress_address(buf, addr);
     memcpy(buf + PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_SHA256_ADDR_BYTES, in, inblocks * PQCLEAN_SPHINCSSHA256256SSIMPLE_CLEAN_N);

--- a/crypto_sign/sphincs-shake256-128f-robust/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128f-robust/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256128FROBUST_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-128f-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128f-robust/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256128FROBUST_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-128f-simple/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128f-simple/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256128FSIMPLE_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-128f-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128f-simple/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256128FSIMPLE_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-128s-robust/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128s-robust/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256128SROBUST_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-128s-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128s-robust/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256128SROBUST_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-128s-simple/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128s-simple/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256128SSIMPLE_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-128s-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-128s-simple/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256128SSIMPLE_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-192f-robust/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192f-robust/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256192FROBUST_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-192f-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192f-robust/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256192FROBUST_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-192f-simple/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192f-simple/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256192FSIMPLE_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-192f-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192f-simple/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256192FSIMPLE_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-192s-robust/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192s-robust/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256192SROBUST_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-192s-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192s-robust/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256192SROBUST_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-192s-simple/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192s-simple/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256192SSIMPLE_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-192s-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-192s-simple/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256192SSIMPLE_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-256f-robust/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256f-robust/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256256FROBUST_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-256f-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256f-robust/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256256FROBUST_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-256f-simple/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256f-simple/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256256FSIMPLE_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-256f-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256f-simple/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256256FSIMPLE_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-256s-robust/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256s-robust/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256256SROBUST_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-256s-robust/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256s-robust/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256256SROBUST_CLEAN_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-256s-simple/avx2/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256s-simple/avx2/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256256SSIMPLE_AVX2_FORS_MSG_BYTES;

--- a/crypto_sign/sphincs-shake256-256s-simple/clean/hash_shake256.c
+++ b/crypto_sign/sphincs-shake256-256s-simple/clean/hash_shake256.c
@@ -57,6 +57,7 @@ void PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_gen_message_random(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(R, PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_N, &state);
+    shake256_inc_ctx_release(&state);
 
     (void)hash_state_seeded; /* Prevent unused parameter warning. */
 }
@@ -87,6 +88,7 @@ void PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_hash_message(
     shake256_inc_absorb(&state, m, mlen);
     shake256_inc_finalize(&state);
     shake256_inc_squeeze(buf, PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_DGST_BYTES, &state);
+    shake256_inc_ctx_release(&state);
 
     memcpy(digest, bufp, PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_FORS_MSG_BYTES);
     bufp += PQCLEAN_SPHINCSSHAKE256256SSIMPLE_CLEAN_FORS_MSG_BYTES;

--- a/test/common/nistkatrng.c
+++ b/test/common/nistkatrng.c
@@ -29,6 +29,7 @@ static void AES256_ECB(uint8_t *key, uint8_t *ctr, uint8_t *buffer) {
     aes256ctx ctx;
     aes256_keyexp(&ctx, key);
     aes256_ecb(buffer, ctr, 1, &ctx);
+    aes256_ctx_release(&ctx);
 }
 
 void nist_kat_init(uint8_t *entropy_input, const uint8_t *personalization_string, int security_strength);

--- a/test/test_valgrind.py
+++ b/test/test_valgrind.py
@@ -46,6 +46,7 @@ def test_valgrind(implementation: pqclean.Implementation, impl_path, test_dir,
                  SCHEME_DIR=os.path.abspath(impl_path),
                  IMPLEMENTATION=implementation.name,
                  DEST_DIR=dest_dir,
+                 EXTRAFLAGS="-g3",
                  NTESTS=1,
                  working_dir=os.path.join(test_dir, 'test'))
     functest_name = './functest_{}_{}'.format(implementation.scheme.name,


### PR DESCRIPTION
This helps enforce proper use of their API.

Fixes #264 