### PR TITLE
Split aes*_keyexp up into ecb and ctr variants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ version: 2.1
         command: |
           docker run -e CI=true -e PQCLEAN_ONLY_TYPES -e PQCLEAN_ONLY_DIFF=1 -e PQCLEAN_SKIP_SCHEMES=sphincs-haraka-128f-robust,sphincs-haraka-192s-robust,sphincs-sha256-128f-robust,sphincs-sha256-192s-robust,sphincs-shake256-128f-robust,sphincs-shake256-192s-robust,sphincs-haraka-128f-simple,sphincs-haraka-192s-simple,sphincs-sha256-128f-simple,sphincs-sha256-192s-simple,sphincs-shake256-128f-simple,sphincs-shake256-192s-simple,sphincs-haraka-128s-robust,sphincs-haraka-256f-robust,sphincs-sha256-128s-robust,sphincs-sha256-256f-robust,sphincs-shake256-128s-robust,sphincs-shake256-256f-robust,sphincs-haraka-128s-simple,sphincs-haraka-256f-simple,sphincs-sha256-128s-simple,sphincs-sha256-256f-simple,sphincs-shake256-128s-simple,sphincs-shake256-256f-simple,sphincs-haraka-192f-robust,sphincs-haraka-256s-robust,sphincs-sha256-192f-robust,sphincs-sha256-256s-robust,sphincs-shake256-192f-robust,sphincs-shake256-256s-robust,sphincs-haraka-192f-simple,sphincs-haraka-256s-simple,sphincs-sha256-192f-simple,sphincs-sha256-256s-simple,sphincs-shake256-192f-simple,sphincs-shake256-256s-simple --rm -v `pwd`:`pwd` -w `pwd` -v ~/ccache:/ccache "pqclean/ci-container:$ARCH" /bin/bash -c "
           uname -a &&
+          PQCLEAN_SKIP_TESTS=api_h,char,duplicate_consistency,metadata,preprocessor,no_symlinks,microsoft_nmakefile_present,makefile_present,format,license
           export CCACHE_NOSTATS=1 &&
           export CCACHE_DIR=/ccache &&
           export CCACHE_SLOPPINESS=include_file_mtime &&

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2.1
         command: |
           docker run -e CI=true -e PQCLEAN_ONLY_TYPES -e PQCLEAN_ONLY_DIFF=1 -e PQCLEAN_SKIP_SCHEMES=sphincs-haraka-128f-robust,sphincs-haraka-192s-robust,sphincs-sha256-128f-robust,sphincs-sha256-192s-robust,sphincs-shake256-128f-robust,sphincs-shake256-192s-robust,sphincs-haraka-128f-simple,sphincs-haraka-192s-simple,sphincs-sha256-128f-simple,sphincs-sha256-192s-simple,sphincs-shake256-128f-simple,sphincs-shake256-192s-simple,sphincs-haraka-128s-robust,sphincs-haraka-256f-robust,sphincs-sha256-128s-robust,sphincs-sha256-256f-robust,sphincs-shake256-128s-robust,sphincs-shake256-256f-robust,sphincs-haraka-128s-simple,sphincs-haraka-256f-simple,sphincs-sha256-128s-simple,sphincs-sha256-256f-simple,sphincs-shake256-128s-simple,sphincs-shake256-256f-simple,sphincs-haraka-192f-robust,sphincs-haraka-256s-robust,sphincs-sha256-192f-robust,sphincs-sha256-256s-robust,sphincs-shake256-192f-robust,sphincs-shake256-256s-robust,sphincs-haraka-192f-simple,sphincs-haraka-256s-simple,sphincs-sha256-192f-simple,sphincs-sha256-256s-simple,sphincs-shake256-192f-simple,sphincs-shake256-256s-simple --rm -v `pwd`:`pwd` -w `pwd` -v ~/ccache:/ccache "pqclean/ci-container:$ARCH" /bin/bash -c "
           uname -a &&
-          PQCLEAN_SKIP_TESTS=api_h,char,duplicate_consistency,metadata,preprocessor,no_symlinks,microsoft_nmakefile_present,makefile_present,format,license
+          PQCLEAN_SKIP_TESTS=api_h,char,duplicate_consistency,metadata,preprocessor,no_symlinks,microsoft_nmakefile_present,makefile_present,format,license,clang_tidy
           export CCACHE_NOSTATS=1 &&
           export CCACHE_DIR=/ccache &&
           export CCACHE_SLOPPINESS=include_file_mtime &&

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ See the section [API](#API) below.
     ```
     4. You may run the tests in the `tests/` folder. See the `README` for how to run the test suite.
     5. Migrate your use of AES, SHA-2, and SHA-3 to the API in the `common` directory.
-    Note that if you use the AES API, you must use the `aes128_keyexp` routine (or 192 or 256) to expand the key into a key schedule object,
+    Note that if you use the AES API, you must use the `aes128_ecb_keyexp` or aes128_ctr_keyexp` routines (or 192 or 256) to expand the key into a key schedule object,
     then use `aes128_ctx_release` to release the key schedule object once you're finished with it.
     For the SHAKE API, use the appropriate `_ctx_release` functions.
     For fixed-output functions SHA-2 and SHA-3, the `_finalize` function will free the state.

--- a/common/aes.c
+++ b/common/aes.c
@@ -587,7 +587,7 @@ void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key) {
 }
 
 void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key) {
-    return aes128_ecb_keyexp(r, key);
+    aes128_ecb_keyexp(r, key);
 }
 
 
@@ -604,7 +604,7 @@ void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key) {
 
 
 void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key) {
-    return aes192_ecb_keyexp(r, key);
+    aes192_ecb_keyexp(r, key);
 }
 
 
@@ -621,7 +621,7 @@ void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key) {
 
 
 void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key) {
-    return aes256_ecb_keyexp(r, key);
+    aes256_ecb_keyexp(r, key);
 }
 
 

--- a/common/aes.c
+++ b/common/aes.c
@@ -574,7 +574,7 @@ static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, 
 
 
 
-void aes128_keyexp(aes128ctx *r, const unsigned char *key) {
+void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key) {
     uint64_t skey[22];
 
     r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES128_STATESIZE);
@@ -586,8 +586,12 @@ void aes128_keyexp(aes128ctx *r, const unsigned char *key) {
     br_aes_ct64_skey_expand(r->sk_exp, skey, 10);
 }
 
+void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key) {
+    return aes128_ecb_keyexp(r, key);
+}
 
-void aes192_keyexp(aes192ctx *r, const unsigned char *key) {
+
+void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key) {
     uint64_t skey[26];
     r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES192_STATESIZE);
     if (r->sk_exp == NULL) {
@@ -599,7 +603,12 @@ void aes192_keyexp(aes192ctx *r, const unsigned char *key) {
 }
 
 
-void aes256_keyexp(aes256ctx *r, const unsigned char *key) {
+void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key) {
+    return aes192_ecb_keyexp(r, key);
+}
+
+
+void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key) {
     uint64_t skey[30];
     r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES256_STATESIZE);
     if (r->sk_exp == NULL) {
@@ -608,6 +617,11 @@ void aes256_keyexp(aes256ctx *r, const unsigned char *key) {
 
     br_aes_ct64_keysched(skey, key, 32);
     br_aes_ct64_skey_expand(r->sk_exp, skey, 14);
+}
+
+
+void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key) {
+    return aes256_ecb_keyexp(r, key);
 }
 
 

--- a/common/aes.h
+++ b/common/aes.h
@@ -29,7 +29,9 @@ typedef struct {
 
 
 /** Initializes the context **/
-void aes128_keyexp(aes128ctx *r, const unsigned char *key);
+void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key);
+
+void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key);
 
 void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes128ctx *ctx);
 
@@ -40,7 +42,9 @@ void aes128_ctx_release(aes128ctx *r);
 
 
 /** Initializes the context **/
-void aes192_keyexp(aes192ctx *r, const unsigned char *key);
+void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key);
+
+void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key);
 
 void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes192ctx *ctx);
 
@@ -50,7 +54,9 @@ void aes192_ctx_release(aes192ctx *r);
 
 
 /** Initializes the context **/
-void aes256_keyexp(aes256ctx *r, const unsigned char *key);
+void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key);
+
+void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key);
 
 void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes256ctx *ctx);
 

--- a/crypto_kem/frodokem1344aes/clean/matrix_aes.c
+++ b/crypto_kem/frodokem1344aes/clean/matrix_aes.c
@@ -21,7 +21,7 @@ int PQCLEAN_FRODOKEM1344AES_CLEAN_mul_add_as_plus_e(uint16_t *out, const uint16_
     int16_t A[PARAMS_N * PARAMS_N] = {0};
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
     for (i = 0; i < PARAMS_N; i++) {
         for (j = 0; j < PARAMS_N; j += PARAMS_STRIPE_STEP) {
             A[i * PARAMS_N + j] = (int16_t) i;                            // Loading values in the little-endian order
@@ -62,7 +62,7 @@ int PQCLEAN_FRODOKEM1344AES_CLEAN_mul_add_sa_plus_e(uint16_t *out, const uint16_
     int16_t A[PARAMS_N * PARAMS_N] = {0};
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
     for (i = 0; i < PARAMS_N; i++) {
         for (j = 0; j < PARAMS_N; j += PARAMS_STRIPE_STEP) {
             A[i * PARAMS_N + j] = (int16_t) i;                            // Loading values in the little-endian order

--- a/crypto_kem/frodokem1344aes/opt/matrix_aes.c
+++ b/crypto_kem/frodokem1344aes/opt/matrix_aes.c
@@ -28,7 +28,7 @@ int PQCLEAN_FRODOKEM1344AES_OPT_mul_add_as_plus_e(uint16_t *out, const uint16_t 
     int16_t a_row_temp[4 * PARAMS_N] = {0};                     // Take four lines of A at once
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
 
     for (j = 0; j < PARAMS_N; j += PARAMS_STRIPE_STEP) {
         a_row_temp[j + 1 + 0 * PARAMS_N] = PQCLEAN_FRODOKEM1344AES_OPT_UINT16_TO_LE(j);     // Loading values in the little-endian order
@@ -86,7 +86,7 @@ int PQCLEAN_FRODOKEM1344AES_OPT_mul_add_sa_plus_e(uint16_t *out, const uint16_t 
     uint16_t a_cols_temp[PARAMS_N * PARAMS_STRIPE_STEP] = {0};
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
 
     for (i = 0, j = 0; i < PARAMS_N; i++, j += PARAMS_STRIPE_STEP) {
         a_cols_temp[j] = PQCLEAN_FRODOKEM1344AES_OPT_UINT16_TO_LE(i);                       // Loading values in the little-endian order

--- a/crypto_kem/frodokem640aes/clean/matrix_aes.c
+++ b/crypto_kem/frodokem640aes/clean/matrix_aes.c
@@ -21,7 +21,7 @@ int PQCLEAN_FRODOKEM640AES_CLEAN_mul_add_as_plus_e(uint16_t *out, const uint16_t
     int16_t A[PARAMS_N * PARAMS_N] = {0};
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
     for (i = 0; i < PARAMS_N; i++) {
         for (j = 0; j < PARAMS_N; j += PARAMS_STRIPE_STEP) {
             A[i * PARAMS_N + j] = (int16_t) i;                            // Loading values in the little-endian order
@@ -62,7 +62,7 @@ int PQCLEAN_FRODOKEM640AES_CLEAN_mul_add_sa_plus_e(uint16_t *out, const uint16_t
     int16_t A[PARAMS_N * PARAMS_N] = {0};
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
     for (i = 0; i < PARAMS_N; i++) {
         for (j = 0; j < PARAMS_N; j += PARAMS_STRIPE_STEP) {
             A[i * PARAMS_N + j] = (int16_t) i;                            // Loading values in the little-endian order

--- a/crypto_kem/frodokem640aes/opt/matrix_aes.c
+++ b/crypto_kem/frodokem640aes/opt/matrix_aes.c
@@ -28,7 +28,7 @@ int PQCLEAN_FRODOKEM640AES_OPT_mul_add_as_plus_e(uint16_t *out, const uint16_t *
     int16_t a_row_temp[4 * PARAMS_N] = {0};                     // Take four lines of A at once
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
 
     for (j = 0; j < PARAMS_N; j += PARAMS_STRIPE_STEP) {
         a_row_temp[j + 1 + 0 * PARAMS_N] = PQCLEAN_FRODOKEM640AES_OPT_UINT16_TO_LE(j);     // Loading values in the little-endian order
@@ -86,7 +86,7 @@ int PQCLEAN_FRODOKEM640AES_OPT_mul_add_sa_plus_e(uint16_t *out, const uint16_t *
     uint16_t a_cols_temp[PARAMS_N * PARAMS_STRIPE_STEP] = {0};
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
 
     for (i = 0, j = 0; i < PARAMS_N; i++, j += PARAMS_STRIPE_STEP) {
         a_cols_temp[j] = PQCLEAN_FRODOKEM640AES_OPT_UINT16_TO_LE(i);                       // Loading values in the little-endian order

--- a/crypto_kem/frodokem976aes/clean/matrix_aes.c
+++ b/crypto_kem/frodokem976aes/clean/matrix_aes.c
@@ -21,7 +21,7 @@ int PQCLEAN_FRODOKEM976AES_CLEAN_mul_add_as_plus_e(uint16_t *out, const uint16_t
     int16_t A[PARAMS_N * PARAMS_N] = {0};
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
     for (i = 0; i < PARAMS_N; i++) {
         for (j = 0; j < PARAMS_N; j += PARAMS_STRIPE_STEP) {
             A[i * PARAMS_N + j] = (int16_t) i;                            // Loading values in the little-endian order
@@ -62,7 +62,7 @@ int PQCLEAN_FRODOKEM976AES_CLEAN_mul_add_sa_plus_e(uint16_t *out, const uint16_t
     int16_t A[PARAMS_N * PARAMS_N] = {0};
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
     for (i = 0; i < PARAMS_N; i++) {
         for (j = 0; j < PARAMS_N; j += PARAMS_STRIPE_STEP) {
             A[i * PARAMS_N + j] = (int16_t) i;                            // Loading values in the little-endian order

--- a/crypto_kem/frodokem976aes/opt/matrix_aes.c
+++ b/crypto_kem/frodokem976aes/opt/matrix_aes.c
@@ -28,7 +28,7 @@ int PQCLEAN_FRODOKEM976AES_OPT_mul_add_as_plus_e(uint16_t *out, const uint16_t *
     int16_t a_row_temp[4 * PARAMS_N] = {0};                     // Take four lines of A at once
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
 
     for (j = 0; j < PARAMS_N; j += PARAMS_STRIPE_STEP) {
         a_row_temp[j + 1 + 0 * PARAMS_N] = PQCLEAN_FRODOKEM976AES_OPT_UINT16_TO_LE(j);     // Loading values in the little-endian order
@@ -86,7 +86,7 @@ int PQCLEAN_FRODOKEM976AES_OPT_mul_add_sa_plus_e(uint16_t *out, const uint16_t *
     uint16_t a_cols_temp[PARAMS_N * PARAMS_STRIPE_STEP] = {0};
     aes128ctx ctx128;
 
-    aes128_keyexp(&ctx128, seed_A);
+    aes128_ecb_keyexp(&ctx128, seed_A);
 
     for (i = 0, j = 0; i < PARAMS_N; i++, j += PARAMS_STRIPE_STEP) {
         a_cols_temp[j] = PQCLEAN_FRODOKEM976AES_OPT_UINT16_TO_LE(i);                       // Loading values in the little-endian order

--- a/crypto_kem/kyber1024-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber1024-90s/clean/aes256ctr.c
@@ -52,7 +52,7 @@ void PQCLEAN_KYBER102490S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const
     iv[0] = nonce;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, key);
+    aes256_ctr_keyexp(&ctx, key);
     aes256_ctr(output, outlen, iv, &ctx);
     aes256_ctx_release(&ctx);
 }
@@ -70,7 +70,7 @@ void PQCLEAN_KYBER102490S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const
 *              - uint8_t y:           second additional byte to "absorb"
 **************************************************/
 void PQCLEAN_KYBER102490S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t *key, uint8_t x, uint8_t y) {
-    aes256_keyexp(&s->sk_exp, key);
+    aes256_ctr_keyexp(&s->sk_exp, key);
     for (int i = 2; i < 12; i++) {
         s->iv[i] = 0;
     }

--- a/crypto_kem/kyber1024-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber1024-90s/clean/aes256ctr.c
@@ -70,7 +70,7 @@ void PQCLEAN_KYBER102490S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const
 *              - uint8_t y:           second additional byte to "absorb"
 **************************************************/
 void PQCLEAN_KYBER102490S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t *key, uint8_t x, uint8_t y) {
-    aes256_ctr_keyexp(&s->sk_exp, key);
+    aes256_ecb_keyexp(&s->sk_exp, key);
     for (int i = 2; i < 12; i++) {
         s->iv[i] = 0;
     }

--- a/crypto_kem/kyber512-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber512-90s/clean/aes256ctr.c
@@ -52,7 +52,7 @@ void PQCLEAN_KYBER51290S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const 
     iv[0] = nonce;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, key);
+    aes256_ctr_keyexp(&ctx, key);
     aes256_ctr(output, outlen, iv, &ctx);
     aes256_ctx_release(&ctx);
 }
@@ -70,7 +70,7 @@ void PQCLEAN_KYBER51290S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const 
 *              - uint8_t y:           second additional byte to "absorb"
 **************************************************/
 void PQCLEAN_KYBER51290S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t *key, uint8_t x, uint8_t y) {
-    aes256_keyexp(&s->sk_exp, key);
+    aes256_ctr_keyexp(&s->sk_exp, key);
     for (int i = 2; i < 12; i++) {
         s->iv[i] = 0;
     }

--- a/crypto_kem/kyber512-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber512-90s/clean/aes256ctr.c
@@ -70,7 +70,7 @@ void PQCLEAN_KYBER51290S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const 
 *              - uint8_t y:           second additional byte to "absorb"
 **************************************************/
 void PQCLEAN_KYBER51290S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t *key, uint8_t x, uint8_t y) {
-    aes256_ctr_keyexp(&s->sk_exp, key);
+    aes256_ecb_keyexp(&s->sk_exp, key);
     for (int i = 2; i < 12; i++) {
         s->iv[i] = 0;
     }

--- a/crypto_kem/kyber768-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber768-90s/clean/aes256ctr.c
@@ -52,7 +52,7 @@ void PQCLEAN_KYBER76890S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const 
     iv[0] = nonce;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, key);
+    aes256_ctr_keyexp(&ctx, key);
     aes256_ctr(output, outlen, iv, &ctx);
     aes256_ctx_release(&ctx);
 }
@@ -70,7 +70,7 @@ void PQCLEAN_KYBER76890S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const 
 *              - uint8_t y:           second additional byte to "absorb"
 **************************************************/
 void PQCLEAN_KYBER76890S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t *key, uint8_t x, uint8_t y) {
-    aes256_keyexp(&s->sk_exp, key);
+    aes256_ctr_keyexp(&s->sk_exp, key);
     for (int i = 2; i < 12; i++) {
         s->iv[i] = 0;
     }

--- a/crypto_kem/kyber768-90s/clean/aes256ctr.c
+++ b/crypto_kem/kyber768-90s/clean/aes256ctr.c
@@ -70,7 +70,7 @@ void PQCLEAN_KYBER76890S_CLEAN_aes256_prf(uint8_t *output, size_t outlen, const 
 *              - uint8_t y:           second additional byte to "absorb"
 **************************************************/
 void PQCLEAN_KYBER76890S_CLEAN_aes256xof_absorb(aes256xof_ctx *s, const uint8_t *key, uint8_t x, uint8_t y) {
-    aes256_ctr_keyexp(&s->sk_exp, key);
+    aes256_ecb_keyexp(&s->sk_exp, key);
     for (int i = 2; i < 12; i++) {
         s->iv[i] = 0;
     }

--- a/crypto_kem/ledakemlt12/leaktime/rng.c
+++ b/crypto_kem/ledakemlt12/leaktime/rng.c
@@ -72,7 +72,7 @@ int PQCLEAN_LEDAKEMLT12_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
         return RNG_BAD_REQ_LEN;
     }
 
-    aes256_keyexp(&ctx256, ctx->key);
+    aes256_ecb_keyexp(&ctx256, ctx->key);
     ctx->length_remaining -= xlen;
 
     offset = 0;

--- a/crypto_kem/ledakemlt32/leaktime/rng.c
+++ b/crypto_kem/ledakemlt32/leaktime/rng.c
@@ -72,7 +72,7 @@ int PQCLEAN_LEDAKEMLT32_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
         return RNG_BAD_REQ_LEN;
     }
 
-    aes256_keyexp(&ctx256, ctx->key);
+    aes256_ecb_keyexp(&ctx256, ctx->key);
     ctx->length_remaining -= xlen;
 
     offset = 0;

--- a/crypto_kem/ledakemlt52/leaktime/rng.c
+++ b/crypto_kem/ledakemlt52/leaktime/rng.c
@@ -72,7 +72,7 @@ int PQCLEAN_LEDAKEMLT52_LEAKTIME_seedexpander(AES_XOF_struct *ctx, uint8_t *x, s
         return RNG_BAD_REQ_LEN;
     }
 
-    aes256_keyexp(&ctx256, ctx->key);
+    aes256_ecb_keyexp(&ctx256, ctx->key);
     ctx->length_remaining -= xlen;
 
     offset = 0;

--- a/crypto_kem/mceliece348864/avx/aes256ctr.c
+++ b/crypto_kem/mceliece348864/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE348864_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece348864/clean/aes256ctr.c
+++ b/crypto_kem/mceliece348864/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE348864_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece348864/sse/aes256ctr.c
+++ b/crypto_kem/mceliece348864/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE348864_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece348864/vec/aes256ctr.c
+++ b/crypto_kem/mceliece348864/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE348864_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece348864f/avx/aes256ctr.c
+++ b/crypto_kem/mceliece348864f/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE348864F_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece348864f/clean/aes256ctr.c
+++ b/crypto_kem/mceliece348864f/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE348864F_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece348864f/sse/aes256ctr.c
+++ b/crypto_kem/mceliece348864f/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE348864F_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece348864f/vec/aes256ctr.c
+++ b/crypto_kem/mceliece348864f/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE348864F_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece460896/avx/aes256ctr.c
+++ b/crypto_kem/mceliece460896/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE460896_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece460896/clean/aes256ctr.c
+++ b/crypto_kem/mceliece460896/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE460896_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece460896/sse/aes256ctr.c
+++ b/crypto_kem/mceliece460896/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE460896_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece460896/vec/aes256ctr.c
+++ b/crypto_kem/mceliece460896/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE460896_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece460896f/avx/aes256ctr.c
+++ b/crypto_kem/mceliece460896f/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE460896F_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece460896f/clean/aes256ctr.c
+++ b/crypto_kem/mceliece460896f/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE460896F_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece460896f/sse/aes256ctr.c
+++ b/crypto_kem/mceliece460896f/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE460896F_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece460896f/vec/aes256ctr.c
+++ b/crypto_kem/mceliece460896f/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE460896F_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6688128/avx/aes256ctr.c
+++ b/crypto_kem/mceliece6688128/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6688128_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6688128/clean/aes256ctr.c
+++ b/crypto_kem/mceliece6688128/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6688128_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6688128/sse/aes256ctr.c
+++ b/crypto_kem/mceliece6688128/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6688128_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6688128/vec/aes256ctr.c
+++ b/crypto_kem/mceliece6688128/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6688128_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6688128f/avx/aes256ctr.c
+++ b/crypto_kem/mceliece6688128f/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6688128F_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6688128f/clean/aes256ctr.c
+++ b/crypto_kem/mceliece6688128f/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6688128F_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6688128f/sse/aes256ctr.c
+++ b/crypto_kem/mceliece6688128f/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6688128F_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6688128f/vec/aes256ctr.c
+++ b/crypto_kem/mceliece6688128f/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6688128F_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6960119/avx/aes256ctr.c
+++ b/crypto_kem/mceliece6960119/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6960119_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6960119/clean/aes256ctr.c
+++ b/crypto_kem/mceliece6960119/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6960119_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6960119/sse/aes256ctr.c
+++ b/crypto_kem/mceliece6960119/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6960119_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6960119/vec/aes256ctr.c
+++ b/crypto_kem/mceliece6960119/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6960119_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6960119f/avx/aes256ctr.c
+++ b/crypto_kem/mceliece6960119f/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6960119F_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6960119f/clean/aes256ctr.c
+++ b/crypto_kem/mceliece6960119f/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6960119F_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6960119f/sse/aes256ctr.c
+++ b/crypto_kem/mceliece6960119f/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6960119F_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece6960119f/vec/aes256ctr.c
+++ b/crypto_kem/mceliece6960119f/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE6960119F_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece8192128/avx/aes256ctr.c
+++ b/crypto_kem/mceliece8192128/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE8192128_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece8192128/clean/aes256ctr.c
+++ b/crypto_kem/mceliece8192128/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE8192128_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece8192128/sse/aes256ctr.c
+++ b/crypto_kem/mceliece8192128/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE8192128_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece8192128/vec/aes256ctr.c
+++ b/crypto_kem/mceliece8192128/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE8192128_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece8192128f/avx/aes256ctr.c
+++ b/crypto_kem/mceliece8192128f/avx/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE8192128F_AVX_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece8192128f/clean/aes256ctr.c
+++ b/crypto_kem/mceliece8192128f/clean/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE8192128F_CLEAN_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece8192128f/sse/aes256ctr.c
+++ b/crypto_kem/mceliece8192128f/sse/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE8192128F_SSE_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_kem/mceliece8192128f/vec/aes256ctr.c
+++ b/crypto_kem/mceliece8192128f/vec/aes256ctr.c
@@ -7,7 +7,7 @@ void PQCLEAN_MCELIECE8192128F_VEC_aes256ctr(
     const uint8_t key[AES256_KEYBYTES]) {
 
     aes256ctx state;
-    aes256_keyexp(&state, key);
+    aes256_ctr_keyexp(&state, key);
     aes256_ctr(out, outlen, nonce, &state);
     aes256_ctx_release(&state);
 }

--- a/crypto_sign/rainbowIIIc-classic/clean/utils_prng.c
+++ b/crypto_sign/rainbowIIIc-classic/clean/utils_prng.c
@@ -14,7 +14,7 @@ static void prng_update(const unsigned char *provided_data,
                         unsigned char *V) {
     unsigned char temp[48];
     aes256ctx ctx;
-    aes256_keyexp(&ctx, Key);
+    aes256_ecb_keyexp(&ctx, Key);
     for (int i = 0; i < 3; i++) {
         //increment V
         for (int j = 15; j >= 0; j--) {
@@ -51,7 +51,7 @@ static int randombytes_with_state(prng_t *state,
     int i = 0;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, state->Key);
+    aes256_ecb_keyexp(&ctx, state->Key);
 
     while (xlen > 0) {
         //increment V

--- a/crypto_sign/rainbowIIIc-cyclic-compressed/clean/utils_prng.c
+++ b/crypto_sign/rainbowIIIc-cyclic-compressed/clean/utils_prng.c
@@ -14,7 +14,7 @@ static void prng_update(const unsigned char *provided_data,
                         unsigned char *V) {
     unsigned char temp[48];
     aes256ctx ctx;
-    aes256_keyexp(&ctx, Key);
+    aes256_ecb_keyexp(&ctx, Key);
     for (int i = 0; i < 3; i++) {
         //increment V
         for (int j = 15; j >= 0; j--) {
@@ -51,7 +51,7 @@ static int randombytes_with_state(prng_t *state,
     int i = 0;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, state->Key);
+    aes256_ecb_keyexp(&ctx, state->Key);
 
     while (xlen > 0) {
         //increment V

--- a/crypto_sign/rainbowIIIc-cyclic/clean/utils_prng.c
+++ b/crypto_sign/rainbowIIIc-cyclic/clean/utils_prng.c
@@ -14,7 +14,7 @@ static void prng_update(const unsigned char *provided_data,
                         unsigned char *V) {
     unsigned char temp[48];
     aes256ctx ctx;
-    aes256_keyexp(&ctx, Key);
+    aes256_ecb_keyexp(&ctx, Key);
     for (int i = 0; i < 3; i++) {
         //increment V
         for (int j = 15; j >= 0; j--) {
@@ -51,7 +51,7 @@ static int randombytes_with_state(prng_t *state,
     int i = 0;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, state->Key);
+    aes256_ecb_keyexp(&ctx, state->Key);
 
     while (xlen > 0) {
         //increment V

--- a/crypto_sign/rainbowIa-classic/clean/utils_prng.c
+++ b/crypto_sign/rainbowIa-classic/clean/utils_prng.c
@@ -14,7 +14,7 @@ static void prng_update(const unsigned char *provided_data,
                         unsigned char *V) {
     unsigned char temp[48];
     aes256ctx ctx;
-    aes256_keyexp(&ctx, Key);
+    aes256_ecb_keyexp(&ctx, Key);
     for (int i = 0; i < 3; i++) {
         //increment V
         for (int j = 15; j >= 0; j--) {
@@ -51,7 +51,7 @@ static int randombytes_with_state(prng_t *state,
     int i = 0;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, state->Key);
+    aes256_ecb_keyexp(&ctx, state->Key);
 
     while (xlen > 0) {
         //increment V

--- a/crypto_sign/rainbowIa-cyclic-compressed/clean/utils_prng.c
+++ b/crypto_sign/rainbowIa-cyclic-compressed/clean/utils_prng.c
@@ -14,7 +14,7 @@ static void prng_update(const unsigned char *provided_data,
                         unsigned char *V) {
     unsigned char temp[48];
     aes256ctx ctx;
-    aes256_keyexp(&ctx, Key);
+    aes256_ecb_keyexp(&ctx, Key);
     for (int i = 0; i < 3; i++) {
         //increment V
         for (int j = 15; j >= 0; j--) {
@@ -51,7 +51,7 @@ static int randombytes_with_state(prng_t *state,
     int i = 0;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, state->Key);
+    aes256_ecb_keyexp(&ctx, state->Key);
 
     while (xlen > 0) {
         //increment V

--- a/crypto_sign/rainbowIa-cyclic/clean/utils_prng.c
+++ b/crypto_sign/rainbowIa-cyclic/clean/utils_prng.c
@@ -14,7 +14,7 @@ static void prng_update(const unsigned char *provided_data,
                         unsigned char *V) {
     unsigned char temp[48];
     aes256ctx ctx;
-    aes256_keyexp(&ctx, Key);
+    aes256_ecb_keyexp(&ctx, Key);
     for (int i = 0; i < 3; i++) {
         //increment V
         for (int j = 15; j >= 0; j--) {
@@ -51,7 +51,7 @@ static int randombytes_with_state(prng_t *state,
     int i = 0;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, state->Key);
+    aes256_ecb_keyexp(&ctx, state->Key);
 
     while (xlen > 0) {
         //increment V

--- a/crypto_sign/rainbowVc-classic/clean/utils_prng.c
+++ b/crypto_sign/rainbowVc-classic/clean/utils_prng.c
@@ -14,7 +14,7 @@ static void prng_update(const unsigned char *provided_data,
                         unsigned char *V) {
     unsigned char temp[48];
     aes256ctx ctx;
-    aes256_keyexp(&ctx, Key);
+    aes256_ecb_keyexp(&ctx, Key);
     for (int i = 0; i < 3; i++) {
         //increment V
         for (int j = 15; j >= 0; j--) {
@@ -51,7 +51,7 @@ static int randombytes_with_state(prng_t *state,
     int i = 0;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, state->Key);
+    aes256_ecb_keyexp(&ctx, state->Key);
 
     while (xlen > 0) {
         //increment V

--- a/crypto_sign/rainbowVc-cyclic-compressed/clean/utils_prng.c
+++ b/crypto_sign/rainbowVc-cyclic-compressed/clean/utils_prng.c
@@ -14,7 +14,7 @@ static void prng_update(const unsigned char *provided_data,
                         unsigned char *V) {
     unsigned char temp[48];
     aes256ctx ctx;
-    aes256_keyexp(&ctx, Key);
+    aes256_ecb_keyexp(&ctx, Key);
     for (int i = 0; i < 3; i++) {
         //increment V
         for (int j = 15; j >= 0; j--) {
@@ -51,7 +51,7 @@ static int randombytes_with_state(prng_t *state,
     int i = 0;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, state->Key);
+    aes256_ecb_keyexp(&ctx, state->Key);
 
     while (xlen > 0) {
         //increment V

--- a/crypto_sign/rainbowVc-cyclic/clean/utils_prng.c
+++ b/crypto_sign/rainbowVc-cyclic/clean/utils_prng.c
@@ -14,7 +14,7 @@ static void prng_update(const unsigned char *provided_data,
                         unsigned char *V) {
     unsigned char temp[48];
     aes256ctx ctx;
-    aes256_keyexp(&ctx, Key);
+    aes256_ecb_keyexp(&ctx, Key);
     for (int i = 0; i < 3; i++) {
         //increment V
         for (int j = 15; j >= 0; j--) {
@@ -51,7 +51,7 @@ static int randombytes_with_state(prng_t *state,
     int i = 0;
 
     aes256ctx ctx;
-    aes256_keyexp(&ctx, state->Key);
+    aes256_ecb_keyexp(&ctx, state->Key);
 
     while (xlen > 0) {
         //increment V

--- a/test/common/nistkatrng.c
+++ b/test/common/nistkatrng.c
@@ -27,7 +27,7 @@ static void AES256_CTR_DRBG_Update(const uint8_t *provided_data, uint8_t *Key, u
 //    buffer - a 128-bit ciphertext value
 static void AES256_ECB(uint8_t *key, uint8_t *ctr, uint8_t *buffer) {
     aes256ctx ctx;
-    aes256_keyexp(&ctx, key);
+    aes256_ecb_keyexp(&ctx, key);
     aes256_ecb(buffer, ctr, 1, &ctx);
     aes256_ctx_release(&ctx);
 }

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -39,8 +39,8 @@ def walk_tree(ast, parent=[]):
     pqclean.Scheme.all_implementations(),
     ids=str,
 )
-@helpers.filtered_test
 @helpers.skip_windows()
+@helpers.filtered_test
 def test_char(implementation):
     errors = []
     for fname in os.listdir(implementation.path()):

--- a/test/test_common/aes.c
+++ b/test/test_common/aes.c
@@ -51,54 +51,60 @@ int main(void)
 {
   unsigned char ct[67];
   int r = 0;
-  aes128ctx ctx128; 
-  aes192ctx ctx192; 
-  aes256ctx ctx256; 
+  aes128ctx ctx128_ecb, ctx128_ctr;
+  aes192ctx ctx192_ecb, ctx192_ctr;
+  aes256ctx ctx256_ecb, ctx256_ctr;
 
-  aes128_keyexp(&ctx128, key);
-  aes192_keyexp(&ctx192, key);
-  aes256_keyexp(&ctx256, key);
+  aes128_ecb_keyexp(&ctx128_ecb, key);
+  aes192_ecb_keyexp(&ctx192_ecb, key);
+  aes256_ecb_keyexp(&ctx256_ecb, key);
+  aes128_ctr_keyexp(&ctx128_ctr, key);
+  aes192_ctr_keyexp(&ctx192_ctr, key);
+  aes256_ctr_keyexp(&ctx256_ctr, key);
 
-  aes128_ctr(ct, 67, nonce, &ctx128);
+  aes128_ctr(ct, 67, nonce, &ctx128_ctr);
   if(memcmp(ct, stream128, 67)) {
     printf("ERROR AES128CTR output does not match test vector.\n");
     r = 1;
   }
 
-  aes192_ctr(ct, 67, nonce, &ctx192);
+  aes192_ctr(ct, 67, nonce, &ctx192_ctr);
   if(memcmp(ct, stream192, 67)) {
     printf("ERROR AES192CTR output does not match test vector.\n");
     r = 1;
   }
 
-  aes256_ctr(ct, 67, nonce, &ctx256);
+  aes256_ctr(ct, 67, nonce, &ctx256_ctr);
   if(memcmp(ct, stream256, 67)) {
     printf("ERROR AES256CTR output does not match test vector.\n");
     r = 1;
   }
 
 
-  aes128_ecb(ct, msg, sizeof(msg) / AES_BLOCKBYTES, &ctx128);
+  aes128_ecb(ct, msg, sizeof(msg) / AES_BLOCKBYTES, &ctx128_ecb);
   if(memcmp(ct, ct128, 48)) {
     printf("ERROR AES128ECB output does not match test vector.\n");
     r = 1;
   }
 
-  aes192_ecb(ct, msg, sizeof(msg) / AES_BLOCKBYTES, &ctx192);
+  aes192_ecb(ct, msg, sizeof(msg) / AES_BLOCKBYTES, &ctx192_ecb);
   if(memcmp(ct, ct192, 48)) {
     printf("ERROR AES192ECB output does not match test vector.\n");
     r = 1;
   }
 
-  aes256_ecb(ct, msg, sizeof(msg) / AES_BLOCKBYTES, &ctx256);
+  aes256_ecb(ct, msg, sizeof(msg) / AES_BLOCKBYTES, &ctx256_ecb);
   if(memcmp(ct, ct256, 48)) {
     printf("ERROR AES256ECB output does not match test vector.\n");
     r = 1;
   }
 
-  aes128_ctx_release(&ctx128);
-  aes192_ctx_release(&ctx192);
-  aes256_ctx_release(&ctx256);
+  aes128_ctx_release(&ctx128_ecb);
+  aes192_ctx_release(&ctx192_ecb);
+  aes256_ctx_release(&ctx256_ecb);
+  aes128_ctx_release(&ctx128_ctr);
+  aes192_ctx_release(&ctx192_ctr);
+  aes256_ctx_release(&ctx256_ctr);
 
   return r;
 }

--- a/test/test_duplicate_consistency.py
+++ b/test/test_duplicate_consistency.py
@@ -17,28 +17,34 @@ sys.tracebacklimit = 0
 def pytest_generate_tests(metafunc):
     ids = []
     argvalues = []
-    for scheme in pqclean.Scheme.all_schemes():
-        for implementation in scheme.implementations:
-            if os.path.isfile(
-                    os.path.join(
+    if 'duplicate_consistency' not in os.environ.get('PQCLEAN_SKIP_TESTS', '').split(','):
+        for scheme in pqclean.Scheme.all_schemes():
+            for implementation in scheme.implementations:
+                if os.path.isfile(
+                        os.path.join(
+                            'duplicate_consistency',
+                            '{}_{}.yml'.format(scheme.name, implementation.name))):
+                    metafile = os.path.join(
                         'duplicate_consistency',
-                        '{}_{}.yml'.format(scheme.name, implementation.name))):
-                metafile = os.path.join(
-                    'duplicate_consistency',
-                    '{}_{}.yml'.format(scheme.name, implementation.name))
-                with open(metafile, encoding='utf-8') as f:
-                    metadata = yaml.safe_load(f.read())
-                    for group in metadata['consistency_checks']:
-                        source = pqclean.Implementation.by_name(
-                            group['source']['scheme'],
-                            group['source']['implementation'])
-                        argvalues.append(
-                            (implementation, source, group['files']))
-                        ids.append(
-                            "{metafile}: {scheme.name} {implementation.name}"
-                            .format(scheme=scheme,
-                                    implementation=implementation,
-                                    metafile=metafile))
+                        '{}_{}.yml'.format(scheme.name, implementation.name))
+                    with open(metafile, encoding='utf-8') as f:
+                        metadata = yaml.safe_load(f.read())
+                        for group in metadata['consistency_checks']:
+                            source = pqclean.Implementation.by_name(
+                                group['source']['scheme'],
+                                group['source']['implementation'])
+                            argvalues.append(
+                                (implementation, source, group['files']))
+                            ids.append(
+                                "{metafile}: {scheme.name} {implementation.name}"
+                                .format(scheme=scheme,
+                                        implementation=implementation,
+                                        metafile=metafile))
+    else:
+        # Placeholders so we don't crash
+        ids = ['dummy']
+        argvalues = [('dummy', 'dummy', 'dummy')]
+
     metafunc.parametrize(('implementation', 'source', 'files'),
                          argvalues,
                          ids=ids)

--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -19,9 +19,6 @@ additional_flags = [] #['-fix-errors']
 @helpers.skip_windows()
 @helpers.filtered_test
 def test_clang_tidy(implementation: pqclean.Implementation):
-    if platform.machine() in ['armv7l']:
-        # armv7l: slow, not more useful than i386
-        raise unittest.SkipTest()
     helpers.ensure_available('clang-tidy')
     cfiles = implementation.cfiles()
     common_files = glob(os.path.join('..', 'common', '*.c'))

--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -19,8 +19,9 @@ additional_flags = [] #['-fix-errors']
 @helpers.skip_windows()
 @helpers.filtered_test
 def test_clang_tidy(implementation: pqclean.Implementation):
-    if platform.machine() in ['i386']:
-        raise unittest.SkipTest("Clang-tidy has false-positives on i386")
+    if platform.machine() in ['armv7l']:
+        # armv7l: slow, not more useful than i386
+        raise unittest.SkipTest()
     helpers.ensure_available('clang-tidy')
     cfiles = implementation.cfiles()
     common_files = glob(os.path.join('..', 'common', '*.c'))


### PR DESCRIPTION
<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->

<!-- If you are not submitting a new scheme, we suggest removing the following lines -->
#### Manually checked properties

* [ ] No stringification macros
* [ ] Output-parameter pointers in functions are on the left
* [ ] Negative return values on failure of API functions (within restrictions of FO transform).
* [ ] variable declarations at the beginning (except in `for (size_t i=...`)
* Optional:
  * [ ] All integer types are of fixed size, using `stdint.h` types (including `uint8_t` instead of `unsigned char`)
  * [ ] Integers used for indexing are of size `size_t`
