### PR TITLE
Clean up undefined behaviour

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,8 +309,8 @@ workflows:
       - amd64-clang-kem
       - amd64-gcc-sign
       - amd64-clang-sign
-      - amd64-clang-sanitizers-kem:
-          requires: &sanitizers
+      - amd64-clang-sanitizers-kem: &sanitizers
+          requires:
             - amd64-gcc-kem
             - amd64-gcc-sign
             - amd64-clang-kem

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,22 @@ jobs:
       CC: clang
       ARCH: amd64
       PQCLEAN_ONLY_TYPES: kem
+  amd64-clang-sanitizers-kem:
+    <<: *nativejob
+    environment:
+      PQCLEAN_ONLY_TESTS: test_functest_sanitizers
+      RUN_SLOW: 1
+      CC: clang
+      ARCH: amd64
+      PQCLEAN_ONLY_TYPES: kem
+  amd64-clang-sanitizers-sign:
+    <<: *nativejob
+    environment:
+      PQCLEAN_ONLY_TESTS: test_functest_sanitizers
+      RUN_SLOW: 1
+      CC: clang
+      ARCH: amd64
+      PQCLEAN_ONLY_TYPES: sign
   i386-gcc-kem:
     <<: *nativejob
     environment:
@@ -293,6 +309,14 @@ workflows:
       - amd64-clang-kem
       - amd64-gcc-sign
       - amd64-clang-sign
+      - amd64-clang-sanitizers-kem:
+          requires: &sanitizers
+            - amd64-gcc-kem
+            - amd64-gcc-sign
+            - amd64-clang-kem
+            - amd64-clang-sign
+      - amd64-clang-sanitizers-sign:
+          <<*: *sanitizers
       # i386
       - i386-gcc-kem: &i386
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ workflows:
             - amd64-clang-kem
             - amd64-clang-sign
       - amd64-clang-sanitizers-sign:
-          <<*: *sanitizers
+          <<: *sanitizers
       # i386
       - i386-gcc-kem: &i386
           requires:

--- a/crypto_kem/firesaber/clean/poly_mul.c
+++ b/crypto_kem/firesaber/clean/poly_mul.c
@@ -8,6 +8,7 @@
 #define N_SB (SABER_N >> 2)
 #define N_SB_RES (2*N_SB-1)
 
+#define OVERFLOWING_MUL(X, Y) ((uint16_t)((uint32_t)(X) * (uint32_t)(Y)))
 
 #define KARATSUBA_N 64
 static void karatsuba_simple(const uint16_t *a_1, const uint16_t *b_1, uint16_t *result_final) {
@@ -37,8 +38,12 @@ static void karatsuba_simple(const uint16_t *a_1, const uint16_t *b_1, uint16_t 
             acc5 = b_1[j]; //b0
             acc6 = b_1[j + KARATSUBA_N / 4]; //b1
 
-            result_final[i + j + 0 * KARATSUBA_N / 4] = result_final[i + j + 0 * KARATSUBA_N / 4] + acc1 * acc5;
-            result_final[i + j + 2 * KARATSUBA_N / 4] = result_final[i + j + 2 * KARATSUBA_N / 4] + acc2 * acc6;
+            result_final[i + j + 0 * KARATSUBA_N / 4] =
+                result_final[i + j + 0 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc1, acc5);
+            result_final[i + j + 2 * KARATSUBA_N / 4] =
+                result_final[i + j + 2 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc2, acc6);
 
             acc7 = acc5 + acc6; //b01
             acc8 = acc1 + acc2; //a01
@@ -47,26 +52,34 @@ static void karatsuba_simple(const uint16_t *a_1, const uint16_t *b_1, uint16_t 
 
             acc7 = b_1[j + 2 * KARATSUBA_N / 4]; //b2
             acc8 = b_1[j + 3 * KARATSUBA_N / 4]; //b3
-            result_final[i + j + 4 * KARATSUBA_N / 4] = result_final[i + j + 4 * KARATSUBA_N / 4] + acc7 * acc3;
+            result_final[i + j + 4 * KARATSUBA_N / 4] =
+                result_final[i + j + 4 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc7, acc3);
 
-            result_final[i + j + 6 * KARATSUBA_N / 4] = result_final[i + j + 6 * KARATSUBA_N / 4] + acc8 * acc4;
+            result_final[i + j + 6 * KARATSUBA_N / 4] =
+                result_final[i + j + 6 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc8, acc4);
 
             acc9 = acc3 + acc4;
             acc10 = acc7 + acc8;
-            d23[i + j] = d23[i + j] + acc9 * acc10;
+            d23[i + j] = d23[i + j] + OVERFLOWING_MUL(acc9, acc10);
             //--------------------------------------------------------
 
             acc5 = acc5 + acc7; //b02
             acc7 = acc1 + acc3; //a02
-            result_d01[i + j + 0 * KARATSUBA_N / 4] = result_d01[i + j + 0 * KARATSUBA_N / 4] + acc5 * acc7;
+            result_d01[i + j + 0 * KARATSUBA_N / 4] =
+                result_d01[i + j + 0 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc5, acc7);
 
             acc6 = acc6 + acc8; //b13
             acc8 = acc2 + acc4;
-            result_d01[i + j + 2 * KARATSUBA_N / 4] = result_d01[i + j + 2 * KARATSUBA_N / 4] + acc6 * acc8;
+            result_d01[i + j + 2 * KARATSUBA_N / 4] =
+                result_d01[i + j + 2 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc6, acc8);
 
             acc5 = acc5 + acc6;
             acc7 = acc7 + acc8;
-            d0123[i + j] = d0123[i + j] + acc5 * acc7;
+            d0123[i + j] = d0123[i + j] + OVERFLOWING_MUL(acc5, acc7);
         }
     }
 
@@ -197,11 +210,11 @@ static void toom_cook_4way (const uint16_t *a1, const uint16_t *b1, uint16_t *re
         r2 = r2 - r6;
         r2 = r2 - r0;
         r1 = r1 + 45 * r2;
-        r4 = (((r4 - (r2 << 3)) * inv3) >> 3);
+        r4 = (uint16_t)(((r4 - (r2 << 3)) * (uint32_t)inv3) >> 3);
         r5 = r5 + r1;
-        r1 = (((r1 + (r3 << 4)) * inv9) >> 1);
+        r1 = (uint16_t)(((r1 + (r3 << 4)) * (uint32_t)inv9) >> 1);
         r3 = -(r3 + r1);
-        r5 = (((30 * r1 - r5) * inv15) >> 2);
+        r5 = (uint16_t)(((30 * r1 - r5) * (uint32_t)inv15) >> 2);
         r2 = r2 - r4;
         r1 = r1 - r5;
 
@@ -215,9 +228,7 @@ static void toom_cook_4way (const uint16_t *a1, const uint16_t *b1, uint16_t *re
     }
 }
 
-void PQCLEAN_FIRESABER_CLEAN_pol_mul(uint16_t *a, uint16_t *b, uint16_t *res, uint16_t p, uint32_t n)
-
-{
+void PQCLEAN_FIRESABER_CLEAN_pol_mul(uint16_t *a, uint16_t *b, uint16_t *res, uint16_t p, uint32_t n) {
     uint32_t i;
     // normal multiplication
     uint16_t c[512];
@@ -232,6 +243,4 @@ void PQCLEAN_FIRESABER_CLEAN_pol_mul(uint16_t *a, uint16_t *b, uint16_t *res, ui
     for (i = n; i < 2 * n; i++) {
         res[i - n] = (c[i - n] - c[i]) & (p - 1);
     }
-
-
 }

--- a/crypto_kem/frodokem1344aes/clean/kem.c
+++ b/crypto_kem/frodokem1344aes/clean/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM1344AES_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct,
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem1344aes/clean/kem.c
+++ b/crypto_kem/frodokem1344aes/clean/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM1344AES_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct,
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM1344AES_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct,
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM1344AES_CLEAN_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem1344aes/opt/kem.c
+++ b/crypto_kem/frodokem1344aes/opt/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM1344AES_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, c
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM1344AES_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, c
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM1344AES_OPT_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem1344aes/opt/kem.c
+++ b/crypto_kem/frodokem1344aes/opt/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM1344AES_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, c
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem1344shake/clean/kem.c
+++ b/crypto_kem/frodokem1344shake/clean/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM1344SHAKE_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *c
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM1344SHAKE_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *c
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM1344SHAKE_CLEAN_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem1344shake/clean/kem.c
+++ b/crypto_kem/frodokem1344shake/clean/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM1344SHAKE_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *c
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem1344shake/opt/kem.c
+++ b/crypto_kem/frodokem1344shake/opt/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM1344SHAKE_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct,
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM1344SHAKE_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct,
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM1344SHAKE_OPT_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem1344shake/opt/kem.c
+++ b/crypto_kem/frodokem1344shake/opt/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM1344SHAKE_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct,
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem640aes/clean/kem.c
+++ b/crypto_kem/frodokem640aes/clean/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM640AES_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM640AES_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM640AES_CLEAN_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem640aes/clean/kem.c
+++ b/crypto_kem/frodokem640aes/clean/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM640AES_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem640aes/opt/kem.c
+++ b/crypto_kem/frodokem640aes/opt/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM640AES_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, co
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem640aes/opt/kem.c
+++ b/crypto_kem/frodokem640aes/opt/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM640AES_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, co
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM640AES_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, co
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM640AES_OPT_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem640shake/clean/kem.c
+++ b/crypto_kem/frodokem640shake/clean/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM640SHAKE_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem640shake/clean/kem.c
+++ b/crypto_kem/frodokem640shake/clean/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM640SHAKE_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM640SHAKE_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM640SHAKE_CLEAN_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem640shake/opt/kem.c
+++ b/crypto_kem/frodokem640shake/opt/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM640SHAKE_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM640SHAKE_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM640SHAKE_OPT_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem640shake/opt/kem.c
+++ b/crypto_kem/frodokem640shake/opt/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM640SHAKE_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem976aes/clean/kem.c
+++ b/crypto_kem/frodokem976aes/clean/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM976AES_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem976aes/clean/kem.c
+++ b/crypto_kem/frodokem976aes/clean/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM976AES_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM976AES_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM976AES_CLEAN_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem976aes/opt/kem.c
+++ b/crypto_kem/frodokem976aes/opt/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM976AES_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, co
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM976AES_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, co
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM976AES_OPT_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem976aes/opt/kem.c
+++ b/crypto_kem/frodokem976aes/opt/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM976AES_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, co
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem976shake/clean/kem.c
+++ b/crypto_kem/frodokem976shake/clean/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM976SHAKE_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem976shake/clean/kem.c
+++ b/crypto_kem/frodokem976shake/clean/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM976SHAKE_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM976SHAKE_CLEAN_crypto_kem_dec(uint8_t *ss, const uint8_t *ct
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM976SHAKE_CLEAN_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem976shake/opt/kem.c
+++ b/crypto_kem/frodokem976shake/opt/kem.c
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM976SHAKE_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
+        S[i] = sk_S[2 * i] | (sk_S[2 * i + 1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/frodokem976shake/opt/kem.c
+++ b/crypto_kem/frodokem976shake/opt/kem.c
@@ -155,7 +155,7 @@ int PQCLEAN_FRODOKEM976SHAKE_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     const uint8_t *ct_c2 = &ct[(PARAMS_LOGQ * PARAMS_N * PARAMS_NBAR) / 8];
     const uint8_t *sk_s = &sk[0];
     const uint8_t *sk_pk = &sk[CRYPTO_BYTES];
-    const uint16_t *sk_S = (uint16_t *) &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
+    const uint8_t *sk_S = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES];
     uint16_t S[PARAMS_N * PARAMS_NBAR];                      // contains secret data
     const uint8_t *sk_pkh = &sk[CRYPTO_BYTES + CRYPTO_PUBLICKEYBYTES + 2 * PARAMS_N * PARAMS_NBAR];
     const uint8_t *pk_seedA = &sk_pk[0];
@@ -172,7 +172,7 @@ int PQCLEAN_FRODOKEM976SHAKE_OPT_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, 
     uint8_t shake_input_seedSEprime[1 + CRYPTO_BYTES];       // contains secret data
 
     for (size_t i = 0; i < PARAMS_N * PARAMS_NBAR; i++) {
-        S[i] = PQCLEAN_FRODOKEM976SHAKE_OPT_LE_TO_UINT16(sk_S[i]);
+        S[i] = sk_S[2*i] | (sk_S[2*i+1] << 8);
     }
 
     // Compute W = C - Bp*S (mod q), and decode the randomness mu

--- a/crypto_kem/kyber1024-90s/clean/reduce.c
+++ b/crypto_kem/kyber1024-90s/clean/reduce.c
@@ -18,7 +18,7 @@ int16_t PQCLEAN_KYBER102490S_CLEAN_montgomery_reduce(int32_t a) {
     int32_t t;
     int16_t u;
 
-    u = (int16_t)(a * QINV);
+    u = (int16_t)(a * (int64_t)QINV);
     t = (int32_t)u * KYBER_Q;
     t = a - t;
     t >>= 16;

--- a/crypto_kem/kyber1024/clean/reduce.c
+++ b/crypto_kem/kyber1024/clean/reduce.c
@@ -18,7 +18,7 @@ int16_t PQCLEAN_KYBER1024_CLEAN_montgomery_reduce(int32_t a) {
     int32_t t;
     int16_t u;
 
-    u = (int16_t)(a * QINV);
+    u = (int16_t)(a * (int64_t)QINV);
     t = (int32_t)u * KYBER_Q;
     t = a - t;
     t >>= 16;

--- a/crypto_kem/kyber512-90s/clean/reduce.c
+++ b/crypto_kem/kyber512-90s/clean/reduce.c
@@ -18,7 +18,7 @@ int16_t PQCLEAN_KYBER51290S_CLEAN_montgomery_reduce(int32_t a) {
     int32_t t;
     int16_t u;
 
-    u = (int16_t)(a * QINV);
+    u = (int16_t)(a * (int64_t)QINV);
     t = (int32_t)u * KYBER_Q;
     t = a - t;
     t >>= 16;

--- a/crypto_kem/kyber512/clean/reduce.c
+++ b/crypto_kem/kyber512/clean/reduce.c
@@ -18,7 +18,7 @@ int16_t PQCLEAN_KYBER512_CLEAN_montgomery_reduce(int32_t a) {
     int32_t t;
     int16_t u;
 
-    u = (int16_t)(a * QINV);
+    u = (int16_t)(a * (int64_t)QINV);
     t = (int32_t)u * KYBER_Q;
     t = a - t;
     t >>= 16;

--- a/crypto_kem/kyber768-90s/clean/reduce.c
+++ b/crypto_kem/kyber768-90s/clean/reduce.c
@@ -18,7 +18,7 @@ int16_t PQCLEAN_KYBER76890S_CLEAN_montgomery_reduce(int32_t a) {
     int32_t t;
     int16_t u;
 
-    u = (int16_t)(a * QINV);
+    u = (int16_t)(a * (int64_t)QINV);
     t = (int32_t)u * KYBER_Q;
     t = a - t;
     t >>= 16;

--- a/crypto_kem/kyber768/clean/reduce.c
+++ b/crypto_kem/kyber768/clean/reduce.c
@@ -18,7 +18,7 @@ int16_t PQCLEAN_KYBER768_CLEAN_montgomery_reduce(int32_t a) {
     int32_t t;
     int16_t u;
 
-    u = (int16_t)(a * QINV);
+    u = (int16_t)(a * (int64_t)QINV);
     t = (int32_t)u * KYBER_Q;
     t = a - t;
     t >>= 16;

--- a/crypto_kem/mceliece348864f/vec/pk_gen.c
+++ b/crypto_kem/mceliece348864f/vec/pk_gen.c
@@ -57,7 +57,7 @@ static inline int ctz(uint64_t in) {
     int i, b, m = 0, r = 0;
 
     for (i = 0; i < 64; i++) {
-        b = ((int)in >> i) & 1;
+        b = ((int)(in >> i)) & 1;
         m |= b;
         r += (m ^ 1) & (b ^ 1);
     }

--- a/crypto_kem/mceliece460896f/vec/pk_gen.c
+++ b/crypto_kem/mceliece460896f/vec/pk_gen.c
@@ -57,7 +57,7 @@ static inline int ctz(uint64_t in) {
     int i, b, m = 0, r = 0;
 
     for (i = 0; i < 64; i++) {
-        b = ((int)in >> i) & 1;
+        b = ((int)(in >> i)) & 1;
         m |= b;
         r += (m ^ 1) & (b ^ 1);
     }

--- a/crypto_kem/ntruhrss701/clean/sample.c
+++ b/crypto_kem/ntruhrss701/clean/sample.c
@@ -37,14 +37,14 @@ void PQCLEAN_NTRUHRSS701_CLEAN_sample_iid_plus(poly *r, const unsigned char unif
 
     /* s = <x*r, r>.  (r[n-1] = 0) */
     for (i = 0; i < NTRU_N - 1; i++) {
-        s += r->coeffs[i + 1] * r->coeffs[i];
+        s += (uint16_t)((uint32_t)r->coeffs[i + 1] * (uint32_t)r->coeffs[i]);
     }
 
     /* Extract sign of s (sign(0) = 1) */
     s = 1 | (-(s >> 15));
 
     for (i = 0; i < NTRU_N; i += 2) {
-        r->coeffs[i] = s * r->coeffs[i];
+        r->coeffs[i] = (uint16_t)((uint32_t)s * (uint32_t)r->coeffs[i]);
     }
 
     /* Map {0,1,2^16-1} -> {0, 1, 2} */

--- a/crypto_kem/saber/clean/poly_mul.c
+++ b/crypto_kem/saber/clean/poly_mul.c
@@ -8,6 +8,7 @@
 #define N_SB (SABER_N >> 2)
 #define N_SB_RES (2*N_SB-1)
 
+#define OVERFLOWING_MUL(X, Y) ((uint16_t)((uint32_t)(X) * (uint32_t)(Y)))
 
 #define KARATSUBA_N 64
 static void karatsuba_simple(const uint16_t *a_1, const uint16_t *b_1, uint16_t *result_final) {
@@ -37,8 +38,12 @@ static void karatsuba_simple(const uint16_t *a_1, const uint16_t *b_1, uint16_t 
             acc5 = b_1[j]; //b0
             acc6 = b_1[j + KARATSUBA_N / 4]; //b1
 
-            result_final[i + j + 0 * KARATSUBA_N / 4] = result_final[i + j + 0 * KARATSUBA_N / 4] + acc1 * acc5;
-            result_final[i + j + 2 * KARATSUBA_N / 4] = result_final[i + j + 2 * KARATSUBA_N / 4] + acc2 * acc6;
+            result_final[i + j + 0 * KARATSUBA_N / 4] =
+                result_final[i + j + 0 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc1, acc5);
+            result_final[i + j + 2 * KARATSUBA_N / 4] =
+                result_final[i + j + 2 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc2, acc6);
 
             acc7 = acc5 + acc6; //b01
             acc8 = acc1 + acc2; //a01
@@ -47,26 +52,34 @@ static void karatsuba_simple(const uint16_t *a_1, const uint16_t *b_1, uint16_t 
 
             acc7 = b_1[j + 2 * KARATSUBA_N / 4]; //b2
             acc8 = b_1[j + 3 * KARATSUBA_N / 4]; //b3
-            result_final[i + j + 4 * KARATSUBA_N / 4] = result_final[i + j + 4 * KARATSUBA_N / 4] + acc7 * acc3;
+            result_final[i + j + 4 * KARATSUBA_N / 4] =
+                result_final[i + j + 4 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc7, acc3);
 
-            result_final[i + j + 6 * KARATSUBA_N / 4] = result_final[i + j + 6 * KARATSUBA_N / 4] + acc8 * acc4;
+            result_final[i + j + 6 * KARATSUBA_N / 4] =
+                result_final[i + j + 6 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc8, acc4);
 
             acc9 = acc3 + acc4;
             acc10 = acc7 + acc8;
-            d23[i + j] = d23[i + j] + acc9 * acc10;
+            d23[i + j] = d23[i + j] + OVERFLOWING_MUL(acc9, acc10);
             //--------------------------------------------------------
 
             acc5 = acc5 + acc7; //b02
             acc7 = acc1 + acc3; //a02
-            result_d01[i + j + 0 * KARATSUBA_N / 4] = result_d01[i + j + 0 * KARATSUBA_N / 4] + acc5 * acc7;
+            result_d01[i + j + 0 * KARATSUBA_N / 4] =
+                result_d01[i + j + 0 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc5, acc7);
 
             acc6 = acc6 + acc8; //b13
             acc8 = acc2 + acc4;
-            result_d01[i + j + 2 * KARATSUBA_N / 4] = result_d01[i + j + 2 * KARATSUBA_N / 4] + acc6 * acc8;
+            result_d01[i + j + 2 * KARATSUBA_N / 4] =
+                result_d01[i + j + 2 * KARATSUBA_N / 4] +
+                OVERFLOWING_MUL(acc6, acc8);
 
             acc5 = acc5 + acc6;
             acc7 = acc7 + acc8;
-            d0123[i + j] = d0123[i + j] + acc5 * acc7;
+            d0123[i + j] = d0123[i + j] + OVERFLOWING_MUL(acc5, acc7);
         }
     }
 
@@ -197,11 +210,11 @@ static void toom_cook_4way (const uint16_t *a1, const uint16_t *b1, uint16_t *re
         r2 = r2 - r6;
         r2 = r2 - r0;
         r1 = r1 + 45 * r2;
-        r4 = (((r4 - (r2 << 3)) * inv3) >> 3);
+        r4 = (uint16_t)(((r4 - (r2 << 3)) * (uint32_t)inv3) >> 3);
         r5 = r5 + r1;
-        r1 = (((r1 + (r3 << 4)) * inv9) >> 1);
+        r1 = (uint16_t)(((r1 + (r3 << 4)) * (uint32_t)inv9) >> 1);
         r3 = -(r3 + r1);
-        r5 = (((30 * r1 - r5) * inv15) >> 2);
+        r5 = (uint16_t)(((30 * r1 - r5) * (uint32_t)inv15) >> 2);
         r2 = r2 - r4;
         r1 = r1 - r5;
 
@@ -215,9 +228,7 @@ static void toom_cook_4way (const uint16_t *a1, const uint16_t *b1, uint16_t *re
     }
 }
 
-void PQCLEAN_SABER_CLEAN_pol_mul(uint16_t *a, uint16_t *b, uint16_t *res, uint16_t p, uint32_t n)
-
-{
+void PQCLEAN_SABER_CLEAN_pol_mul(uint16_t *a, uint16_t *b, uint16_t *res, uint16_t p, uint32_t n) {
     uint32_t i;
     // normal multiplication
     uint16_t c[512];
@@ -232,6 +243,4 @@ void PQCLEAN_SABER_CLEAN_pol_mul(uint16_t *a, uint16_t *b, uint16_t *res, uint16
     for (i = n; i < 2 * n; i++) {
         res[i - n] = (c[i - n] - c[i]) & (p - 1);
     }
-
-
 }

--- a/crypto_sign/qtesla-p-I/clean/gauss.c
+++ b/crypto_sign/qtesla-p-I/clean/gauss.c
@@ -23,7 +23,7 @@ void PQCLEAN_QTESLAPI_CLEAN_sample_gauss_poly(poly z, const uint8_t *seed, uint1
         cSHAKE(buf, CHUNK_SIZE * CDT_COLS * sizeof(int32_t), (uint8_t *)NULL, 0, dmsp_bytes, 2, seed, CRYPTO_RANDOMBYTES);
         ++dmsp;
         for (size_t i = 0, j = 0; i < CHUNK_SIZE * CDT_COLS; i += 1, j += 4) {
-            samp[i] = (int32_t)(buf[j] | (buf[j + 1] << 8) | (buf[j + 2] << 16) | (buf[j + 3] << 24));
+            samp[i] = (int32_t)(buf[j] | (buf[j + 1] << 8) | (buf[j + 2] << 16) | (int32_t)((uint32_t)buf[j + 3] << 24));
         }
         for (size_t i = 0; i < CHUNK_SIZE; i++) {
             z[chunk + i] = 0;

--- a/crypto_sign/qtesla-p-I/clean/pack.c
+++ b/crypto_sign/qtesla-p-I/clean/pack.c
@@ -75,13 +75,13 @@ void PQCLEAN_QTESLAPI_CLEAN_decode_pk(int32_t *pk, uint8_t *seedA, const uint8_t
     const uint8_t *a = pk_in;
 
     for (i = 0, j = 0; i < PARAM_N * PARAM_K; i += 8, j += 29) {
-        pk[i  ] = (int32_t)(( a[j   ]     | (a[j + 1] << 8) | (a[j + 2] << 16) | (a[j + 3] << 24)                ) & mask29);
-        pk[i + 1] = (int32_t)(((a[j + 3] >> 5) | (a[j + 4] << 3) | (a[j + 5] << 11) | (a[j + 6] << 19) | (a[j + 7] << 27)) & mask29);
+        pk[i  ] = (int32_t)(( a[j   ]     | (a[j + 1] << 8) | (a[j + 2] << 16) | (int32_t)((uint32_t)a[j + 3] << 24)                ) & mask29);
+        pk[i + 1] = (int32_t)(((a[j + 3] >> 5) | (a[j + 4] << 3) | (a[j + 5] << 11) | (a[j + 6] << 19) | (int32_t)((uint32_t)a[j + 7] << 27)) & mask29);
         pk[i + 2] = (int32_t)(((a[j + 7] >> 2) | (a[j + 8] << 6) | (a[j + 9] << 14) | (a[j + 10] << 22)                ) & mask29);
-        pk[i + 3] = (int32_t)(((a[j + 10] >> 7) | (a[j + 11] << 1) | (a[j + 12] << 9) | (a[j + 13] << 17) | (a[j + 14] << 25)) & mask29);
-        pk[i + 4] = (int32_t)(((a[j + 14] >> 4) | (a[j + 15] << 4) | (a[j + 16] << 12) | (a[j + 17] << 20) | (a[j + 18] << 28)) & mask29);
+        pk[i + 3] = (int32_t)(((a[j + 10] >> 7) | (a[j + 11] << 1) | (a[j + 12] << 9) | (a[j + 13] << 17) | (int32_t)((uint32_t)a[j + 14] << 25)) & mask29);
+        pk[i + 4] = (int32_t)(((a[j + 14] >> 4) | (a[j + 15] << 4) | (a[j + 16] << 12) | (a[j + 17] << 20) | (int32_t)((uint32_t)a[j + 18] << 28)) & mask29);
         pk[i + 5] = (int32_t)(((a[j + 18] >> 1) | (a[j + 19] << 7) | (a[j + 20] << 15) | (a[j + 21] << 23)                ) & mask29);
-        pk[i + 6] = (int32_t)(((a[j + 21] >> 6) | (a[j + 22] << 2) | (a[j + 23] << 10) | (a[j + 24] << 18) | (a[j + 25] << 26)) & mask29);
+        pk[i + 6] = (int32_t)(((a[j + 21] >> 6) | (a[j + 22] << 2) | (a[j + 23] << 10) | (a[j + 24] << 18) | (int32_t)((uint32_t)a[j + 25] << 26)) & mask29);
         pk[i + 7] = (int32_t)( (a[j + 25] >> 3) | (a[j + 26] << 5) | (a[j + 27] << 13) | (a[j + 28] << 21)                          );
     }
 
@@ -96,7 +96,7 @@ void PQCLEAN_QTESLAPI_CLEAN_encode_sig(uint8_t *sm, uint8_t *c, const poly z) {
     for (i = 0, j = 0; i < PARAM_N; i += 2, j += 5) {
         sm[j  ] = (uint8_t)(  z[i  ]    );
         sm[j + 1] = (uint8_t)(  z[i  ] >> 8);
-        sm[j + 2] = (uint8_t)(((z[i  ] >> 16) & 0x0F) | (z[i + 1] << 4));
+        sm[j + 2] = (uint8_t)(((z[i  ] >> 16) & 0x0F) | (int64_t)((uint64_t)z[i + 1] << 4));
         sm[j + 3] = (uint8_t)(  z[i + 1] >> 4);
         sm[j + 4] = (uint8_t)(  z[i + 1] >> 12);
     }
@@ -109,8 +109,8 @@ void PQCLEAN_QTESLAPI_CLEAN_decode_sig(uint8_t *c, poly z, const uint8_t *sm) {
     size_t i, j;
 
     for (i = 0, j = 0; i < PARAM_N; i += 2, j += 5) {
-        z[i  ] =  sm[j  ]     | (sm[j + 1] << 8) | (((int64_t)sm[j + 2] << 60) >> 44);
-        z[i + 1] = (sm[j + 2] >> 4) | (sm[j + 3] << 4) | (((int64_t)sm[j + 4] << 56) >> 44);
+        z[i  ] =  sm[j  ]     | (sm[j + 1] << 8) | ((int64_t)((uint64_t)sm[j + 2] << 60) >> 44);
+        z[i + 1] = (sm[j + 2] >> 4) | (sm[j + 3] << 4) | ((int64_t)((uint64_t)sm[j + 4] << 56) >> 44);
     }
 
     memcpy(c, &sm[j], CRYPTO_C_BYTES);

--- a/crypto_sign/qtesla-p-I/clean/poly.c
+++ b/crypto_sign/qtesla-p-I/clean/poly.c
@@ -215,27 +215,27 @@ void PQCLEAN_QTESLAPI_CLEAN_poly_uniform(poly_k a, const uint8_t *seed) {
             pos = 0;
         }
         val1 = ((uint32_t)(buf[pos])
-                |  (uint32_t)(buf[pos + 1] << 8)
-                |  (uint32_t)(buf[pos + 2] << 16)
-                |  (uint32_t)(buf[pos + 3] << 24))
+                |  ((uint32_t)buf[pos + 1] << 8)
+                |  ((uint32_t)buf[pos + 2] << 16)
+                |  ((uint32_t)buf[pos + 3] << 24))
                & mask;
         pos += nbytes;
         val2 = ((uint32_t)(buf[pos])
-                |  (uint32_t)(buf[pos + 1] << 8)
-                |  (uint32_t)(buf[pos + 2] << 16)
-                |  (uint32_t)(buf[pos + 3] << 24))
+                |  ((uint32_t)buf[pos + 1] << 8)
+                |  ((uint32_t)buf[pos + 2] << 16)
+                |  ((uint32_t)buf[pos + 3] << 24))
                & mask;
         pos += nbytes;
         val3 = ((uint32_t)(buf[pos])
-                |  (uint32_t)(buf[pos + 1] << 8)
-                |  (uint32_t)(buf[pos + 2] << 16)
-                |  (uint32_t)(buf[pos + 3] << 24))
+                |  ((uint32_t)buf[pos + 1] << 8)
+                |  ((uint32_t)buf[pos + 2] << 16)
+                |  ((uint32_t)buf[pos + 3] << 24))
                & mask;
         pos += nbytes;
         val4 = ((uint32_t)(buf[pos])
-                |  (uint32_t)(buf[pos + 1] << 8)
-                |  (uint32_t)(buf[pos + 2] << 16)
-                |  (uint32_t)(buf[pos + 3] << 24))
+                |  ((uint32_t)buf[pos + 1] << 8)
+                |  ((uint32_t)buf[pos + 2] << 16)
+                |  ((uint32_t)buf[pos + 3] << 24))
                & mask;
         pos += nbytes;
         if (val1 < PARAM_Q && i < PARAM_K * PARAM_N) {

--- a/crypto_sign/qtesla-p-I/clean/sign.c
+++ b/crypto_sign/qtesla-p-I/clean/sign.c
@@ -77,7 +77,7 @@ static int test_correctness(const poly v) {
 
         left = val;
         val = (val + (1 << (PARAM_D - 1)) - 1) >> PARAM_D;
-        val = left - (val << PARAM_D);
+        val = left - (int32_t)((uint32_t)val << PARAM_D);
         // If (Abs(val) < (1<<(PARAM_D-1))-PARAM_E) then t1 = 0, else t1 = 1
         t1 = (uint32_t)(~(Abs(val) - ((1 << (PARAM_D - 1)) - PARAM_E))) >> (RADIX32 - 1);
 

--- a/crypto_sign/qtesla-p-III/clean/gauss.c
+++ b/crypto_sign/qtesla-p-III/clean/gauss.c
@@ -23,7 +23,7 @@ void PQCLEAN_QTESLAPIII_CLEAN_sample_gauss_poly(poly z, const uint8_t *seed, uin
         cSHAKE(buf, CHUNK_SIZE * CDT_COLS * sizeof(int32_t), (uint8_t *)NULL, 0, dmsp_bytes, 2, seed, CRYPTO_RANDOMBYTES);
         ++dmsp;
         for (size_t i = 0, j = 0; i < CHUNK_SIZE * CDT_COLS; i += 1, j += 4) {
-            samp[i] = (int32_t)(buf[j] | (buf[j + 1] << 8) | (buf[j + 2] << 16) | (buf[j + 3] << 24));
+            samp[i] = (int32_t)(buf[j] | (buf[j + 1] << 8) | (buf[j + 2] << 16) | (int32_t)((uint32_t)buf[j + 3] << 24));
         }
         for (size_t i = 0; i < CHUNK_SIZE; i++) {
             z[chunk + i] = 0;

--- a/crypto_sign/qtesla-p-III/clean/pack.c
+++ b/crypto_sign/qtesla-p-III/clean/pack.c
@@ -61,9 +61,9 @@ void PQCLEAN_QTESLAPIII_CLEAN_decode_pk(int32_t *pk, uint8_t *seedA, const uint8
     const uint8_t *a = pk_in;
 
     for (i = 0, j = 0; i < PARAM_N * PARAM_K; i += 4, j += 15) {
-        pk[i  ] = (int32_t)(( a[j   ]     | (a[j + 1] << 8) | (a[j + 2] << 16) | (a[j + 3] << 24)                ) & mask30);
-        pk[i + 1] = (int32_t)(((a[j + 3] >> 6) | (a[j + 4] << 2) | (a[j + 5] << 10) | (a[j + 6] << 18) | (a[j + 7] << 26)) & mask30);
-        pk[i + 2] = (int32_t)(((a[j + 7] >> 4) | (a[j + 8] << 4) | (a[j + 9] << 12) | (a[j + 10] << 20) | (a[j + 11] << 28)) & mask30);
+        pk[i  ] = (int32_t)(( a[j   ]     | (a[j + 1] << 8) | (a[j + 2] << 16) | (int32_t)((uint32_t)a[j + 3] << 24)                ) & mask30);
+        pk[i + 1] = (int32_t)(((a[j + 3] >> 6) | (a[j + 4] << 2) | (a[j + 5] << 10) | (a[j + 6] << 18) | (int32_t)((uint32_t)a[j + 7] << 26)) & mask30);
+        pk[i + 2] = (int32_t)(((a[j + 7] >> 4) | (a[j + 8] << 4) | (a[j + 9] << 12) | (a[j + 10] << 20) | (int32_t)((uint32_t)a[j + 11] << 28)) & mask30);
         pk[i + 3] = (int32_t)( (a[j + 11] >> 2) | (a[j + 12] << 6) | (a[j + 13] << 14) | (a[j + 14] << 22)                          );
     }
 
@@ -78,13 +78,13 @@ void PQCLEAN_QTESLAPIII_CLEAN_encode_sig(uint8_t *sm, uint8_t *c, const poly z) 
     for (i = 0, j = 0; i < PARAM_N; i += 4, j += 11) {
         sm[j   ] = (uint8_t)(  z[i  ]    );
         sm[j + 1] = (uint8_t)(  z[i  ] >> 8);
-        sm[j + 2] = (uint8_t)(((z[i  ] >> 16) & 0x3F) | (z[i + 1] << 6));
+        sm[j + 2] = (uint8_t)(((z[i  ] >> 16) & 0x3F) | ((uint64_t)z[i + 1] << 6));
         sm[j + 3] = (uint8_t)(  z[i + 1] >> 2);
         sm[j + 4] = (uint8_t)(  z[i + 1] >> 10);
-        sm[j + 5] = (uint8_t)(((z[i + 1] >> 18) & 0x0F) | (z[i + 2] << 4));
+        sm[j + 5] = (uint8_t)(((z[i + 1] >> 18) & 0x0F) | ((uint64_t)z[i + 2] << 4));
         sm[j + 6] = (uint8_t)(  z[i + 2] >> 4);
         sm[j + 7] = (uint8_t)(  z[i + 2] >> 12);
-        sm[j + 8] = (uint8_t)(((z[i + 2] >> 20) & 0x03) | (z[i + 3] << 2));
+        sm[j + 8] = (uint8_t)(((z[i + 2] >> 20) & 0x03) | ((uint64_t)z[i + 3] << 2));
         sm[j + 9] = (uint8_t)(  z[i + 3] >> 6);
         sm[j + 10] = (uint8_t)(  z[i + 3] >> 14);
     }
@@ -98,10 +98,10 @@ void PQCLEAN_QTESLAPIII_CLEAN_decode_sig(uint8_t *c, poly z, const uint8_t *sm) 
     size_t i, j;
 
     for (i = 0, j = 0; i < PARAM_N; i += 4, j += 11) {
-        z[i  ] =  sm[j  ]     | (sm[j + 1] << 8) |                 (((int64_t)sm[j + 2] << 58) >> 42);
-        z[i + 1] = (sm[j + 2] >> 6) | (sm[j + 3] << 2) | (sm[j + 4] << 10) | (((int64_t)sm[j + 5] << 60) >> 42);
-        z[i + 2] = (sm[j + 5] >> 4) | (sm[j + 6] << 4) | (sm[j + 7] << 12) | (((int64_t)sm[j + 8] << 62) >> 42);
-        z[i + 3] = (sm[j + 8] >> 2) | (sm[j + 9] << 6) |                 (((int64_t)sm[j + 10] << 56) >> 42);
+        z[i  ] =  sm[j  ]     | (sm[j + 1] << 8) |                 ((int64_t)((uint64_t)sm[j + 2] << 58) >> 42);
+        z[i + 1] = (sm[j + 2] >> 6) | (sm[j + 3] << 2) | (sm[j + 4] << 10) | ((int64_t)((uint64_t)sm[j + 5] << 60) >> 42);
+        z[i + 2] = (sm[j + 5] >> 4) | (sm[j + 6] << 4) | (sm[j + 7] << 12) | ((int64_t)((uint64_t)sm[j + 8] << 62) >> 42);
+        z[i + 3] = (sm[j + 8] >> 2) | (sm[j + 9] << 6) |                 ((int64_t)((uint64_t)sm[j + 10] << 56) >> 42);
     }
 
     memcpy(c, &sm[j], CRYPTO_C_BYTES);

--- a/crypto_sign/qtesla-p-III/clean/poly.c
+++ b/crypto_sign/qtesla-p-III/clean/poly.c
@@ -206,27 +206,27 @@ void PQCLEAN_QTESLAPIII_CLEAN_poly_uniform(poly_k a, const uint8_t *seed) {
             pos = 0;
         }
         val1 = ((uint32_t)(buf[pos])
-                |  (uint32_t)(buf[pos + 1] << 8)
-                |  (uint32_t)(buf[pos + 2] << 16)
-                |  (uint32_t)(buf[pos + 3] << 24))
+                |  ((uint32_t)buf[pos + 1] << 8)
+                |  ((uint32_t)buf[pos + 2] << 16)
+                |  ((uint32_t)buf[pos + 3] << 24))
                & mask;
         pos += nbytes;
         val2 = ((uint32_t)(buf[pos])
-                |  (uint32_t)(buf[pos + 1] << 8)
-                |  (uint32_t)(buf[pos + 2] << 16)
-                |  (uint32_t)(buf[pos + 3] << 24))
+                |  ((uint32_t)buf[pos + 1] << 8)
+                |  ((uint32_t)buf[pos + 2] << 16)
+                |  ((uint32_t)buf[pos + 3] << 24))
                & mask;
         pos += nbytes;
         val3 = ((uint32_t)(buf[pos])
-                |  (uint32_t)(buf[pos + 1] << 8)
-                |  (uint32_t)(buf[pos + 2] << 16)
-                |  (uint32_t)(buf[pos + 3] << 24))
+                |  ((uint32_t)buf[pos + 1] << 8)
+                |  ((uint32_t)buf[pos + 2] << 16)
+                |  ((uint32_t)buf[pos + 3] << 24))
                & mask;
         pos += nbytes;
         val4 = ((uint32_t)(buf[pos])
-                |  (uint32_t)(buf[pos + 1] << 8)
-                |  (uint32_t)(buf[pos + 2] << 16)
-                |  (uint32_t)(buf[pos + 3] << 24))
+                |  ((uint32_t)buf[pos + 1] << 8)
+                |  ((uint32_t)buf[pos + 2] << 16)
+                |  ((uint32_t)buf[pos + 3] << 24))
                & mask;
         pos += nbytes;
         if (val1 < PARAM_Q && i < PARAM_K * PARAM_N) {

--- a/crypto_sign/qtesla-p-III/clean/sign.c
+++ b/crypto_sign/qtesla-p-III/clean/sign.c
@@ -77,7 +77,7 @@ static int test_correctness(const poly v) {
 
         left = val;
         val = (val + (1 << (PARAM_D - 1)) - 1) >> PARAM_D;
-        val = left - (val << PARAM_D);
+        val = left - (int32_t)((uint32_t)val << PARAM_D);
         // If (Abs(val) < (1<<(PARAM_D-1))-PARAM_E) then t1 = 0, else t1 = 1
         t1 = (uint32_t)(~(Abs(val) - ((1 << (PARAM_D - 1)) - PARAM_E))) >> (RADIX32 - 1);
 

--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -70,7 +70,9 @@ def test_functest_sanitizers(implementation, impl_path, test_dir,
                  TYPE=implementation.scheme.type,
                  SCHEME=implementation.scheme.name,
                  IMPLEMENTATION=implementation.name,
-                 EXTRAFLAGS='-g -fsanitize=address,undefined',
+                 EXTRAFLAGS=(
+                     '-g -fsanitize=address,undefined '
+                     '-fno-sanitize-recover=undefined'),
                  SCHEME_DIR=impl_path,
                  DEST_DIR=dest_dir,
                  working_dir=os.path.join(test_dir, 'test'),


### PR DESCRIPTION
This PR:

* Fixes the undefined behaviour tests
* Enables the `-fsanitize` tests in CI (only on amd64)
* Fixes a bunch of UB, as described below.
 
Fix signed-integer overflow by doing a 64-bit multiplication and then casting it down.

* [x] Fix UB in Kybers
* [x] Fix UB in NTRU-HTRSS701
* [x] Fix UB in lightsaber
* [x] Fix UB in Saber
* [x] Fix UB in FireSaber

Closes #276

Alignment problems in Frodo (``crypto_kem_dec`` ``uint16_t`` use of ``uint8_t`` pointer):

* [x] Fix UB in Frodo640aes
  * [x] clean
  * [x] opt
* [x] Fix UB in Frodo640shake
  * [x] clean
  * [x] opt
* [x] Fix UB in Frodo976aes
  * [x] clean
  * [x] opt
* [x] Fix UB in Frodo976shake
  * [x] clean
  * [x] opt
* [x] Fix UB in Frodo1344aes
  * [x] clean
  * [x] opt
* [x] Fix UB in Frodo1344shake
  * [x] clean
  * [x] opt

Shift by width of int:

* [x] McEliece348864f vec
* [x] McEliece460896f vec

Shift left of signed int? in qTESLA:

* [x] qTESLA-p-I
* [x] qTESLA-p-III