### PR TITLE
Add domain separation to NewHope

### DIFF
--- a/crypto_kem/newhope1024cca/META.yml
+++ b/crypto_kem/newhope1024cca/META.yml
@@ -6,7 +6,7 @@ length-public-key: 1824
 length-secret-key: 3680
 length-ciphertext: 2208
 length-shared-secret: 32
-nistkat-sha256: 8500b88222b3a62e57a6ecaac57f79258f08af49211e0c3f2ca7eab8089c0ce0
+nistkat-sha256: 4a21f329bb5402a90d343af01ec1c8bc8ffffa8098cb0b89e1d2129f5157a073
 principal-submitters:
   - Thomas Pöppelmann
 auxiliary-submitters:

--- a/crypto_kem/newhope1024cca/clean/cpapke.c
+++ b/crypto_kem/newhope1024cca/clean/cpapke.c
@@ -101,8 +101,9 @@ void PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_keypair(unsigned char *pk,
     unsigned char *publicseed = z;
     unsigned char *noiseseed = z + NEWHOPE_SYMBYTES;
 
-    randombytes(z, NEWHOPE_SYMBYTES);
-    shake256(z, 2 * NEWHOPE_SYMBYTES, z, NEWHOPE_SYMBYTES);
+    z[0] = 0x01;
+    randombytes(z + 1, NEWHOPE_SYMBYTES);
+    shake256(z, 2 * NEWHOPE_SYMBYTES, z, NEWHOPE_SYMBYTES + 1);
 
     gen_a(&ahat, publicseed);
 

--- a/crypto_kem/newhope1024cca/clean/kem.c
+++ b/crypto_kem/newhope1024cca/clean/kem.c
@@ -52,16 +52,18 @@ int PQCLEAN_NEWHOPE1024CCA_CLEAN_crypto_kem_keypair(unsigned char *pk, unsigned 
 **************************************************/
 int PQCLEAN_NEWHOPE1024CCA_CLEAN_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk) {
     unsigned char k_coins_d[3 * NEWHOPE_SYMBYTES];                                              /* Will contain key, coins, qrom-hash */
-    unsigned char buf[2 * NEWHOPE_SYMBYTES];
+    unsigned char buf[2 * NEWHOPE_SYMBYTES + 1];
     int i;
 
-    randombytes(buf, NEWHOPE_SYMBYTES);
+    buf[0] = 0x04;
+    randombytes(buf + 1, NEWHOPE_SYMBYTES);
 
-    shake256(buf, NEWHOPE_SYMBYTES, buf, NEWHOPE_SYMBYTES);                                     /* Don't release system RNG output */
-    shake256(buf + NEWHOPE_SYMBYTES, NEWHOPE_SYMBYTES, pk, NEWHOPE_CCAKEM_PUBLICKEYBYTES);      /* Multitarget countermeasure for coins + contributory KEM */
-    shake256(k_coins_d, 3 * NEWHOPE_SYMBYTES, buf, 2 * NEWHOPE_SYMBYTES);
+    shake256(buf + 1, NEWHOPE_SYMBYTES, buf, NEWHOPE_SYMBYTES + 1);                             /* Don't release system RNG output */
+    shake256(buf + 1 + NEWHOPE_SYMBYTES, NEWHOPE_SYMBYTES, pk, NEWHOPE_CCAKEM_PUBLICKEYBYTES);  /* Multitarget countermeasure for coins + contributory KEM */
+    buf[0] = 0x08;
+    shake256(k_coins_d, 3 * NEWHOPE_SYMBYTES, buf, 2 * NEWHOPE_SYMBYTES + 1);
 
-    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_enc(ct, buf, pk, k_coins_d + NEWHOPE_SYMBYTES);                                      /* coins are in k_coins_d+NEWHOPE_SYMBYTES */
+    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_enc(ct, buf + 1, pk, k_coins_d + NEWHOPE_SYMBYTES);     /* coins are in k_coins_d+NEWHOPE_SYMBYTES */
 
     for (i = 0; i < NEWHOPE_SYMBYTES; i++) {
         ct[i + NEWHOPE_CPAPKE_CIPHERTEXTBYTES] = k_coins_d[i + 2 * NEWHOPE_SYMBYTES];    /* copy Targhi-Unruh hash into ct */
@@ -89,18 +91,19 @@ int PQCLEAN_NEWHOPE1024CCA_CLEAN_crypto_kem_enc(unsigned char *ct, unsigned char
 int PQCLEAN_NEWHOPE1024CCA_CLEAN_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned char *sk) {
     int i, fail;
     unsigned char ct_cmp[NEWHOPE_CCAKEM_CIPHERTEXTBYTES];
-    unsigned char buf[2 * NEWHOPE_SYMBYTES];
+    unsigned char buf[2 * NEWHOPE_SYMBYTES + 1];
     unsigned char k_coins_d[3 * NEWHOPE_SYMBYTES];                                              /* Will contain key, coins, qrom-hash */
     const unsigned char *pk = sk + NEWHOPE_CPAPKE_SECRETKEYBYTES;
 
-    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_dec(buf, ct, sk);
+    buf[0] = 0x08;
+    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_dec(buf + 1, ct, sk);
 
     for (i = 0; i < NEWHOPE_SYMBYTES; i++) {                                                    /* Use hash of pk stored in sk */
-        buf[NEWHOPE_SYMBYTES + i] = sk[NEWHOPE_CCAKEM_SECRETKEYBYTES - 2 * NEWHOPE_SYMBYTES + i];
+        buf[1 + NEWHOPE_SYMBYTES + i] = sk[NEWHOPE_CCAKEM_SECRETKEYBYTES - 2 * NEWHOPE_SYMBYTES + i];
     }
-    shake256(k_coins_d, 3 * NEWHOPE_SYMBYTES, buf, 2 * NEWHOPE_SYMBYTES);
+    shake256(k_coins_d, 3 * NEWHOPE_SYMBYTES, buf, 2 * NEWHOPE_SYMBYTES + 1);
 
-    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_enc(ct_cmp, buf, pk, k_coins_d + NEWHOPE_SYMBYTES);                                  /* coins are in k_coins_d+NEWHOPE_SYMBYTES */
+    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_enc(ct_cmp, buf + 1, pk, k_coins_d + NEWHOPE_SYMBYTES); /* coins are in k_coins_d+NEWHOPE_SYMBYTES */
 
     for (i = 0; i < NEWHOPE_SYMBYTES; i++) {
         ct_cmp[i + NEWHOPE_CPAPKE_CIPHERTEXTBYTES] = k_coins_d[i + 2 * NEWHOPE_SYMBYTES];

--- a/crypto_kem/newhope1024cca/clean/kem.c
+++ b/crypto_kem/newhope1024cca/clean/kem.c
@@ -63,7 +63,7 @@ int PQCLEAN_NEWHOPE1024CCA_CLEAN_crypto_kem_enc(unsigned char *ct, unsigned char
     buf[0] = 0x08;
     shake256(k_coins_d, 3 * NEWHOPE_SYMBYTES, buf, 2 * NEWHOPE_SYMBYTES + 1);
 
-    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_enc(ct, buf + 1, pk, k_coins_d + NEWHOPE_SYMBYTES);     /* coins are in k_coins_d+NEWHOPE_SYMBYTES */
+    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_enc(ct, buf + 1, pk, k_coins_d + NEWHOPE_SYMBYTES);      /* coins are in k_coins_d+NEWHOPE_SYMBYTES */
 
     for (i = 0; i < NEWHOPE_SYMBYTES; i++) {
         ct[i + NEWHOPE_CPAPKE_CIPHERTEXTBYTES] = k_coins_d[i + 2 * NEWHOPE_SYMBYTES];    /* copy Targhi-Unruh hash into ct */
@@ -103,7 +103,7 @@ int PQCLEAN_NEWHOPE1024CCA_CLEAN_crypto_kem_dec(unsigned char *ss, const unsigne
     }
     shake256(k_coins_d, 3 * NEWHOPE_SYMBYTES, buf, 2 * NEWHOPE_SYMBYTES + 1);
 
-    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_enc(ct_cmp, buf + 1, pk, k_coins_d + NEWHOPE_SYMBYTES); /* coins are in k_coins_d+NEWHOPE_SYMBYTES */
+    PQCLEAN_NEWHOPE1024CCA_CLEAN_cpapke_enc(ct_cmp, buf + 1, pk, k_coins_d + NEWHOPE_SYMBYTES);  /* coins are in k_coins_d+NEWHOPE_SYMBYTES */
 
     for (i = 0; i < NEWHOPE_SYMBYTES; i++) {
         ct_cmp[i + NEWHOPE_CPAPKE_CIPHERTEXTBYTES] = k_coins_d[i + 2 * NEWHOPE_SYMBYTES];

--- a/crypto_kem/newhope1024cpa/META.yml
+++ b/crypto_kem/newhope1024cpa/META.yml
@@ -6,7 +6,7 @@ length-public-key: 1824
 length-secret-key: 1792
 length-ciphertext: 2176
 length-shared-secret: 32
-nistkat-sha256: f48b42b21a51d7f9325abc5fbda74872d62feaa8cbf818bee87f29bf96630a2f
+nistkat-sha256: 440e2afb40d212a44d1bb1dc9963d7c942fa6ceb16fed2b1ccf015fa75ab115b
 principal-submitters:
   - Thomas Pöppelmann
 auxiliary-submitters:

--- a/crypto_kem/newhope1024cpa/clean/cpapke.c
+++ b/crypto_kem/newhope1024cpa/clean/cpapke.c
@@ -101,8 +101,9 @@ void PQCLEAN_NEWHOPE1024CPA_CLEAN_cpapke_keypair(unsigned char *pk,
     unsigned char *publicseed = z;
     unsigned char *noiseseed = z + NEWHOPE_SYMBYTES;
 
-    randombytes(z, NEWHOPE_SYMBYTES);
-    shake256(z, 2 * NEWHOPE_SYMBYTES, z, NEWHOPE_SYMBYTES);
+    z[0] = 0x01;
+    randombytes(z + 1, NEWHOPE_SYMBYTES);
+    shake256(z, 2 * NEWHOPE_SYMBYTES, z, NEWHOPE_SYMBYTES + 1);
 
     gen_a(&ahat, publicseed);
 

--- a/crypto_kem/newhope1024cpa/clean/kem.c
+++ b/crypto_kem/newhope1024cpa/clean/kem.c
@@ -39,9 +39,10 @@ int PQCLEAN_NEWHOPE1024CPA_CLEAN_crypto_kem_keypair(unsigned char *pk, unsigned 
 int PQCLEAN_NEWHOPE1024CPA_CLEAN_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk) {
     unsigned char buf[2 * NEWHOPE_SYMBYTES];
 
-    randombytes(buf, NEWHOPE_SYMBYTES);
+    buf[0] = 0x02;
+    randombytes(buf + 1, NEWHOPE_SYMBYTES);
 
-    shake256(buf, 2 * NEWHOPE_SYMBYTES, buf, NEWHOPE_SYMBYTES);                    /* Don't release system RNG output */
+    shake256(buf, 2 * NEWHOPE_SYMBYTES, buf, NEWHOPE_SYMBYTES + 1);                    /* Don't release system RNG output */
 
     PQCLEAN_NEWHOPE1024CPA_CLEAN_cpapke_enc(ct, buf, pk, buf + NEWHOPE_SYMBYTES);                               /* coins are in buf+NEWHOPE_SYMBYTES */
 

--- a/crypto_kem/newhope512cca/META.yml
+++ b/crypto_kem/newhope512cca/META.yml
@@ -6,7 +6,7 @@ length-public-key: 928
 length-secret-key: 1888
 length-ciphertext: 1120
 length-shared-secret: 32
-nistkat-sha256: 5b0389f8d9c30055ad0fb83da540ca36969dde041bebe6f1018c37768c5e1479
+nistkat-sha256: 4290da64305e70e65766be5d4e488dee2b4b238172876ceefc931934b6964a7d
 principal-submitters:
   - Thomas Pöppelmann
 auxiliary-submitters:

--- a/crypto_kem/newhope512cca/clean/cpapke.c
+++ b/crypto_kem/newhope512cca/clean/cpapke.c
@@ -101,8 +101,9 @@ void PQCLEAN_NEWHOPE512CCA_CLEAN_cpapke_keypair(unsigned char *pk,
     unsigned char *publicseed = z;
     unsigned char *noiseseed = z + NEWHOPE_SYMBYTES;
 
-    randombytes(z, NEWHOPE_SYMBYTES);
-    shake256(z, 2 * NEWHOPE_SYMBYTES, z, NEWHOPE_SYMBYTES);
+    z[0] = 0x01;
+    randombytes(z + 1, NEWHOPE_SYMBYTES);
+    shake256(z, 2 * NEWHOPE_SYMBYTES, z, NEWHOPE_SYMBYTES + 1);
 
     gen_a(&ahat, publicseed);
 

--- a/crypto_kem/newhope512cpa/META.yml
+++ b/crypto_kem/newhope512cpa/META.yml
@@ -6,7 +6,7 @@ length-public-key: 928
 length-secret-key: 896
 length-ciphertext: 1088
 length-shared-secret: 32
-nistkat-sha256: 42444446b96f45c9b7221c4fde8afd5dfc0b3c2ff05b9a88ff12ea3949fbb76c
+nistkat-sha256: 7df3eae4740483a61d13610f6bc2221f27e32c7849cf371e9770f986ce6fdb54
 principal-submitters:
   - Thomas Pöppelmann
 auxiliary-submitters:

--- a/crypto_kem/newhope512cpa/clean/cpapke.c
+++ b/crypto_kem/newhope512cpa/clean/cpapke.c
@@ -101,8 +101,9 @@ void PQCLEAN_NEWHOPE512CPA_CLEAN_cpapke_keypair(unsigned char *pk,
     unsigned char *publicseed = z;
     unsigned char *noiseseed = z + NEWHOPE_SYMBYTES;
 
-    randombytes(z, NEWHOPE_SYMBYTES);
-    shake256(z, 2 * NEWHOPE_SYMBYTES, z, NEWHOPE_SYMBYTES);
+    z[0] = 0x01;
+    randombytes(z + 1, NEWHOPE_SYMBYTES);
+    shake256(z, 2 * NEWHOPE_SYMBYTES, z, NEWHOPE_SYMBYTES + 1);
 
     gen_a(&ahat, publicseed);
 

--- a/crypto_kem/newhope512cpa/clean/kem.c
+++ b/crypto_kem/newhope512cpa/clean/kem.c
@@ -39,9 +39,10 @@ int PQCLEAN_NEWHOPE512CPA_CLEAN_crypto_kem_keypair(unsigned char *pk, unsigned c
 int PQCLEAN_NEWHOPE512CPA_CLEAN_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk) {
     unsigned char buf[2 * NEWHOPE_SYMBYTES];
 
-    randombytes(buf, NEWHOPE_SYMBYTES);
+    buf[0] = 0x02;
+    randombytes(buf + 1, NEWHOPE_SYMBYTES);
 
-    shake256(buf, 2 * NEWHOPE_SYMBYTES, buf, NEWHOPE_SYMBYTES);                    /* Don't release system RNG output */
+    shake256(buf, 2 * NEWHOPE_SYMBYTES, buf, NEWHOPE_SYMBYTES + 1);                    /* Don't release system RNG output */
 
     PQCLEAN_NEWHOPE512CPA_CLEAN_cpapke_enc(ct, buf, pk, buf + NEWHOPE_SYMBYTES);                               /* coins are in buf+NEWHOPE_SYMBYTES */
 


### PR DESCRIPTION
NewHope announced a version 1.1 of their specification that adds explicit domain separation. This is a port of https://github.com/newhopecrypto/newhope/commit/607a9d3.