### PR TITLE
Wshadow at Dilithium/avx2

### DIFF
--- a/crypto_sign/dilithium2/avx2/Makefile
+++ b/crypto_sign/dilithium2/avx2/Makefile
@@ -12,7 +12,7 @@ HEADERS = alignment.h api.h params.h sign.h polyvec.h poly.h packing.h ntt.h  \
 
 CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror \
 	   -Wmissing-prototypes -Wredundant-decls -std=c99 \
-	   -Wcast-align \
+	   -Wcast-align -Werror=shadow\
 	   -mavx2 -mbmi -mpopcnt -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)

--- a/crypto_sign/dilithium2/avx2/fips202x4.c
+++ b/crypto_sign/dilithium2/avx2/fips202x4.c
@@ -43,7 +43,7 @@ static void keccak_absorb4x(__m256i *s,
     uint8_t t3[200];
     uint64_t *ss = (uint64_t *)s;
 
-    for (size_t i = 0; i < 25; ++i) {
+    for (i = 0; i < 25; ++i) {
         s[i] = _mm256_xor_si256(s[i], s[i]);
     }
 

--- a/crypto_sign/dilithium3/avx2/Makefile
+++ b/crypto_sign/dilithium3/avx2/Makefile
@@ -12,7 +12,7 @@ HEADERS = alignment.h api.h params.h sign.h polyvec.h poly.h packing.h ntt.h  \
 
 CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror \
 	   -Wmissing-prototypes -Wredundant-decls -std=c99 \
-	   -Wcast-align \
+	   -Wcast-align -Werror=shadow\
 	   -mavx2 -mbmi -mpopcnt -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)

--- a/crypto_sign/dilithium3/avx2/fips202x4.c
+++ b/crypto_sign/dilithium3/avx2/fips202x4.c
@@ -43,7 +43,7 @@ static void keccak_absorb4x(__m256i *s,
     uint8_t t3[200];
     uint64_t *ss = (uint64_t *)s;
 
-    for (size_t i = 0; i < 25; ++i) {
+    for (i = 0; i < 25; ++i) {
         s[i] = _mm256_xor_si256(s[i], s[i]);
     }
 

--- a/crypto_sign/dilithium4/avx2/Makefile
+++ b/crypto_sign/dilithium4/avx2/Makefile
@@ -12,7 +12,7 @@ HEADERS = alignment.h api.h params.h sign.h polyvec.h poly.h packing.h ntt.h  \
 
 CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror \
 	   -Wmissing-prototypes -Wredundant-decls -std=c99 \
-	   -Wcast-align \
+	   -Wcast-align -Werror=shadow\
 	   -mavx2 -mbmi -mpopcnt -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)

--- a/crypto_sign/dilithium4/avx2/fips202x4.c
+++ b/crypto_sign/dilithium4/avx2/fips202x4.c
@@ -43,7 +43,7 @@ static void keccak_absorb4x(__m256i *s,
     uint8_t t3[200];
     uint64_t *ss = (uint64_t *)s;
 
-    for (size_t i = 0; i < 25; ++i) {
+    for (i = 0; i < 25; ++i) {
         s[i] = _mm256_xor_si256(s[i], s[i]);
     }
 


### PR DESCRIPTION
This fixes compile errors in more strict (`-Wshadow`) downstream (liboqs) compilation of Dilithium2/3/4 AVX2 variant.

