### PR TITLE
Avoid type-punning warning in Falcon when strict-aliasing turned on

### DIFF
--- a/crypto_sign/falcon-1024/clean/rng.c
+++ b/crypto_sign/falcon-1024/clean/rng.c
@@ -88,7 +88,6 @@ PQCLEAN_FALCON1024_CLEAN_prng_refill(prng *p) {
 
     uint64_t cc;
     size_t u;
-
     uint32_t *d32 = (uint32_t *) p->state.d;
     uint64_t *d64 = (uint64_t *) p->state.d;
 

--- a/crypto_sign/falcon-512/clean/rng.c
+++ b/crypto_sign/falcon-512/clean/rng.c
@@ -46,6 +46,9 @@ PQCLEAN_FALCON512_CLEAN_prng_init(prng *p, inner_shake256_context *src) {
     uint64_t th, tl;
     int i;
 
+    uint32_t *d32 = (uint32_t *) p->state.d;
+    uint64_t *d64 = (uint64_t *) p->state.d;
+
     inner_shake256_extract(src, tmp, 56);
     for (i = 0; i < 14; i ++) {
         uint32_t w;
@@ -54,11 +57,11 @@ PQCLEAN_FALCON512_CLEAN_prng_init(prng *p, inner_shake256_context *src) {
             | ((uint32_t)tmp[(i << 2) + 1] << 8)
             | ((uint32_t)tmp[(i << 2) + 2] << 16)
             | ((uint32_t)tmp[(i << 2) + 3] << 24);
-        *(uint32_t *)(p->state.d + (i << 2)) = w;
+        d32[i] = w;
     }
-    tl = *(uint32_t *)(p->state.d + 48);
-    th = *(uint32_t *)(p->state.d + 52);
-    *(uint64_t *)(p->state.d + 48) = tl + (th << 32);
+    tl = d32[48 / sizeof(uint32_t)];
+    th = d32[52 / sizeof(uint32_t)];
+    d64[48 / sizeof(uint64_t)] = tl + (th << 32);
     PQCLEAN_FALCON512_CLEAN_prng_refill(p);
 }
 
@@ -86,11 +89,14 @@ PQCLEAN_FALCON512_CLEAN_prng_refill(prng *p) {
     uint64_t cc;
     size_t u;
 
+    uint32_t *d32 = (uint32_t *) p->state.d;
+    uint64_t *d64 = (uint64_t *) p->state.d;
+
     /*
      * State uses local endianness. Only the output bytes must be
      * converted to little endian (if used on a big-endian machine).
      */
-    cc = *(uint64_t *)(p->state.d + 48);
+    cc = d64[48 / sizeof(uint64_t)];
     for (u = 0; u < 8; u ++) {
         uint32_t state[16];
         size_t v;
@@ -134,11 +140,11 @@ PQCLEAN_FALCON512_CLEAN_prng_refill(prng *p) {
             state[v] += CW[v];
         }
         for (v = 4; v < 14; v ++) {
-            state[v] += ((uint32_t *)p->state.d)[v - 4];
+            state[v] += d32[v - 4];
         }
-        state[14] += ((uint32_t *)p->state.d)[10]
+        state[14] += d32[10]
                      ^ (uint32_t)cc;
-        state[15] += ((uint32_t *)p->state.d)[11]
+        state[15] += d32[11]
                      ^ (uint32_t)(cc >> 32);
         cc ++;
 
@@ -157,7 +163,7 @@ PQCLEAN_FALCON512_CLEAN_prng_refill(prng *p) {
                 (uint8_t)(state[v] >> 24);
         }
     }
-    *(uint64_t *)(p->state.d + 48) = cc;
+    d64[48 / sizeof(uint64_t)] = cc;
 
 
     p->ptr = 0;

--- a/crypto_sign/falcon-512/clean/rng.c
+++ b/crypto_sign/falcon-512/clean/rng.c
@@ -142,10 +142,8 @@ PQCLEAN_FALCON512_CLEAN_prng_refill(prng *p) {
         for (v = 4; v < 14; v ++) {
             state[v] += d32[v - 4];
         }
-        state[14] += d32[10]
-                     ^ (uint32_t)cc;
-        state[15] += d32[11]
-                     ^ (uint32_t)(cc >> 32);
+        state[14] += d32[10] ^ (uint32_t)cc;
+        state[15] += d32[11] ^ (uint32_t)(cc >> 32);
         cc ++;
 
         /*

--- a/crypto_sign/falcon-512/clean/rng.c
+++ b/crypto_sign/falcon-512/clean/rng.c
@@ -88,7 +88,6 @@ PQCLEAN_FALCON512_CLEAN_prng_refill(prng *p) {
 
     uint64_t cc;
     size_t u;
-
     uint32_t *d32 = (uint32_t *) p->state.d;
     uint64_t *d64 = (uint64_t *) p->state.d;
 


### PR DESCRIPTION
A liboqs build encountered warnings about type-punning in Falcon, which caused errors when strict aliasing is turned on; see log below.  This patch should fix that.

```../src/sig/falcon/pqclean_falcon-1024_clean/rng.c: In function 'PQCLEAN_FALCON1024_CLEAN_prng_init':
../src/sig/falcon/pqclean_falcon-1024_clean/rng.c:57:9: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
         *(uint32_t *)(p->state.d + (i << 2)) = w;
         ^
../src/sig/falcon/pqclean_falcon-1024_clean/rng.c:59:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     tl = *(uint32_t *)(p->state.d + 48);
     ^
../src/sig/falcon/pqclean_falcon-1024_clean/rng.c:60:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     th = *(uint32_t *)(p->state.d + 52);
     ^
../src/sig/falcon/pqclean_falcon-1024_clean/rng.c:61:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     *(uint64_t *)(p->state.d + 48) = tl + (th << 32);
     ^
../src/sig/falcon/pqclean_falcon-1024_clean/rng.c: In function 'PQCLEAN_FALCON1024_CLEAN_prng_refill':
../src/sig/falcon/pqclean_falcon-1024_clean/rng.c:93:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     cc = *(uint64_t *)(p->state.d + 48);
     ^
../src/sig/falcon/pqclean_falcon-1024_clean/rng.c:139:9: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
         state[14] += ((uint32_t *)p->state.d)[10]
         ^
../src/sig/falcon/pqclean_falcon-1024_clean/rng.c:141:9: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
         state[15] += ((uint32_t *)p->state.d)[11]
         ^
../src/sig/falcon/pqclean_falcon-1024_clean/rng.c:160:5: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
     *(uint64_t *)(p->state.d + 48) = cc;
     ^
```