### PR TITLE
Fix NewHope CCA verify function

### DIFF
--- a/crypto_kem/newhope1024cca/clean/reduce.c
+++ b/crypto_kem/newhope1024cca/clean/reduce.c
@@ -5,7 +5,7 @@ static const uint32_t qinv = 12287; // -inverse_mod(p,2^18)
 static const uint32_t rlog = 18;
 
 /*************************************************
-* Name:        verify
+* Name:        montgomery_reduce
 *
 * Description: Montgomery reduction; given a 32-bit integer a, computes
 *              16-bit integer congruent to a * R^-1 mod q,

--- a/crypto_kem/newhope1024cca/clean/verify.c
+++ b/crypto_kem/newhope1024cca/clean/verify.c
@@ -22,7 +22,7 @@ int PQCLEAN_NEWHOPE1024CCA_CLEAN_verify(const unsigned char *a, const unsigned c
         r |= a[i] ^ b[i];
     }
 
-    r = (-r) >> 63;
+    r = (uint64_t)(-(int64_t)r) >> 63;
     return (int)r;
 }
 

--- a/crypto_kem/newhope1024cca/clean/verify.c
+++ b/crypto_kem/newhope1024cca/clean/verify.c
@@ -22,7 +22,7 @@ int PQCLEAN_NEWHOPE1024CCA_CLEAN_verify(const unsigned char *a, const unsigned c
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int64_t)r) >> 63;
+    r = (-r) >> 63;
     return (int)r;
 }
 

--- a/crypto_kem/newhope1024cpa/clean/reduce.c
+++ b/crypto_kem/newhope1024cpa/clean/reduce.c
@@ -5,7 +5,7 @@ static const uint32_t qinv = 12287; // -inverse_mod(p,2^18)
 static const uint32_t rlog = 18;
 
 /*************************************************
-* Name:        verify
+* Name:        montgomery_reduce
 *
 * Description: Montgomery reduction; given a 32-bit integer a, computes
 *              16-bit integer congruent to a * R^-1 mod q,

--- a/crypto_kem/newhope1024cpa/clean/verify.c
+++ b/crypto_kem/newhope1024cpa/clean/verify.c
@@ -22,7 +22,7 @@ int PQCLEAN_NEWHOPE1024CPA_CLEAN_verify(const unsigned char *a, const unsigned c
         r |= a[i] ^ b[i];
     }
 
-    r = (-r) >> 63;
+    r = (uint64_t)(-(int64_t)r) >> 63;
     return (int)r;
 }
 

--- a/crypto_kem/newhope1024cpa/clean/verify.c
+++ b/crypto_kem/newhope1024cpa/clean/verify.c
@@ -22,7 +22,7 @@ int PQCLEAN_NEWHOPE1024CPA_CLEAN_verify(const unsigned char *a, const unsigned c
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int64_t)r) >> 63;
+    r = (-r) >> 63;
     return (int)r;
 }
 

--- a/crypto_kem/newhope512cca/clean/reduce.c
+++ b/crypto_kem/newhope512cca/clean/reduce.c
@@ -5,7 +5,7 @@ static const uint32_t qinv = 12287; // -inverse_mod(p,2^18)
 static const uint32_t rlog = 18;
 
 /*************************************************
-* Name:        verify
+* Name:        montgomery_reduce
 *
 * Description: Montgomery reduction; given a 32-bit integer a, computes
 *              16-bit integer congruent to a * R^-1 mod q,

--- a/crypto_kem/newhope512cca/clean/verify.c
+++ b/crypto_kem/newhope512cca/clean/verify.c
@@ -22,7 +22,7 @@ int PQCLEAN_NEWHOPE512CCA_CLEAN_verify(const unsigned char *a, const unsigned ch
         r |= a[i] ^ b[i];
     }
 
-    r = (-r) >> 63;
+    r = (uint64_t)(-(int64_t)r) >> 63;
     return (int)r;
 }
 

--- a/crypto_kem/newhope512cca/clean/verify.c
+++ b/crypto_kem/newhope512cca/clean/verify.c
@@ -22,7 +22,7 @@ int PQCLEAN_NEWHOPE512CCA_CLEAN_verify(const unsigned char *a, const unsigned ch
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int64_t)r) >> 63;
+    r = (-r) >> 63;
     return (int)r;
 }
 

--- a/crypto_kem/newhope512cpa/clean/reduce.c
+++ b/crypto_kem/newhope512cpa/clean/reduce.c
@@ -5,7 +5,7 @@ static const uint32_t qinv = 12287; // -inverse_mod(p,2^18)
 static const uint32_t rlog = 18;
 
 /*************************************************
-* Name:        verify
+* Name:        montgomery_reduce
 *
 * Description: Montgomery reduction; given a 32-bit integer a, computes
 *              16-bit integer congruent to a * R^-1 mod q,

--- a/crypto_kem/newhope512cpa/clean/verify.c
+++ b/crypto_kem/newhope512cpa/clean/verify.c
@@ -22,7 +22,7 @@ int PQCLEAN_NEWHOPE512CPA_CLEAN_verify(const unsigned char *a, const unsigned ch
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int64_t)r) >> 63;
+    r = (-r) >> 63;
     return (int)r;
 }
 

--- a/crypto_kem/newhope512cpa/clean/verify.c
+++ b/crypto_kem/newhope512cpa/clean/verify.c
@@ -22,7 +22,7 @@ int PQCLEAN_NEWHOPE512CPA_CLEAN_verify(const unsigned char *a, const unsigned ch
         r |= a[i] ^ b[i];
     }
 
-    r = (-r) >> 63;
+    r = (uint64_t)(-(int64_t)r) >> 63;
     return (int)r;
 }
 


### PR DESCRIPTION
Fixes #269.
https://github.com/mupq/pqm4/issues/132 reported that the NewHope verify function does not actually return 0 or 1, but 0 or -1, which consequently breaks the cmov in the FO transform (in case of a re-encryption failure). 
This bug was introduced when I integrated this into PQClean. I added a wrong cast. Without the cast, it works correctly on my machine. 
If I recall correctly, this failed on some of the other platforms. Let's see. 
