### PR TITLE
Update required_flags for Dilithium's META.ymls

### DIFF
--- a/crypto_sign/dilithium2/META.yml
+++ b/crypto_sign/dilithium2/META.yml
@@ -27,4 +27,5 @@ implementations:
                 - Linux
             required_flags:
                 - avx2
-                - bmi2
+                - bmi1
+                - popcnt

--- a/crypto_sign/dilithium3/META.yml
+++ b/crypto_sign/dilithium3/META.yml
@@ -27,4 +27,5 @@ implementations:
                 - Linux
             required_flags:
                 - avx2
-                - bmi2
+                - bmi1
+                - popcnt

--- a/crypto_sign/dilithium4/META.yml
+++ b/crypto_sign/dilithium4/META.yml
@@ -27,4 +27,5 @@ implementations:
                 - Linux
             required_flags:
                 - avx2
-                - bmi2
+                - bmi1
+                - popcnt


### PR DESCRIPTION
Updated `required_flags` in Dilithium META.yml files to match the flags used in corresponding Makefiles.