### PR TITLE
C guard

### DIFF
--- a/common/randombytes.h
+++ b/common/randombytes.h
@@ -8,6 +8,14 @@
 #include <unistd.h>
 #endif
 
-int randombytes(uint8_t *buf, size_t n);
+#ifdef __cplusplus
+#define EXTERNC extern "C"
+#else
+#define EXTERNC
+#endif
+
+EXTERNC int randombytes(uint8_t *buf, size_t n);
+
+#undef EXTERNC
 
 #endif


### PR DESCRIPTION
We're using pqm4 in an Arduino application. In appears that we need to implement this as randombytes.cpp (included below), and so this file needs guards. I'm very happy to look at ways to change our own code instead. It should be pretty obvious that I have no idea what I'm doing.

Dummy code for randombytes.cpp:
#include <stdint.h>
#include <Arduino.h>
#include "randombytes.h"

//TODO Maybe we do not want to use the hardware RNG for all randomness, but instead only read a seed and then expand that using fips202.

extern "C" {
  int randombytes(uint8_t *obuf, size_t len)
  {
      union
      {
          unsigned char aschar[4];
          uint32_t asint;
      } rnd;

      while (len > 4)
      {
          rnd.asint = random(2147483647);
          *obuf++ = rnd.aschar[0];
          *obuf++ = rnd.aschar[1];
          *obuf++ = rnd.aschar[2];
          *obuf++ = rnd.aschar[3];
          len -= 4;
      }
      if (len > 0)
      {
          for (rnd.asint = random(2147483647); len > 0; --len)
          {
              *obuf++ = rnd.aschar[len - 1];
          }
      }

      return 0;
  }
}