### PR TITLE
Add missing obj file to Windows SPHINCS+ AVX2 builds

### DIFF
--- a/crypto_sign/sphincs-haraka-128f-robust/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-128f-robust/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-128f-robust_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-128f-simple/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-128f-simple/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-128f-simple_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-128s-robust/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-128s-robust/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-128s-robust_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-128s-simple/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-128s-simple/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-128s-simple_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-192f-robust/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-192f-robust/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-192f-robust_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-192f-simple/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-192f-simple/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-192f-simple_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-192s-robust/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-192s-robust/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-192s-robust_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-192s-simple/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-192s-simple/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-192s-simple_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-256f-robust/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-256f-robust/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-256f-robust_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-256f-simple/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-256f-simple/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-256f-simple_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-256s-robust/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-256s-robust/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-256s-robust_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_robust.obj hash_harakax4.obj thash_haraka_robustx4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-haraka-256s-simple/aesni/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-haraka-256s-simple/aesni/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-haraka-256s-simple_aesni.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_haraka.obj thash_haraka_simple.obj hash_harakax4.obj thash_haraka_simplex4.obj haraka.obj
 
 # We ignore warning C4127: in thash_haraka_*x4.c we use a conditional
 # that when the macro is generated for inblocks = 1 results in a case

--- a/crypto_sign/sphincs-sha256-128f-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-128f-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-128f-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-128f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128f-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-128f-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-128f-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-128f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128s-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-128s-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-128s-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-128s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128s-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-128s-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-128s-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-128s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-128s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-128s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-128s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192f-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-192f-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-192f-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-192f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192f-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-192f-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-192f-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-192f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192s-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-192s-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-192s-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-192s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192s-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-192s-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-192s-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-192s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-192s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-192s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-192s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256f-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-256f-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-256f-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-256f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256f-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-256f-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-256f-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-256f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256s-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-256s-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-256s-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_robust.o hash_sha256x8.o thash_sha256_robustx8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-256s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_robust.obj hash_sha256x8.obj thash_sha256_robustx8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256s-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-sha256-256s-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-sha256-256s-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx8.h sha256avx.h sha256x8.h fors.h api.h hash.h hashx8.h hash_state.h thash.h thashx8.h  sha256.h
-OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o hash_sha256x8.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
+OBJECTS =          address.o wots.o utils.o utilsx8.o sha256avx.o sha256x8.o fors.o sign.o hash_sha256.o thash_sha256_simple.o hash_sha256x8.o thash_sha256_simplex8.o sha256.o
 
 CFLAGS=-mavx2 -O3 -Wall -Wconversion -Wextra -Wpedantic -Wvla -Werror -Wmissing-prototypes -Wredundant-decls -std=c99 -I../../../common $(EXTRAFLAGS)
 

--- a/crypto_sign/sphincs-sha256-256s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-sha256-256s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-sha256-256s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-sha256-256s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj hash_sha256x8.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx8.obj sha256avx.obj sha256x8.obj fors.obj sign.obj hash_sha256.obj thash_sha256_simple.obj hash_sha256x8.obj thash_sha256_simplex8.obj sha256.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-128f-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-128f-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-128f-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-128f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128f-robust/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-128f-robust_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-128f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-128f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-128f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-128f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-128f-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-128f-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-128f-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-128f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-128f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-128f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-128f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-128f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128f-simple/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-128f-simple_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-128s-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-128s-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-128s-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-128s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-128s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-128s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-128s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-128s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128s-robust/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-128s-robust_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-128s-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-128s-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-128s-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-128s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128s-simple/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-128s-simple_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-128s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-128s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-128s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-128s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-128s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-192f-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-192f-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-192f-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-192f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-192f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-192f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-192f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-192f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192f-robust/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-192f-robust_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-192f-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-192f-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-192f-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-192f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-192f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-192f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192f-simple/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-192f-simple_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-192f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-192f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-192s-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-192s-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-192s-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-192s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-192s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-192s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-192s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-192s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192s-robust/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-192s-robust_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-192s-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-192s-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-192s-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-192s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-192s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-192s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192s-simple/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-192s-simple_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-192s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-192s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-192s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-256f-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-256f-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-256f-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-256f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256f-robust/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-256f-robust_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-256f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-256f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-256f-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256f-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-256f-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-256f-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-256f-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-256f-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-256f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-256f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-256f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256f-simple/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-256f-simple_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-256f-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256f-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-256f-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-256s-robust/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-256s-robust/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-256s-robust_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_robust.o hash_shake256x4.o thash_shake256_robustx4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-256s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256s-robust/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-256s-robust_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)

--- a/crypto_sign/sphincs-shake256-256s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-256s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-256s-robust/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256s-robust/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-256s-robust_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_robust.obj hash_shake256x4.obj thash_shake256_robustx4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-256s-simple/avx2/Makefile
+++ b/crypto_sign/sphincs-shake256-256s-simple/avx2/Makefile
@@ -3,7 +3,7 @@
 LIB=libsphincs-shake256-256s-simple_avx2.a
 
 HEADERS = params.h address.h wots.h utils.h utilsx4.h fips202x4.h fors.h api.h hash.h hashx4.h hash_state.h thash.h thashx4.h 
-OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o hash_shake256x4.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
+OBJECTS =          address.o wots.o utils.o utilsx4.o fips202x4.o fors.o sign.o hash_shake256.o thash_shake256_simple.o hash_shake256x4.o thash_shake256_simplex4.o
 
 KECCAK4XDIR=../../../common/keccak4x
 KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o

--- a/crypto_sign/sphincs-shake256-256s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-256s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-256s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256s-simple/avx2/Makefile.Microsoft_nmake
@@ -2,7 +2,7 @@
 #    nmake /f Makefile.Microsoft_nmake
 
 LIBRARY=libsphincs-shake256-256s-simple_avx2.lib
-OBJECTS=address.obj wots.obj utils.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
+OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 

--- a/crypto_sign/sphincs-shake256-256s-simple/avx2/Makefile.Microsoft_nmake
+++ b/crypto_sign/sphincs-shake256-256s-simple/avx2/Makefile.Microsoft_nmake
@@ -4,6 +4,10 @@
 LIBRARY=libsphincs-shake256-256s-simple_avx2.lib
 OBJECTS=address.obj wots.obj utils.obj utilsx4.obj fips202x4.obj fors.obj sign.obj hash_shake256.obj thash_shake256_simple.obj hash_shake256x4.obj thash_shake256_simplex4.obj
 
+KECCAK4XDIR=..\..\..\common\keccak4x
+KECCAK4XOBJ=KeccakP-1600-times4-SIMD256.o
+KECCAK4X=$(KECCAK4XDIR)\$(KECCAK4XOBJ)
+
 CFLAGS=/nologo /arch:AVX2 /O2 /I ..\..\..\common /W4 /WX
 
 all: $(LIBRARY)
@@ -11,8 +15,11 @@ all: $(LIBRARY)
 # Make sure objects are recompiled if headers change.
 $(OBJECTS): *.h
 
-$(LIBRARY): $(OBJECTS)
+$(LIBRARY): $(OBJECTS) $(KECCAKX4)
 	LIB.EXE /NOLOGO /WX /OUT:$@ $**
+
+$(KECCAK4X):
+	cd $(KECCAK4XDIR) && $(MAKE) $(KECCAK4XOBJ)
 
 clean:
     -DEL $(OBJECTS)


### PR DESCRIPTION
It didn't compile on Windows.