### PR TITLE
Fix remaining memory leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ matrix:
     # MacOS builds
     - name: "KEMs: MacOS + Clang"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.3
       compiler: clang
       before_install:
         - pip3 install -r requirements.txt
@@ -136,7 +136,7 @@ matrix:
             - ccache
     - name: "KEMs: MacOS + GCC9"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.3
       compiler: gcc
       addons:
         homebrew:
@@ -167,7 +167,7 @@ matrix:
         - "cd test && travis_wait 60 python3 -m pytest --numprocesses=auto"
     - name: "SIGs on MacOS + Clang"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.3
       compiler: clang
       before_install:
         - pip3 install -r requirements.txt
@@ -194,7 +194,7 @@ matrix:
             - ccache
     - name: "SIGs on MacOS + GCC9"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.3
       compiler: gcc
       addons:
         homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,7 @@ matrix:
         PQCLEAN_SKIP_SCHEMES: sphincs-haraka-128f-robust,sphincs-haraka-192s-robust,sphincs-sha256-128f-robust,sphincs-sha256-192s-robust,sphincs-shake256-128f-robust,sphincs-shake256-192s-robust,sphincs-haraka-128f-simple,sphincs-haraka-192s-simple,sphincs-sha256-128f-simple,sphincs-sha256-192s-simple,sphincs-shake256-128f-simple,sphincs-shake256-192s-simple,sphincs-haraka-128s-robust,sphincs-haraka-256f-robust,sphincs-sha256-128s-robust,sphincs-sha256-256f-robust,sphincs-shake256-128s-robust,sphincs-shake256-256f-robust,sphincs-haraka-128s-simple,sphincs-haraka-256f-simple,sphincs-sha256-128s-simple,sphincs-sha256-256f-simple,sphincs-shake256-128s-simple,sphincs-shake256-256f-simple,sphincs-haraka-192f-robust,sphincs-haraka-256s-robust,sphincs-sha256-192f-robust,sphincs-sha256-256s-robust,sphincs-shake256-192f-robust,sphincs-shake256-256s-robust,sphincs-haraka-192f-simple,sphincs-haraka-256s-simple,sphincs-sha256-192f-simple,sphincs-sha256-256s-simple,sphincs-shake256-192f-simple,sphincs-shake256-256s-simple
       addons:
         homebrew:
+          update: true
           packages:
             - astyle
             - ccache
@@ -140,6 +141,7 @@ matrix:
       compiler: gcc
       addons:
         homebrew:
+          update: true
           packages:
             - astyle
             - ccache
@@ -189,6 +191,7 @@ matrix:
         PQCLEAN_SKIP_SCHEMES: sphincs-haraka-128f-robust,sphincs-haraka-192s-robust,sphincs-sha256-128f-robust,sphincs-sha256-192s-robust,sphincs-shake256-128f-robust,sphincs-shake256-192s-robust,sphincs-haraka-128f-simple,sphincs-haraka-192s-simple,sphincs-sha256-128f-simple,sphincs-sha256-192s-simple,sphincs-shake256-128f-simple,sphincs-shake256-192s-simple,sphincs-haraka-128s-robust,sphincs-haraka-256f-robust,sphincs-sha256-128s-robust,sphincs-sha256-256f-robust,sphincs-shake256-128s-robust,sphincs-shake256-256f-robust,sphincs-haraka-128s-simple,sphincs-haraka-256f-simple,sphincs-sha256-128s-simple,sphincs-sha256-256f-simple,sphincs-shake256-128s-simple,sphincs-shake256-256f-simple,sphincs-haraka-192f-robust,sphincs-haraka-256s-robust,sphincs-sha256-192f-robust,sphincs-sha256-256s-robust,sphincs-shake256-192f-robust,sphincs-shake256-256s-robust,sphincs-haraka-192f-simple,sphincs-haraka-256s-simple,sphincs-sha256-192f-simple,sphincs-sha256-256s-simple,sphincs-shake256-192f-simple,sphincs-shake256-256s-simple
       addons:
         homebrew:
+          update: true
           packages:
             - astyle
             - ccache
@@ -198,6 +201,7 @@ matrix:
       compiler: gcc
       addons:
         homebrew:
+          update: true
           packages:
             - astyle
             - ccache

--- a/crypto_kem/ledakemlt12/leaktime/rng.c
+++ b/crypto_kem/ledakemlt12/leaktime/rng.c
@@ -81,7 +81,7 @@ int PQCLEAN_LEDAKEMLT12_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
             memcpy(x + offset, ctx->buffer + ctx->buffer_pos, xlen);
             ctx->buffer_pos += xlen;
 
-            return RNG_SUCCESS;
+            goto end;
         }
 
         // take what's in the buffer
@@ -103,7 +103,8 @@ int PQCLEAN_LEDAKEMLT12_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
         }
 
     }
-    aes256_ctx_release(&ctx256);
+end:
 
+    aes256_ctx_release(&ctx256);
     return RNG_SUCCESS;
 }

--- a/crypto_kem/ledakemlt12/leaktime/rng.c
+++ b/crypto_kem/ledakemlt12/leaktime/rng.c
@@ -104,7 +104,7 @@ int PQCLEAN_LEDAKEMLT12_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
 
     }
 end:
-
     aes256_ctx_release(&ctx256);
+
     return RNG_SUCCESS;
 }

--- a/crypto_kem/ledakemlt32/leaktime/rng.c
+++ b/crypto_kem/ledakemlt32/leaktime/rng.c
@@ -81,7 +81,7 @@ int PQCLEAN_LEDAKEMLT32_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
             memcpy(x + offset, ctx->buffer + ctx->buffer_pos, xlen);
             ctx->buffer_pos += xlen;
 
-            return RNG_SUCCESS;
+            goto end;
         }
 
         // take what's in the buffer
@@ -103,6 +103,7 @@ int PQCLEAN_LEDAKEMLT32_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
         }
 
     }
+end:
     aes256_ctx_release(&ctx256);
 
     return RNG_SUCCESS;

--- a/crypto_kem/ledakemlt52/leaktime/rng.c
+++ b/crypto_kem/ledakemlt52/leaktime/rng.c
@@ -81,7 +81,7 @@ int PQCLEAN_LEDAKEMLT52_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
             memcpy(x + offset, ctx->buffer + ctx->buffer_pos, xlen);
             ctx->buffer_pos += xlen;
 
-            return RNG_SUCCESS;
+            goto end;
         }
 
         // take what's in the buffer
@@ -103,6 +103,7 @@ int PQCLEAN_LEDAKEMLT52_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
         }
 
     }
+end:
     aes256_ctx_release(&ctx256);
 
     return RNG_SUCCESS;

--- a/crypto_kem/newhope1024cca/clean/poly.c
+++ b/crypto_kem/newhope1024cca/clean/poly.c
@@ -225,6 +225,7 @@ void PQCLEAN_NEWHOPE1024CCA_CLEAN_poly_uniform(poly *a, const unsigned char *see
                 }
             }
         }
+        shake128_ctx_release(&state);
     }
 }
 

--- a/crypto_kem/newhope1024cpa/clean/poly.c
+++ b/crypto_kem/newhope1024cpa/clean/poly.c
@@ -225,6 +225,7 @@ void PQCLEAN_NEWHOPE1024CPA_CLEAN_poly_uniform(poly *a, const unsigned char *see
                 }
             }
         }
+        shake128_ctx_release(&state);
     }
 }
 

--- a/crypto_kem/newhope512cca/clean/poly.c
+++ b/crypto_kem/newhope512cca/clean/poly.c
@@ -221,6 +221,7 @@ void PQCLEAN_NEWHOPE512CCA_CLEAN_poly_uniform(poly *a, const unsigned char *seed
                 }
             }
         }
+        shake128_ctx_release(&state);
     }
 }
 

--- a/crypto_kem/newhope512cpa/clean/poly.c
+++ b/crypto_kem/newhope512cpa/clean/poly.c
@@ -221,6 +221,7 @@ void PQCLEAN_NEWHOPE512CPA_CLEAN_poly_uniform(poly *a, const unsigned char *seed
                 }
             }
         }
+        shake128_ctx_release(&state);
     }
 }
 

--- a/crypto_sign/dilithium2/avx2/sign.c
+++ b/crypto_sign/dilithium2/avx2/sign.c
@@ -95,6 +95,7 @@ void PQCLEAN_DILITHIUM2_AVX2_challenge(poly *c,
         c->coeffs[b] ^= -(signs & 1) & (1 ^ (Q - 1));
         signs >>= 1;
     }
+    shake256_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_sign/dilithium2/clean/sign.c
+++ b/crypto_sign/dilithium2/clean/sign.c
@@ -85,6 +85,7 @@ void PQCLEAN_DILITHIUM2_CLEAN_challenge(poly *c,
         c->coeffs[b] ^= -((int32_t)signs & 1) & (1 ^ (Q - 1));
         signs >>= 1;
     }
+    shake256_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_sign/dilithium3/avx2/sign.c
+++ b/crypto_sign/dilithium3/avx2/sign.c
@@ -107,6 +107,7 @@ void PQCLEAN_DILITHIUM3_AVX2_challenge(poly *c,
         c->coeffs[b] ^= -(signs & 1) & (1 ^ (Q - 1));
         signs >>= 1;
     }
+    shake256_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_sign/dilithium3/clean/sign.c
+++ b/crypto_sign/dilithium3/clean/sign.c
@@ -85,6 +85,7 @@ void PQCLEAN_DILITHIUM3_CLEAN_challenge(poly *c,
         c->coeffs[b] ^= -((int32_t)signs & 1) & (1 ^ (Q - 1));
         signs >>= 1;
     }
+    shake256_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_sign/dilithium4/avx2/sign.c
+++ b/crypto_sign/dilithium4/avx2/sign.c
@@ -122,6 +122,7 @@ void PQCLEAN_DILITHIUM4_AVX2_challenge(poly *c,
         c->coeffs[b] ^= -(signs & 1) & (1 ^ (Q - 1));
         signs >>= 1;
     }
+    shake256_ctx_release(&state);
 }
 
 /*************************************************

--- a/crypto_sign/dilithium4/clean/sign.c
+++ b/crypto_sign/dilithium4/clean/sign.c
@@ -85,6 +85,7 @@ void PQCLEAN_DILITHIUM4_CLEAN_challenge(poly *c,
         c->coeffs[b] ^= -((int32_t)signs & 1) & (1 ^ (Q - 1));
         signs >>= 1;
     }
+    shake256_ctx_release(&state);
 }
 
 /*************************************************

--- a/test/test_valgrind.py
+++ b/test/test_valgrind.py
@@ -54,6 +54,7 @@ def test_valgrind(implementation: pqclean.Implementation, impl_path, test_dir,
     helpers.run_subprocess(
         ['valgrind',
          '--error-exitcode=1',
+         '--leak-check=yes',
          *(['--exit-on-first-error=yes']
            if valgrind_supports_exit_early()
            else []),


### PR DESCRIPTION
It turns out Valgrind is pretty lax about memory leaks,
so I ran ASAN and found these remaining leaks.

ASAN is not run by the CI framework because it slows down
stuff a lot.