### PR TITLE
Ban boolean operators in arithmetic expressions

### DIFF
--- a/crypto_kem/frodokem1344aes/clean/util.c
+++ b/crypto_kem/frodokem1344aes/clean/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM1344AES_CLEAN_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem1344aes/clean/util.c
+++ b/crypto_kem/frodokem1344aes/clean/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM1344AES_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem1344aes/opt/util.c
+++ b/crypto_kem/frodokem1344aes/opt/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM1344AES_OPT_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem1344aes/opt/util.c
+++ b/crypto_kem/frodokem1344aes/opt/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM1344AES_OPT_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem1344shake/clean/util.c
+++ b/crypto_kem/frodokem1344shake/clean/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM1344SHAKE_CLEAN_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem1344shake/clean/util.c
+++ b/crypto_kem/frodokem1344shake/clean/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM1344SHAKE_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem1344shake/opt/util.c
+++ b/crypto_kem/frodokem1344shake/opt/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM1344SHAKE_OPT_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem1344shake/opt/util.c
+++ b/crypto_kem/frodokem1344shake/opt/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM1344SHAKE_OPT_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem640aes/clean/util.c
+++ b/crypto_kem/frodokem640aes/clean/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM640AES_CLEAN_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem640aes/clean/util.c
+++ b/crypto_kem/frodokem640aes/clean/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM640AES_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem640aes/opt/util.c
+++ b/crypto_kem/frodokem640aes/opt/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM640AES_OPT_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem640aes/opt/util.c
+++ b/crypto_kem/frodokem640aes/opt/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM640AES_OPT_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem640shake/clean/util.c
+++ b/crypto_kem/frodokem640shake/clean/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM640SHAKE_CLEAN_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem640shake/clean/util.c
+++ b/crypto_kem/frodokem640shake/clean/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM640SHAKE_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem640shake/opt/util.c
+++ b/crypto_kem/frodokem640shake/opt/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM640SHAKE_OPT_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem640shake/opt/util.c
+++ b/crypto_kem/frodokem640shake/opt/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM640SHAKE_OPT_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem976aes/clean/util.c
+++ b/crypto_kem/frodokem976aes/clean/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM976AES_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem976aes/clean/util.c
+++ b/crypto_kem/frodokem976aes/clean/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM976AES_CLEAN_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem976aes/opt/util.c
+++ b/crypto_kem/frodokem976aes/opt/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM976AES_OPT_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem976aes/opt/util.c
+++ b/crypto_kem/frodokem976aes/opt/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM976AES_OPT_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem976shake/clean/util.c
+++ b/crypto_kem/frodokem976shake/clean/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM976SHAKE_CLEAN_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem976shake/clean/util.c
+++ b/crypto_kem/frodokem976shake/clean/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM976SHAKE_CLEAN_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/frodokem976shake/opt/util.c
+++ b/crypto_kem/frodokem976shake/opt/util.c
@@ -12,8 +12,10 @@
 #include "params.h"
 
 static inline uint8_t min(uint8_t x, uint8_t y) {
-  if (x < y) return x;
-  return y;
+    if (x < y) {
+        return x;
+    }
+    return y;
 }
 
 uint16_t PQCLEAN_FRODOKEM976SHAKE_OPT_LE_TO_UINT16(uint16_t n) {

--- a/crypto_kem/frodokem976shake/opt/util.c
+++ b/crypto_kem/frodokem976shake/opt/util.c
@@ -11,7 +11,10 @@
 #include "common.h"
 #include "params.h"
 
-#define min(x, y) (((x) < (y)) ? (x) : (y))
+static inline uint8_t min(uint8_t x, uint8_t y) {
+  if (x < y) return x;
+  return y;
+}
 
 uint16_t PQCLEAN_FRODOKEM976SHAKE_OPT_LE_TO_UINT16(uint16_t n) {
     return (((uint8_t *) &n)[0] | (((uint8_t *) &n)[1] << 8));

--- a/crypto_kem/mceliece348864/avx/int32_sort.c
+++ b/crypto_kem/mceliece348864/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece348864/avx/int32_sort.c
+++ b/crypto_kem/mceliece348864/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece348864f/avx/int32_sort.c
+++ b/crypto_kem/mceliece348864f/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece348864f/avx/int32_sort.c
+++ b/crypto_kem/mceliece348864f/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece460896/avx/int32_sort.c
+++ b/crypto_kem/mceliece460896/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece460896/avx/int32_sort.c
+++ b/crypto_kem/mceliece460896/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece460896f/avx/int32_sort.c
+++ b/crypto_kem/mceliece460896f/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece460896f/avx/int32_sort.c
+++ b/crypto_kem/mceliece460896f/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece6688128/avx/int32_sort.c
+++ b/crypto_kem/mceliece6688128/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece6688128/avx/int32_sort.c
+++ b/crypto_kem/mceliece6688128/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece6688128f/avx/int32_sort.c
+++ b/crypto_kem/mceliece6688128f/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece6688128f/avx/int32_sort.c
+++ b/crypto_kem/mceliece6688128f/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece6960119/avx/int32_sort.c
+++ b/crypto_kem/mceliece6960119/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece6960119/avx/int32_sort.c
+++ b/crypto_kem/mceliece6960119/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece6960119f/avx/int32_sort.c
+++ b/crypto_kem/mceliece6960119f/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece6960119f/avx/int32_sort.c
+++ b/crypto_kem/mceliece6960119f/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece8192128/avx/int32_sort.c
+++ b/crypto_kem/mceliece8192128/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece8192128/avx/int32_sort.c
+++ b/crypto_kem/mceliece8192128/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece8192128f/avx/int32_sort.c
+++ b/crypto_kem/mceliece8192128f/avx/int32_sort.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/mceliece8192128f/avx/int32_sort.c
+++ b/crypto_kem/mceliece8192128f/avx/int32_sort.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/ntruhps2048509/avx2/crypto_sort_int32.c
+++ b/crypto_kem/ntruhps2048509/avx2/crypto_sort_int32.c
@@ -1,8 +1,8 @@
+#include "crypto_sort_int32.h"
+#include <immintrin.h>
 // Based on supercop-20200820/crypto_sort/int32/avx2
 
-#include "crypto_sort_int32.h"
 
-#include <immintrin.h>
 #define int32 int32_t
 
 typedef __m256i int32x8;
@@ -469,8 +469,11 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/ntruhps2048509/avx2/crypto_sort_int32.h
+++ b/crypto_kem/ntruhps2048509/avx2/crypto_sort_int32.h
@@ -1,10 +1,9 @@
 #ifndef CRYPTO_SORT
 #define CRYPTO_SORT
-
 #include "params.h"
-
 #include <stddef.h>
 #include <stdint.h>
+
 
 void PQCLEAN_NTRUHPS2048509_AVX2_crypto_sort_int32(int32_t *x, size_t n);
 

--- a/crypto_kem/ntruhps2048677/avx2/crypto_sort_int32.c
+++ b/crypto_kem/ntruhps2048677/avx2/crypto_sort_int32.c
@@ -1,8 +1,8 @@
+#include "crypto_sort_int32.h"
+#include <immintrin.h>
 // Based on supercop-20200820/crypto_sort/int32/avx2
 
-#include "crypto_sort_int32.h"
 
-#include <immintrin.h>
 #define int32 int32_t
 
 typedef __m256i int32x8;
@@ -469,8 +469,11 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/ntruhps2048677/avx2/crypto_sort_int32.h
+++ b/crypto_kem/ntruhps2048677/avx2/crypto_sort_int32.h
@@ -1,10 +1,9 @@
 #ifndef CRYPTO_SORT
 #define CRYPTO_SORT
-
 #include "params.h"
-
 #include <stddef.h>
 #include <stdint.h>
+
 
 void PQCLEAN_NTRUHPS2048677_AVX2_crypto_sort_int32(int32_t *x, size_t n);
 

--- a/crypto_kem/ntruhps4096821/avx2/crypto_sort_int32.c
+++ b/crypto_kem/ntruhps4096821/avx2/crypto_sort_int32.c
@@ -1,8 +1,8 @@
+#include "crypto_sort_int32.h"
+#include <immintrin.h>
 // Based on supercop-20200820/crypto_sort/int32/avx2
 
-#include "crypto_sort_int32.h"
 
-#include <immintrin.h>
 #define int32 int32_t
 
 typedef __m256i int32x8;
@@ -469,8 +469,11 @@ static void int32_sort_2power(int32 *x, size_t n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/ntruhps4096821/avx2/crypto_sort_int32.h
+++ b/crypto_kem/ntruhps4096821/avx2/crypto_sort_int32.h
@@ -1,10 +1,9 @@
 #ifndef CRYPTO_SORT
 #define CRYPTO_SORT
-
 #include "params.h"
-
 #include <stddef.h>
 #include <stdint.h>
+
 
 void PQCLEAN_NTRUHPS4096821_AVX2_crypto_sort_int32(int32_t *x, size_t n);
 

--- a/crypto_kem/ntrulpr653/avx2/crypto_sort_int32.c
+++ b/crypto_kem/ntrulpr653/avx2/crypto_sort_int32.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/ntrulpr653/avx2/crypto_sort_int32.c
+++ b/crypto_kem/ntrulpr653/avx2/crypto_sort_int32.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/ntrulpr761/avx2/crypto_sort_int32.c
+++ b/crypto_kem/ntrulpr761/avx2/crypto_sort_int32.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/ntrulpr761/avx2/crypto_sort_int32.c
+++ b/crypto_kem/ntrulpr761/avx2/crypto_sort_int32.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/ntrulpr857/avx2/crypto_sort_int32.c
+++ b/crypto_kem/ntrulpr857/avx2/crypto_sort_int32.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/ntrulpr857/avx2/crypto_sort_int32.c
+++ b/crypto_kem/ntrulpr857/avx2/crypto_sort_int32.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/sntrup653/avx2/crypto_sort_int32.c
+++ b/crypto_kem/sntrup653/avx2/crypto_sort_int32.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/sntrup653/avx2/crypto_sort_int32.c
+++ b/crypto_kem/sntrup653/avx2/crypto_sort_int32.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/sntrup761/avx2/crypto_sort_int32.c
+++ b/crypto_kem/sntrup761/avx2/crypto_sort_int32.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/sntrup761/avx2/crypto_sort_int32.c
+++ b/crypto_kem/sntrup761/avx2/crypto_sort_int32.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/sntrup857/avx2/crypto_sort_int32.c
+++ b/crypto_kem/sntrup857/avx2/crypto_sort_int32.c
@@ -462,8 +462,9 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
             }
 
             q = n >> 3;
-            flip = (p << 1 == q);
-            flipflip = !flip;
+            flip = 0;
+            if (p << 1 == q) flip = 1;
+            flipflip = 1-flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_kem/sntrup857/avx2/crypto_sort_int32.c
+++ b/crypto_kem/sntrup857/avx2/crypto_sort_int32.c
@@ -463,8 +463,10 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
 
             q = n >> 3;
             flip = 0;
-            if (p << 1 == q) flip = 1;
-            flipflip = 1-flip;
+            if (p << 1 == q) {
+                flip = 1;
+            }
+            flipflip = 1 - flip;
             for (j = 0; j < q; j += p + p) {
                 for (k = j; k < j + p + p; k += p) {
                     for (i = k; i < k + p; i += 8) {

--- a/crypto_sign/falcon-1024/clean/codec.c
+++ b/crypto_sign/falcon-1024/clean/codec.c
@@ -443,7 +443,8 @@ PQCLEAN_FALCON1024_CLEAN_comp_decode(
                 return 0;
             }
         }
-        x[u] = (int16_t)(s ? -(int)m : (int)m);
+        x[u] = (int16_t) m;
+        if (s) x[u] = -x[u];
     }
     return v;
 }

--- a/crypto_sign/falcon-1024/clean/codec.c
+++ b/crypto_sign/falcon-1024/clean/codec.c
@@ -444,7 +444,9 @@ PQCLEAN_FALCON1024_CLEAN_comp_decode(
             }
         }
         x[u] = (int16_t) m;
-        if (s) x[u] = -x[u];
+        if (s) {
+          x[u] = (int16_t) -x[u];
+        }
     }
     return v;
 }

--- a/crypto_sign/falcon-1024/clean/codec.c
+++ b/crypto_sign/falcon-1024/clean/codec.c
@@ -445,7 +445,7 @@ PQCLEAN_FALCON1024_CLEAN_comp_decode(
         }
         x[u] = (int16_t) m;
         if (s) {
-          x[u] = (int16_t) -x[u];
+            x[u] = (int16_t) - x[u];
         }
     }
     return v;

--- a/crypto_sign/falcon-1024/clean/fpr.h
+++ b/crypto_sign/falcon-1024/clean/fpr.h
@@ -436,8 +436,8 @@ fpr_lt(fpr x, fpr y) {
      */
     int cc0, cc1;
 
-    cc0 = *(int64_t *)&x < *(int64_t *)&y;
-    cc1 = *(int64_t *)&x > *(int64_t *)&y;
+    cc0 = ((*(int64_t *)&x - *(int64_t *)&y) >> 63) & 1;
+    cc1 = ((*(int64_t *)&y - *(int64_t *)&x) >> 63) & 1;
     return cc0 ^ ((cc0 ^ cc1) & (int)((x & y) >> 63));
 }
 

--- a/crypto_sign/falcon-1024/clean/fpr.h
+++ b/crypto_sign/falcon-1024/clean/fpr.h
@@ -436,8 +436,8 @@ fpr_lt(fpr x, fpr y) {
      */
     int cc0, cc1;
 
-    cc0 = ((*(int64_t *)&x - *(int64_t *)&y) >> 63) & 1;
-    cc1 = ((*(int64_t *)&y - *(int64_t *)&x) >> 63) & 1;
+    cc0 = (int)((*(int64_t *)&x - *(int64_t *)&y) >> 63) & 1;
+    cc1 = (int)((*(int64_t *)&y - *(int64_t *)&x) >> 63) & 1;
     return cc0 ^ ((cc0 ^ cc1) & (int)((x & y) >> 63));
 }
 

--- a/crypto_sign/falcon-1024/clean/fpr.h
+++ b/crypto_sign/falcon-1024/clean/fpr.h
@@ -424,20 +424,32 @@ fpr fpr_sqrt(fpr x);
 static inline int
 fpr_lt(fpr x, fpr y) {
     /*
-     * If x >= 0 or y >= 0, a signed comparison yields the proper
-     * result:
+     * If both x and y are positive, then a signed comparison yields
+     * the proper result:
      *   - For positive values, the order is preserved.
      *   - The sign bit is at the same place as in integers, so
      *     sign is preserved.
+     * Moreover, we can compute [x < y] as sgn(x-y) and the computation
+     * of x-y will not overflow.
+     *
+     * If the signs differ, then sgn(x) gives the proper result.
      *
      * If both x and y are negative, then the order is reversed.
-     * We cannot simply invert the comparison result in that case
-     * because it would not handle the edge case x = y properly.
+     * Hence [x < y] = sgn(y-x). We must compute this separately from
+     * sgn(x-y); simply inverting sgn(x-y) would not handle the edge
+     * case x = y properly.
      */
     int cc0, cc1;
+    int64_t sx;
+    int64_t sy;
 
-    cc0 = (int)((*(int64_t *)&x - * (int64_t *)&y) >> 63) & 1;
-    cc1 = (int)((*(int64_t *)&y - * (int64_t *)&x) >> 63) & 1;
+    sx = *(int64_t *)&x;
+    sy = *(int64_t *)&y;
+    sy &= ~((sx ^ sy) >> 63); /* set sy=0 if signs differ */
+
+    cc0 = (int)((sx - sy) >> 63) & 1; /* Neither subtraction overflows when */
+    cc1 = (int)((sy - sx) >> 63) & 1; /* the signs are the same. */
+
     return cc0 ^ ((cc0 ^ cc1) & (int)((x & y) >> 63));
 }
 

--- a/crypto_sign/falcon-1024/clean/fpr.h
+++ b/crypto_sign/falcon-1024/clean/fpr.h
@@ -436,8 +436,8 @@ fpr_lt(fpr x, fpr y) {
      */
     int cc0, cc1;
 
-    cc0 = (int)((*(int64_t *)&x - *(int64_t *)&y) >> 63) & 1;
-    cc1 = (int)((*(int64_t *)&y - *(int64_t *)&x) >> 63) & 1;
+    cc0 = (int)((*(int64_t *)&x - * (int64_t *)&y) >> 63) & 1;
+    cc1 = (int)((*(int64_t *)&y - * (int64_t *)&x) >> 63) & 1;
     return cc0 ^ ((cc0 ^ cc1) & (int)((x & y) >> 63));
 }
 

--- a/crypto_sign/falcon-1024/clean/keygen.c
+++ b/crypto_sign/falcon-1024/clean/keygen.c
@@ -1903,9 +1903,9 @@ zint_add_scaled_mul_small(uint32_t *x, size_t xlen,
          */
         v = u - sch;
         if (v < ylen) {
-          wy = y[v];
+            wy = y[v];
         } else {
-          wy = ysign;
+            wy = ysign;
         }
         wys = ((wy << scl) & 0x7FFFFFFF) | tw;
         tw = wy >> (31 - scl);
@@ -1965,9 +1965,9 @@ zint_sub_scaled(uint32_t *x, size_t xlen,
          */
         v = u - sch;
         if (v < ylen) {
-          wy = y[v];
+            wy = y[v];
         } else {
-          wy = ysign;
+            wy = ysign;
         }
         wys = ((wy << scl) & 0x7FFFFFFF) | tw;
         tw = wy >> (31 - scl);
@@ -2656,16 +2656,18 @@ make_fg(uint32_t *data, const int8_t *f, const int8_t *g,
         return;
     }
 
-    if (depth == 0) return;
+    if (depth == 0) {
+        return;
+    }
     if (depth == 1) {
-      make_fg_step(data, logn, 0, 0, out_ntt);
-      return;
+        make_fg_step(data, logn, 0, 0, out_ntt);
+        return;
     }
     make_fg_step(data, logn, 0, 0, 1);
-    for (d = 1; d+1 < depth; d ++) {
+    for (d = 1; d + 1 < depth; d ++) {
         make_fg_step(data, logn - d, d, 1, 1);
     }
-    make_fg_step(data, logn-depth+1, depth-1, 1, out_ntt);
+    make_fg_step(data, logn - depth + 1, depth - 1, 1, out_ntt);
 }
 
 /*
@@ -3043,7 +3045,9 @@ solve_NTRU_intermediate(unsigned logn_top,
      * middle or the upper half of these top 10 words.
      */
     rlen = slen;
-    if (rlen > 10) rlen = 10;
+    if (rlen > 10) {
+        rlen = 10;
+    }
     poly_big_to_fp(rt3, ft + slen - rlen, rlen, slen, logn);
     poly_big_to_fp(rt4, gt + slen - rlen, rlen, slen, logn);
 
@@ -3118,7 +3122,9 @@ solve_NTRU_intermediate(unsigned logn_top,
          * scaling if the current length is more than 10 words.
          */
         rlen = FGlen;
-        if (rlen > 10) rlen = 10;
+        if (rlen > 10) {
+            rlen = 10;
+        }
         scale_FG = 31 * (int)(FGlen - rlen);
         poly_big_to_fp(rt1, Ft + FGlen - rlen, rlen, llen, logn);
         poly_big_to_fp(rt2, Gt + FGlen - rlen, rlen, llen, logn);

--- a/crypto_sign/falcon-1024/clean/keygen.c
+++ b/crypto_sign/falcon-1024/clean/keygen.c
@@ -1902,7 +1902,11 @@ zint_add_scaled_mul_small(uint32_t *x, size_t xlen,
          * Get the next word of y (scaled).
          */
         v = u - sch;
-        wy = v < ylen ? y[v] : ysign;
+        if (v < ylen) {
+          wy = y[v];
+        } else {
+          wy = ysign;
+        }
         wys = ((wy << scl) & 0x7FFFFFFF) | tw;
         tw = wy >> (31 - scl);
 
@@ -1960,7 +1964,11 @@ zint_sub_scaled(uint32_t *x, size_t xlen,
          * Get the next word of y (scaled).
          */
         v = u - sch;
-        wy = v < ylen ? y[v] : ysign;
+        if (v < ylen) {
+          wy = y[v];
+        } else {
+          wy = ysign;
+        }
         wys = ((wy << scl) & 0x7FFFFFFF) | tw;
         tw = wy >> (31 - scl);
 
@@ -2648,10 +2656,16 @@ make_fg(uint32_t *data, const int8_t *f, const int8_t *g,
         return;
     }
 
-    for (d = 0; d < depth; d ++) {
-        make_fg_step(data, logn - d, d,
-                     d != 0, (d + 1) < depth || out_ntt);
+    if (depth == 0) return;
+    if (depth == 1) {
+      make_fg_step(data, logn, 0, 0, out_ntt);
+      return;
     }
+    make_fg_step(data, logn, 0, 0, 1);
+    for (d = 1; d+1 < depth; d ++) {
+        make_fg_step(data, logn - d, d, 1, 1);
+    }
+    make_fg_step(data, logn-depth+1, depth-1, 1, out_ntt);
 }
 
 /*
@@ -3028,7 +3042,8 @@ solve_NTRU_intermediate(unsigned logn_top,
      * computed so that average maximum length will fall in the
      * middle or the upper half of these top 10 words.
      */
-    rlen = (slen > 10) ? 10 : slen;
+    rlen = slen;
+    if (rlen > 10) rlen = 10;
     poly_big_to_fp(rt3, ft + slen - rlen, rlen, slen, logn);
     poly_big_to_fp(rt4, gt + slen - rlen, rlen, slen, logn);
 
@@ -3102,7 +3117,8 @@ solve_NTRU_intermediate(unsigned logn_top,
          * Convert current F and G into floating-point. We apply
          * scaling if the current length is more than 10 words.
          */
-        rlen = (FGlen > 10) ? 10 : FGlen;
+        rlen = FGlen;
+        if (rlen > 10) rlen = 10;
         scale_FG = 31 * (int)(FGlen - rlen);
         poly_big_to_fp(rt1, Ft + FGlen - rlen, rlen, llen, logn);
         poly_big_to_fp(rt2, Gt + FGlen - rlen, rlen, llen, logn);

--- a/crypto_sign/falcon-1024/clean/sign.c
+++ b/crypto_sign/falcon-1024/clean/sign.c
@@ -1190,9 +1190,9 @@ PQCLEAN_FALCON1024_CLEAN_sign_tree(int16_t *sig, inner_shake256_context *rng,
          * SHAKE context ('rng').
          */
         if (logn == 10) {
-          spc.sigma_min = fpr_sigma_min_10;
+            spc.sigma_min = fpr_sigma_min_10;
         } else {
-          spc.sigma_min = fpr_sigma_min_9;
+            spc.sigma_min = fpr_sigma_min_9;
         }
         PQCLEAN_FALCON1024_CLEAN_prng_init(&spc.p, rng);
         samp = PQCLEAN_FALCON1024_CLEAN_sampler;
@@ -1237,9 +1237,9 @@ PQCLEAN_FALCON1024_CLEAN_sign_dyn(int16_t *sig, inner_shake256_context *rng,
          * SHAKE context ('rng').
          */
         if (logn == 10) {
-          spc.sigma_min = fpr_sigma_min_10;
+            spc.sigma_min = fpr_sigma_min_10;
         } else {
-          spc.sigma_min = fpr_sigma_min_9;
+            spc.sigma_min = fpr_sigma_min_9;
         }
         PQCLEAN_FALCON1024_CLEAN_prng_init(&spc.p, rng);
         samp = PQCLEAN_FALCON1024_CLEAN_sampler;

--- a/crypto_sign/falcon-1024/clean/sign.c
+++ b/crypto_sign/falcon-1024/clean/sign.c
@@ -1189,9 +1189,11 @@ PQCLEAN_FALCON1024_CLEAN_sign_tree(int16_t *sig, inner_shake256_context *rng,
          * Normal sampling. We use a fast PRNG seeded from our
          * SHAKE context ('rng').
          */
-        spc.sigma_min = (logn == 10)
-                        ? fpr_sigma_min_10
-                        : fpr_sigma_min_9;
+        if (logn == 10) {
+          spc.sigma_min = fpr_sigma_min_10;
+        } else {
+          spc.sigma_min = fpr_sigma_min_9;
+        }
         PQCLEAN_FALCON1024_CLEAN_prng_init(&spc.p, rng);
         samp = PQCLEAN_FALCON1024_CLEAN_sampler;
         samp_ctx = &spc;
@@ -1234,9 +1236,11 @@ PQCLEAN_FALCON1024_CLEAN_sign_dyn(int16_t *sig, inner_shake256_context *rng,
          * Normal sampling. We use a fast PRNG seeded from our
          * SHAKE context ('rng').
          */
-        spc.sigma_min = (logn == 10)
-                        ? fpr_sigma_min_10
-                        : fpr_sigma_min_9;
+        if (logn == 10) {
+          spc.sigma_min = fpr_sigma_min_10;
+        } else {
+          spc.sigma_min = fpr_sigma_min_9;
+        }
         PQCLEAN_FALCON1024_CLEAN_prng_init(&spc.p, rng);
         samp = PQCLEAN_FALCON1024_CLEAN_sampler;
         samp_ctx = &spc;

--- a/crypto_sign/falcon-512/clean/codec.c
+++ b/crypto_sign/falcon-512/clean/codec.c
@@ -443,7 +443,8 @@ PQCLEAN_FALCON512_CLEAN_comp_decode(
                 return 0;
             }
         }
-        x[u] = (int16_t)(s ? -(int)m : (int)m);
+        x[u] = (int16_t) m;
+        if (s) x[u] = -x[u];
     }
     return v;
 }

--- a/crypto_sign/falcon-512/clean/codec.c
+++ b/crypto_sign/falcon-512/clean/codec.c
@@ -444,7 +444,9 @@ PQCLEAN_FALCON512_CLEAN_comp_decode(
             }
         }
         x[u] = (int16_t) m;
-        if (s) x[u] = -x[u];
+        if (s) {
+          x[u] = (int16_t) -x[u];
+        }
     }
     return v;
 }

--- a/crypto_sign/falcon-512/clean/codec.c
+++ b/crypto_sign/falcon-512/clean/codec.c
@@ -445,7 +445,7 @@ PQCLEAN_FALCON512_CLEAN_comp_decode(
         }
         x[u] = (int16_t) m;
         if (s) {
-          x[u] = (int16_t) -x[u];
+            x[u] = (int16_t) - x[u];
         }
     }
     return v;

--- a/crypto_sign/falcon-512/clean/fpr.h
+++ b/crypto_sign/falcon-512/clean/fpr.h
@@ -436,8 +436,8 @@ fpr_lt(fpr x, fpr y) {
      */
     int cc0, cc1;
 
-    cc0 = *(int64_t *)&x < *(int64_t *)&y;
-    cc1 = *(int64_t *)&x > *(int64_t *)&y;
+    cc0 = ((*(int64_t *)&x - *(int64_t *)&y) >> 63) & 1;
+    cc1 = ((*(int64_t *)&y - *(int64_t *)&x) >> 63) & 1;
     return cc0 ^ ((cc0 ^ cc1) & (int)((x & y) >> 63));
 }
 

--- a/crypto_sign/falcon-512/clean/fpr.h
+++ b/crypto_sign/falcon-512/clean/fpr.h
@@ -436,8 +436,8 @@ fpr_lt(fpr x, fpr y) {
      */
     int cc0, cc1;
 
-    cc0 = ((*(int64_t *)&x - *(int64_t *)&y) >> 63) & 1;
-    cc1 = ((*(int64_t *)&y - *(int64_t *)&x) >> 63) & 1;
+    cc0 = (int)((*(int64_t *)&x - *(int64_t *)&y) >> 63) & 1;
+    cc1 = (int)((*(int64_t *)&y - *(int64_t *)&x) >> 63) & 1;
     return cc0 ^ ((cc0 ^ cc1) & (int)((x & y) >> 63));
 }
 

--- a/crypto_sign/falcon-512/clean/fpr.h
+++ b/crypto_sign/falcon-512/clean/fpr.h
@@ -424,20 +424,32 @@ fpr fpr_sqrt(fpr x);
 static inline int
 fpr_lt(fpr x, fpr y) {
     /*
-     * If x >= 0 or y >= 0, a signed comparison yields the proper
-     * result:
+     * If both x and y are positive, then a signed comparison yields
+     * the proper result:
      *   - For positive values, the order is preserved.
      *   - The sign bit is at the same place as in integers, so
      *     sign is preserved.
+     * Moreover, we can compute [x < y] as sgn(x-y) and the computation
+     * of x-y will not overflow.
+     *
+     * If the signs differ, then sgn(x) gives the proper result.
      *
      * If both x and y are negative, then the order is reversed.
-     * We cannot simply invert the comparison result in that case
-     * because it would not handle the edge case x = y properly.
+     * Hence [x < y] = sgn(y-x). We must compute this separately from
+     * sgn(x-y); simply inverting sgn(x-y) would not handle the edge
+     * case x = y properly.
      */
     int cc0, cc1;
+    int64_t sx;
+    int64_t sy;
 
-    cc0 = (int)((*(int64_t *)&x - * (int64_t *)&y) >> 63) & 1;
-    cc1 = (int)((*(int64_t *)&y - * (int64_t *)&x) >> 63) & 1;
+    sx = *(int64_t *)&x;
+    sy = *(int64_t *)&y;
+    sy &= ~((sx ^ sy) >> 63); /* set sy=0 if signs differ */
+
+    cc0 = (int)((sx - sy) >> 63) & 1; /* Neither subtraction overflows when */
+    cc1 = (int)((sy - sx) >> 63) & 1; /* the signs are the same. */
+
     return cc0 ^ ((cc0 ^ cc1) & (int)((x & y) >> 63));
 }
 

--- a/crypto_sign/falcon-512/clean/fpr.h
+++ b/crypto_sign/falcon-512/clean/fpr.h
@@ -436,8 +436,8 @@ fpr_lt(fpr x, fpr y) {
      */
     int cc0, cc1;
 
-    cc0 = (int)((*(int64_t *)&x - *(int64_t *)&y) >> 63) & 1;
-    cc1 = (int)((*(int64_t *)&y - *(int64_t *)&x) >> 63) & 1;
+    cc0 = (int)((*(int64_t *)&x - * (int64_t *)&y) >> 63) & 1;
+    cc1 = (int)((*(int64_t *)&y - * (int64_t *)&x) >> 63) & 1;
     return cc0 ^ ((cc0 ^ cc1) & (int)((x & y) >> 63));
 }
 

--- a/crypto_sign/falcon-512/clean/keygen.c
+++ b/crypto_sign/falcon-512/clean/keygen.c
@@ -1903,9 +1903,9 @@ zint_add_scaled_mul_small(uint32_t *x, size_t xlen,
          */
         v = u - sch;
         if (v < ylen) {
-          wy = y[v];
+            wy = y[v];
         } else {
-          wy = ysign;
+            wy = ysign;
         }
         wys = ((wy << scl) & 0x7FFFFFFF) | tw;
         tw = wy >> (31 - scl);
@@ -1965,9 +1965,9 @@ zint_sub_scaled(uint32_t *x, size_t xlen,
          */
         v = u - sch;
         if (v < ylen) {
-          wy = y[v];
+            wy = y[v];
         } else {
-          wy = ysign;
+            wy = ysign;
         }
         wys = ((wy << scl) & 0x7FFFFFFF) | tw;
         tw = wy >> (31 - scl);
@@ -2656,16 +2656,18 @@ make_fg(uint32_t *data, const int8_t *f, const int8_t *g,
         return;
     }
 
-    if (depth == 0) return;
+    if (depth == 0) {
+        return;
+    }
     if (depth == 1) {
-      make_fg_step(data, logn, 0, 0, out_ntt);
-      return;
+        make_fg_step(data, logn, 0, 0, out_ntt);
+        return;
     }
     make_fg_step(data, logn, 0, 0, 1);
-    for (d = 1; d+1 < depth; d ++) {
+    for (d = 1; d + 1 < depth; d ++) {
         make_fg_step(data, logn - d, d, 1, 1);
     }
-    make_fg_step(data, logn-depth+1, depth-1, 1, out_ntt);
+    make_fg_step(data, logn - depth + 1, depth - 1, 1, out_ntt);
 }
 
 /*
@@ -3043,7 +3045,9 @@ solve_NTRU_intermediate(unsigned logn_top,
      * middle or the upper half of these top 10 words.
      */
     rlen = slen;
-    if (rlen > 10) rlen = 10;
+    if (rlen > 10) {
+        rlen = 10;
+    }
     poly_big_to_fp(rt3, ft + slen - rlen, rlen, slen, logn);
     poly_big_to_fp(rt4, gt + slen - rlen, rlen, slen, logn);
 
@@ -3118,7 +3122,9 @@ solve_NTRU_intermediate(unsigned logn_top,
          * scaling if the current length is more than 10 words.
          */
         rlen = FGlen;
-        if (rlen > 10) rlen = 10;
+        if (rlen > 10) {
+            rlen = 10;
+        }
         scale_FG = 31 * (int)(FGlen - rlen);
         poly_big_to_fp(rt1, Ft + FGlen - rlen, rlen, llen, logn);
         poly_big_to_fp(rt2, Gt + FGlen - rlen, rlen, llen, logn);

--- a/crypto_sign/falcon-512/clean/keygen.c
+++ b/crypto_sign/falcon-512/clean/keygen.c
@@ -1902,7 +1902,11 @@ zint_add_scaled_mul_small(uint32_t *x, size_t xlen,
          * Get the next word of y (scaled).
          */
         v = u - sch;
-        wy = v < ylen ? y[v] : ysign;
+        if (v < ylen) {
+          wy = y[v];
+        } else {
+          wy = ysign;
+        }
         wys = ((wy << scl) & 0x7FFFFFFF) | tw;
         tw = wy >> (31 - scl);
 
@@ -1960,7 +1964,11 @@ zint_sub_scaled(uint32_t *x, size_t xlen,
          * Get the next word of y (scaled).
          */
         v = u - sch;
-        wy = v < ylen ? y[v] : ysign;
+        if (v < ylen) {
+          wy = y[v];
+        } else {
+          wy = ysign;
+        }
         wys = ((wy << scl) & 0x7FFFFFFF) | tw;
         tw = wy >> (31 - scl);
 
@@ -2648,10 +2656,16 @@ make_fg(uint32_t *data, const int8_t *f, const int8_t *g,
         return;
     }
 
-    for (d = 0; d < depth; d ++) {
-        make_fg_step(data, logn - d, d,
-                     d != 0, (d + 1) < depth || out_ntt);
+    if (depth == 0) return;
+    if (depth == 1) {
+      make_fg_step(data, logn, 0, 0, out_ntt);
+      return;
     }
+    make_fg_step(data, logn, 0, 0, 1);
+    for (d = 1; d+1 < depth; d ++) {
+        make_fg_step(data, logn - d, d, 1, 1);
+    }
+    make_fg_step(data, logn-depth+1, depth-1, 1, out_ntt);
 }
 
 /*
@@ -3028,7 +3042,8 @@ solve_NTRU_intermediate(unsigned logn_top,
      * computed so that average maximum length will fall in the
      * middle or the upper half of these top 10 words.
      */
-    rlen = (slen > 10) ? 10 : slen;
+    rlen = slen;
+    if (rlen > 10) rlen = 10;
     poly_big_to_fp(rt3, ft + slen - rlen, rlen, slen, logn);
     poly_big_to_fp(rt4, gt + slen - rlen, rlen, slen, logn);
 
@@ -3102,7 +3117,8 @@ solve_NTRU_intermediate(unsigned logn_top,
          * Convert current F and G into floating-point. We apply
          * scaling if the current length is more than 10 words.
          */
-        rlen = (FGlen > 10) ? 10 : FGlen;
+        rlen = FGlen;
+        if (rlen > 10) rlen = 10;
         scale_FG = 31 * (int)(FGlen - rlen);
         poly_big_to_fp(rt1, Ft + FGlen - rlen, rlen, llen, logn);
         poly_big_to_fp(rt2, Gt + FGlen - rlen, rlen, llen, logn);

--- a/crypto_sign/falcon-512/clean/sign.c
+++ b/crypto_sign/falcon-512/clean/sign.c
@@ -1189,9 +1189,11 @@ PQCLEAN_FALCON512_CLEAN_sign_tree(int16_t *sig, inner_shake256_context *rng,
          * Normal sampling. We use a fast PRNG seeded from our
          * SHAKE context ('rng').
          */
-        spc.sigma_min = (logn == 10)
-                        ? fpr_sigma_min_10
-                        : fpr_sigma_min_9;
+        if (logn == 10) {
+          spc.sigma_min = fpr_sigma_min_10;
+        } else {
+          spc.sigma_min = fpr_sigma_min_9;
+        }
         PQCLEAN_FALCON512_CLEAN_prng_init(&spc.p, rng);
         samp = PQCLEAN_FALCON512_CLEAN_sampler;
         samp_ctx = &spc;
@@ -1234,9 +1236,11 @@ PQCLEAN_FALCON512_CLEAN_sign_dyn(int16_t *sig, inner_shake256_context *rng,
          * Normal sampling. We use a fast PRNG seeded from our
          * SHAKE context ('rng').
          */
-        spc.sigma_min = (logn == 10)
-                        ? fpr_sigma_min_10
-                        : fpr_sigma_min_9;
+        if (logn == 10) {
+          spc.sigma_min = fpr_sigma_min_10;
+        } else {
+          spc.sigma_min = fpr_sigma_min_9;
+        }
         PQCLEAN_FALCON512_CLEAN_prng_init(&spc.p, rng);
         samp = PQCLEAN_FALCON512_CLEAN_sampler;
         samp_ctx = &spc;

--- a/crypto_sign/falcon-512/clean/sign.c
+++ b/crypto_sign/falcon-512/clean/sign.c
@@ -1190,9 +1190,9 @@ PQCLEAN_FALCON512_CLEAN_sign_tree(int16_t *sig, inner_shake256_context *rng,
          * SHAKE context ('rng').
          */
         if (logn == 10) {
-          spc.sigma_min = fpr_sigma_min_10;
+            spc.sigma_min = fpr_sigma_min_10;
         } else {
-          spc.sigma_min = fpr_sigma_min_9;
+            spc.sigma_min = fpr_sigma_min_9;
         }
         PQCLEAN_FALCON512_CLEAN_prng_init(&spc.p, rng);
         samp = PQCLEAN_FALCON512_CLEAN_sampler;
@@ -1237,9 +1237,9 @@ PQCLEAN_FALCON512_CLEAN_sign_dyn(int16_t *sig, inner_shake256_context *rng,
          * SHAKE context ('rng').
          */
         if (logn == 10) {
-          spc.sigma_min = fpr_sigma_min_10;
+            spc.sigma_min = fpr_sigma_min_10;
         } else {
-          spc.sigma_min = fpr_sigma_min_9;
+            spc.sigma_min = fpr_sigma_min_9;
         }
         PQCLEAN_FALCON512_CLEAN_prng_init(&spc.p, rng);
         samp = PQCLEAN_FALCON512_CLEAN_sampler;

--- a/crypto_sign/rainbowIIIc-classic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIIIc-classic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, !PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowIIIc-classic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIIIc-classic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1 ^ PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowIIIc-classic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIIIc-classic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWIIICCLASSIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowIIIc-cyclic-compressed/clean/blas_comm.c
+++ b/crypto_sign/rainbowIIIc-cyclic-compressed/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1 ^ PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowIIIc-cyclic-compressed/clean/blas_comm.c
+++ b/crypto_sign/rainbowIIIc-cyclic-compressed/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, !PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowIIIc-cyclic-compressed/clean/blas_comm.c
+++ b/crypto_sign/rainbowIIIc-cyclic-compressed/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWIIICCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowIIIc-cyclic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIIIc-cyclic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1 ^ PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowIIIc-cyclic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIIIc-cyclic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowIIIc-cyclic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIIIc-cyclic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, !PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWIIICCYCLIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowIa-classic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIa-classic/clean/blas_comm.c
@@ -74,7 +74,7 @@ static unsigned int gf16mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsigne
         uint8_t *ai = mat + n_w_byte * i;
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + n_w_byte * j;
-            PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1^PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
+            PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1 ^ PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
         }
         uint8_t pivot = PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16v_get_ele(ai, i);
         r8 &= PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16_is_nonzero(pivot);

--- a/crypto_sign/rainbowIa-classic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIa-classic/clean/blas_comm.c
@@ -74,7 +74,7 @@ static unsigned int gf16mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsigne
         uint8_t *ai = mat + n_w_byte * i;
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + n_w_byte * j;
-            PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1-PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
+            PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1^PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
         }
         uint8_t pivot = PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16v_get_ele(ai, i);
         r8 &= PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16_is_nonzero(pivot);

--- a/crypto_sign/rainbowIa-classic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIa-classic/clean/blas_comm.c
@@ -74,7 +74,7 @@ static unsigned int gf16mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsigne
         uint8_t *ai = mat + n_w_byte * i;
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + n_w_byte * j;
-            PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf256v_predicated_add(ai + offset_byte, !PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
+            PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1-PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
         }
         uint8_t pivot = PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16v_get_ele(ai, i);
         r8 &= PQCLEAN_RAINBOWIACLASSIC_CLEAN_gf16_is_nonzero(pivot);

--- a/crypto_sign/rainbowIa-cyclic-compressed/clean/blas_comm.c
+++ b/crypto_sign/rainbowIa-cyclic-compressed/clean/blas_comm.c
@@ -74,7 +74,7 @@ static unsigned int gf16mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsigne
         uint8_t *ai = mat + n_w_byte * i;
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + n_w_byte * j;
-            PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + offset_byte, 1^PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
+            PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + offset_byte, 1 ^ PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
         }
         uint8_t pivot = PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16v_get_ele(ai, i);
         r8 &= PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16_is_nonzero(pivot);

--- a/crypto_sign/rainbowIa-cyclic-compressed/clean/blas_comm.c
+++ b/crypto_sign/rainbowIa-cyclic-compressed/clean/blas_comm.c
@@ -74,7 +74,7 @@ static unsigned int gf16mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsigne
         uint8_t *ai = mat + n_w_byte * i;
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + n_w_byte * j;
-            PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + offset_byte, !PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
+            PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + offset_byte, 1-PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
         }
         uint8_t pivot = PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16v_get_ele(ai, i);
         r8 &= PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16_is_nonzero(pivot);

--- a/crypto_sign/rainbowIa-cyclic-compressed/clean/blas_comm.c
+++ b/crypto_sign/rainbowIa-cyclic-compressed/clean/blas_comm.c
@@ -74,7 +74,7 @@ static unsigned int gf16mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsigne
         uint8_t *ai = mat + n_w_byte * i;
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + n_w_byte * j;
-            PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + offset_byte, 1-PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
+            PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + offset_byte, 1^PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
         }
         uint8_t pivot = PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16v_get_ele(ai, i);
         r8 &= PQCLEAN_RAINBOWIACYCLICCOMPRESSED_CLEAN_gf16_is_nonzero(pivot);

--- a/crypto_sign/rainbowIa-cyclic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIa-cyclic/clean/blas_comm.c
@@ -74,7 +74,7 @@ static unsigned int gf16mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsigne
         uint8_t *ai = mat + n_w_byte * i;
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + n_w_byte * j;
-            PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1^PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
+            PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1 ^ PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
         }
         uint8_t pivot = PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16v_get_ele(ai, i);
         r8 &= PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16_is_nonzero(pivot);

--- a/crypto_sign/rainbowIa-cyclic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIa-cyclic/clean/blas_comm.c
@@ -74,7 +74,7 @@ static unsigned int gf16mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsigne
         uint8_t *ai = mat + n_w_byte * i;
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + n_w_byte * j;
-            PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf256v_predicated_add(ai + offset_byte, !PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
+            PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1-PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
         }
         uint8_t pivot = PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16v_get_ele(ai, i);
         r8 &= PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16_is_nonzero(pivot);

--- a/crypto_sign/rainbowIa-cyclic/clean/blas_comm.c
+++ b/crypto_sign/rainbowIa-cyclic/clean/blas_comm.c
@@ -74,7 +74,7 @@ static unsigned int gf16mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsigne
         uint8_t *ai = mat + n_w_byte * i;
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + n_w_byte * j;
-            PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1-PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
+            PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf256v_predicated_add(ai + offset_byte, 1^PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16_is_nonzero(PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16v_get_ele(ai, i)), aj + offset_byte, n_w_byte - offset_byte);
         }
         uint8_t pivot = PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16v_get_ele(ai, i);
         r8 &= PQCLEAN_RAINBOWIACYCLIC_CLEAN_gf16_is_nonzero(pivot);

--- a/crypto_sign/rainbowVc-classic/clean/blas_comm.c
+++ b/crypto_sign/rainbowVc-classic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1 ^ PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowVc-classic/clean/blas_comm.c
+++ b/crypto_sign/rainbowVc-classic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowVc-classic/clean/blas_comm.c
+++ b/crypto_sign/rainbowVc-classic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, !PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWVCCLASSIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowVc-cyclic-compressed/clean/blas_comm.c
+++ b/crypto_sign/rainbowVc-cyclic-compressed/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, !PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowVc-cyclic-compressed/clean/blas_comm.c
+++ b/crypto_sign/rainbowVc-cyclic-compressed/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowVc-cyclic-compressed/clean/blas_comm.c
+++ b/crypto_sign/rainbowVc-cyclic-compressed/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1 ^ PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWVCCYCLICCOMPRESSED_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowVc-cyclic/clean/blas_comm.c
+++ b/crypto_sign/rainbowVc-cyclic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowVc-cyclic/clean/blas_comm.c
+++ b/crypto_sign/rainbowVc-cyclic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, !PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1-PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/rainbowVc-cyclic/clean/blas_comm.c
+++ b/crypto_sign/rainbowVc-cyclic/clean/blas_comm.c
@@ -72,7 +72,7 @@ static unsigned int gf256mat_gauss_elim_ref(uint8_t *mat, unsigned int h, unsign
 
         for (unsigned int j = i + 1; j < h; j++) {
             uint8_t *aj = mat + w * j;
-            PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1^PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
+            PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256v_predicated_add(ai + skip_len_align4, 1 ^ PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256_is_nonzero(ai[i]), aj + skip_len_align4, w - skip_len_align4);
         }
         r8 &= PQCLEAN_RAINBOWVCCYCLIC_CLEAN_gf256_is_nonzero(ai[i]);
         uint8_t pivot = ai[i];

--- a/crypto_sign/sphincs-sha256-128f-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-128f-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-128f-robust/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256128FROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-128f-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-128f-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-128f-simple/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256128FSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-128s-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-128s-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-128s-robust/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256128SROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-128s-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-128s-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-128s-simple/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256128SSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-192f-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-192f-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-192f-robust/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256192FROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-192f-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-192f-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-192f-simple/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256192FSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-192s-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-192s-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-192s-robust/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256192SROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-192s-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-192s-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-192s-simple/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256192SSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-256f-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-256f-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-256f-robust/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256256FROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-256f-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-256f-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-256f-simple/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256256FSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-256s-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-256s-robust/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-256s-robust/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256256SROBUST_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-256s-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/avx2/sha256avx.c
@@ -67,7 +67,9 @@ void PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
 
     while (i < len) {
         bytes_to_copy = len - i;
-        if (bytes_to_copy > 64) bytes_to_copy = 64;
+        if (bytes_to_copy > 64) {
+            bytes_to_copy = 64;
+        }
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/crypto_sign/sphincs-sha256-256s-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha256-256s-simple/avx2/sha256avx.c
@@ -63,9 +63,11 @@ void PQCLEAN_SPHINCSSHA256256SSIMPLE_AVX2_sha256_update8x(sha256ctxx8 *ctx,
         const unsigned char *d7,
         unsigned long long len) {
     unsigned long long i = 0;
+    unsigned long long bytes_to_copy;
 
     while (i < len) {
-        unsigned long long bytes_to_copy = (len - i) > 64 ? 64 : (len - i);
+        bytes_to_copy = len - i;
+        if (bytes_to_copy > 64) bytes_to_copy = 64;
         memcpy(&ctx->msgblocks[64 * 0], d0 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 1], d1 + i, bytes_to_copy);
         memcpy(&ctx->msgblocks[64 * 2], d2 + i, bytes_to_copy);

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -27,6 +27,12 @@ class ForbiddenLineVisitor(pycparser.c_ast.NodeVisitor):
     v.visit(node.rvalue)
     self.errors.extend(v.errors)
 
+  def visit_Decl(self, node):
+    if node.init:
+        v = ForbiddenOpVisitor();
+        v.visit(node.init)
+        self.errors.extend(v.errors)
+
   def visit_FuncCall(self, node): 
     if node.args:
         v = ForbiddenOpVisitor();

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -1,0 +1,103 @@
+
+"""
+Checks that the implementation does not make use of boolean operations (==, <=, !, etc)
+in assignments or function calls.
+"""
+
+import os
+
+import pytest
+
+import helpers
+import pqclean
+import pycparser
+
+
+def setup_module():
+    if not(os.path.exists(os.path.join('pycparser', '.git'))):
+        print("Please run `git submodule update --init`")
+
+
+class ForbiddenLineVisitor(pycparser.c_ast.NodeVisitor): 
+  def __init__(self):
+    self.errors = []
+
+  def visit_Assignment(self, node): 
+    v = ForbiddenOpVisitor();
+    v.visit(node.rvalue)
+    self.errors.extend(v.errors)
+
+  def visit_FuncCall(self, node): 
+    if node.args:
+        v = ForbiddenOpVisitor();
+        v.visit(node.args)
+        self.errors.extend(v.errors)
+
+class ForbiddenOpVisitor(pycparser.c_ast.NodeVisitor): 
+  def __init__(self):
+    self.errors = []
+
+  def visit_BinaryOp(self, node): 
+    v = ForbiddenOpVisitor();
+    v.visit(node.left)
+    self.errors.extend(v.errors)
+    if node.op in ['<', '<=', '>', '>=', '==', '!=', '&&', '||']:
+      err = "\n {} at {c.file}:{c.line}:{c.column}".format(node.op, c=node.coord)
+      self.errors.append(err)
+    v = ForbiddenOpVisitor();
+    v.visit(node.right)
+    self.errors.extend(v.errors)
+
+  def visit_UnaryOp(self, node): 
+    if node.op == '!':
+      err = "\n {} at {c.file}:{c.line}:{c.column}".format(node.op, c=node.coord)
+      self.errors.append(err)
+    v = ForbiddenOpVisitor();
+    v.visit(node.expr)
+    self.errors.extend(v.errors)
+
+  def visit_TernaryOp(self, node): 
+    err = "\n ternary operator at {c.file}:{c.line}:{c.column}".format(c=node.coord)
+    self.errors.append(err)
+
+
+@pytest.mark.parametrize(
+    'implementation',
+    pqclean.Scheme.all_implementations(),
+    ids=str,
+)
+@helpers.skip_windows()
+@helpers.filtered_test
+def test_boolean(implementation):
+    errors = []
+    for fname in os.listdir(implementation.path()):
+        if not fname.endswith(".c"):
+            continue
+        tdir, _ = os.path.split(os.path.realpath(__file__))
+        ast = pycparser.parse_file(
+            os.path.join(implementation.path(), fname),
+            use_cpp=True,
+            cpp_path='cc',  # not all platforms link cpp correctly; cc -E works
+            cpp_args=[
+                '-E',
+                '-std=c99',
+                '-nostdinc',  # pycparser cannot deal with e.g. __attribute__
+                '-I{}'.format(os.path.join(tdir, "../common")),
+                # necessary to mock e.g. <stdint.h>
+                '-I{}'.format(
+                    os.path.join(tdir, 'pycparser/utils/fake_libc_include')),
+            ]
+        )
+        v = ForbiddenLineVisitor()
+        v.visit(ast)
+        errors.extend(v.errors)
+    if errors:
+        raise AssertionError(
+            "Prohibited use of boolean operations in assignment or function call" +
+            "".join(errors)
+        )
+
+
+if __name__ == "__main__":
+    import sys
+    pytest.main(sys.argv)


### PR DESCRIPTION
Compilers will occasionally generate non-constant time code when boolean operators are used in arithmetic expressions.

For example, prior to Aug 23, 2020, there was 0/1 flag in a polynomial inversion routine in NTRU that was flipped using "!x" instead of "1-x". Recent versions of clang (but not gcc) with -O3 on haswell would generate two separate vectorized implementations of a particular loop, one for each value of x, and make a conditional jump. This jump could, in principle, leak the value of x. The bug was caught by TIMECOP.

The test_boolean.py script added by this PR catches the same bug. It also identifies several potential problems in other pqclean implementations. The issues with hqc are fixed in the more recent release. The issues in mceliece and ntru are false positives. The issues in rainbow are also (as far as I can tell) false positives. The issues in falcon need to be checked carefully. 