### PR TITLE
Kyber768 and Kyber1024 don't need -maes (see #296)

### DIFF
--- a/crypto_kem/kyber1024/META.yml
+++ b/crypto_kem/kyber1024/META.yml
@@ -29,7 +29,6 @@ implementations:
           operating_systems:
             - Linux
           required_flags:
-              - aes
               - avx2
               - bmi2
               - popcnt

--- a/crypto_kem/kyber768/META.yml
+++ b/crypto_kem/kyber768/META.yml
@@ -29,7 +29,6 @@ implementations:
           operating_systems:
             - Linux
           required_flags:
-            - aes
             - avx2
             - bmi2
             - popcnt


### PR DESCRIPTION
This somehow got included, but they don't need AES support.