### PR TITLE
hqc: Add -Wshadow and fix shadowing warnings

### DIFF
--- a/crypto_kem/hqc-128/META.yml
+++ b/crypto_kem/hqc-128/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:
@@ -33,4 +33,4 @@ implementations:
             required_flags:
                 - avx2
                 - bmi1
-                - pclmul
+                - pclmulqdq

--- a/crypto_kem/hqc-128/META.yml
+++ b/crypto_kem/hqc-128/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-128/avx2/Makefile
+++ b/crypto_kem/hqc-128/avx2/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-128_avx2.a
 HEADERS=alpha_table.h api.h bch.h code.h fft.h gen_matrix.h gf2x.h gf.h hqc.h parameters.h parsing.h repetition.h vector.h 
 OBJECTS=bch.o code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o repetition.o vector.o 
 
-CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wshadow -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-128/avx2/bch.c
+++ b/crypto_kem/hqc-128/avx2/bch.c
@@ -146,7 +146,7 @@ void compute_syndromes(__m256i *syndromes, const uint64_t *rcv) {
     __m256i tmp_repeat;
     uint32_t *aux;
     int16_t *alpha_tmp;
-    uint32_t i;
+    size_t i, j;
     uint32_t nzflag;
     // static variable so that it is stored in the DATA segment
     // not in the STACK segment
@@ -167,11 +167,11 @@ void compute_syndromes(__m256i *syndromes, const uint64_t *rcv) {
     }
 
     // Evaluation of the polynomial corresponding to the vector v in alpha^i for i in {1, ..., 2 * PARAM_DELTA}
-    for (size_t j = 0; j < SYND_SIZE_256; ++j) {
+    for (j = 0; j < SYND_SIZE_256; ++j) {
         S = zero_256;
         alpha_tmp = table_alpha_ij + (j << 4);
 
-        for (size_t i = 0; i < PARAM_N1; ++i) {
+        for (i = 0; i < PARAM_N1; ++i) {
             nzflag = ((-(int32_t) tmp_array[i]) >> 31) & 1;
             tmp_repeat = _mm256_set1_epi64x(nzflag);
             L = _mm256_cmpeq_epi64(tmp_repeat, un_256);

--- a/crypto_kem/hqc-128/avx2/code.c
+++ b/crypto_kem/hqc-128/avx2/code.c
@@ -35,9 +35,9 @@ static inline uint64_t mux(uint64_t a, uint64_t b, int64_t bit) {
  */
 void PQCLEAN_HQC128_AVX2_code_encode(uint64_t *em, const uint64_t *m) {
     const uint64_t mask[2][2] = {{0x0UL, 0x0UL}, {0x7FFFFFFFUL, 0x3FFFFFFFUL}};
-    size_t i, pos_r;
+    size_t i, j, pos_r;
     uint64_t bit;
-    uint64_t idx_r;
+    uint16_t idx_r;
     uint64_t select;
 
 
@@ -71,8 +71,8 @@ void PQCLEAN_HQC128_AVX2_code_encode(uint64_t *em, const uint64_t *m) {
     /* now we add the message m */
     /* systematic encoding */
     pos_r = PARAM_N2 * (PARAM_N1 - PARAM_K);
-    for (int32_t i = 0; i < 4; i++) {
-        for (int32_t j = 0; j < 64; j++) {
+    for (i = 0; i < 4; i++) {
+        for (j = 0; j < 64; j++) {
             bit = (m[i] >> j) & 0x1;
 
 

--- a/crypto_kem/hqc-128/avx2/vector.c
+++ b/crypto_kem/hqc-128/avx2/vector.c
@@ -36,9 +36,13 @@ void PQCLEAN_HQC128_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint6
     __m256i bit256[PARAM_OMEGA_R];
     __m256i bloc256[PARAM_OMEGA_R];
     __m256i posCmp256 = _mm256_set_epi64x(3, 2, 1, 0);
+    __m256i pos256;
+    __m256i mask256;
+    __m256i aux;
+    __m256i i256;
     uint64_t bloc, pos, bit64;
     uint8_t inc;
-    size_t i, j;
+    size_t i, j, k;
 
     i = 0;
     j = random_bytes_size;
@@ -58,7 +62,7 @@ void PQCLEAN_HQC128_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint6
         tmp[i] = tmp[i] % PARAM_N;
 
         inc = 1;
-        for (uint32_t k = 0; k < i; k++) {
+        for (k = 0; k < i; k++) {
             if (tmp[k] == tmp[i]) {
                 inc = 0;
             }
@@ -71,19 +75,18 @@ void PQCLEAN_HQC128_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint6
         bloc = tmp[i] >> 6;
         bloc256[i] = _mm256_set1_epi64x(bloc >> 2);
         pos = (bloc & 0x3UL);
-        __m256i pos256 = _mm256_set1_epi64x(pos);
-        __m256i mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
+        pos256 = _mm256_set1_epi64x(pos);
+        mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
         bit64 = 1ULL << (tmp[i] & 0x3f);
-        __m256i bloc256 = _mm256_set1_epi64x(bit64);
-        bit256[i] = bloc256 & mask256;
+        bit256[i] = _mm256_set1_epi64x(bit64)&mask256;
     }
 
     for (i = 0; i < CEIL_DIVIDE(PARAM_N, 256); i++) {
-        __m256i aux = _mm256_loadu_si256(((__m256i *)v) + i);
-        __m256i i256 = _mm256_set1_epi64x(i);
+        aux = _mm256_loadu_si256(((__m256i *)v) + i);
+        i256 = _mm256_set1_epi64x(i);
 
         for (j = 0; j < weight; j++) {
-            __m256i mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
+            mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
             aux ^= bit256[j] & mask256;
         }
         _mm256_storeu_si256(((__m256i *)v) + i, aux);

--- a/crypto_kem/hqc-128/clean/Makefile
+++ b/crypto_kem/hqc-128/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-128_clean.a
 HEADERS=api.h bch.h code.h fft.h gf2x.h gf.h hqc.h parameters.h parsing.h repetition.h vector.h 
 OBJECTS=bch.o code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o repetition.o vector.o 
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wshadow -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-192/META.yml
+++ b/crypto_kem/hqc-192/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:
@@ -33,4 +33,4 @@ implementations:
             required_flags:
                 - avx2
                 - bmi1
-                - pclmul
+                - pclmulqdq

--- a/crypto_kem/hqc-192/META.yml
+++ b/crypto_kem/hqc-192/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-192/avx2/Makefile
+++ b/crypto_kem/hqc-192/avx2/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-192_avx2.a
 HEADERS=alpha_table.h api.h bch.h code.h fft.h gen_matrix.h gf2x.h gf.h hqc.h parameters.h parsing.h repetition.h vector.h 
 OBJECTS=bch.o code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o repetition.o vector.o 
 
-CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wshadow -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-192/avx2/bch.c
+++ b/crypto_kem/hqc-192/avx2/bch.c
@@ -146,7 +146,7 @@ void compute_syndromes(__m256i *syndromes, const uint64_t *rcv) {
     __m256i tmp_repeat;
     uint32_t *aux;
     int16_t *alpha_tmp;
-    uint32_t i;
+    size_t i, j;
     uint32_t nzflag;
     // static variable so that it is stored in the DATA segment
     // not in the STACK segment
@@ -167,11 +167,11 @@ void compute_syndromes(__m256i *syndromes, const uint64_t *rcv) {
     }
 
     // Evaluation of the polynomial corresponding to the vector v in alpha^i for i in {1, ..., 2 * PARAM_DELTA}
-    for (size_t j = 0; j < SYND_SIZE_256; ++j) {
+    for (j = 0; j < SYND_SIZE_256; ++j) {
         S = zero_256;
         alpha_tmp = table_alpha_ij + (j << 4);
 
-        for (size_t i = 0; i < PARAM_N1; ++i) {
+        for (i = 0; i < PARAM_N1; ++i) {
             nzflag = ((-(int32_t) tmp_array[i]) >> 31) & 1;
             tmp_repeat = _mm256_set1_epi64x(nzflag);
             L = _mm256_cmpeq_epi64(tmp_repeat, un_256);

--- a/crypto_kem/hqc-192/avx2/code.c
+++ b/crypto_kem/hqc-192/avx2/code.c
@@ -35,7 +35,7 @@ static inline uint64_t mux(uint64_t a, uint64_t b, int64_t bit) {
  */
 void PQCLEAN_HQC192_AVX2_code_encode(uint64_t *em, const uint64_t *m) {
     const uint64_t mask[2][2] = {{0x0UL, 0x0UL}, {0x7FFFFFFFFFFFFFFUL, 0x3FFFFFFFFFFFFFFUL}};
-    size_t i, pos_r;
+    size_t i, j, pos_r;
     uint64_t bit;
     uint16_t idx_r;
     uint64_t select;
@@ -71,8 +71,8 @@ void PQCLEAN_HQC192_AVX2_code_encode(uint64_t *em, const uint64_t *m) {
     /* now we add the message m */
     /* systematic encoding */
     pos_r = PARAM_N2 * (PARAM_N1 - PARAM_K);
-    for (int32_t i = 0; i < 4; i++) {
-        for (int32_t j = 0; j < 64; j++) {
+    for (i = 0; i < 4; i++) {
+        for (j = 0; j < 64; j++) {
             bit = (m[i] >> j) & 0x1;
 
 

--- a/crypto_kem/hqc-192/avx2/vector.c
+++ b/crypto_kem/hqc-192/avx2/vector.c
@@ -36,9 +36,13 @@ void PQCLEAN_HQC192_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint6
     __m256i bit256[PARAM_OMEGA_R];
     __m256i bloc256[PARAM_OMEGA_R];
     __m256i posCmp256 = _mm256_set_epi64x(3, 2, 1, 0);
+    __m256i pos256;
+    __m256i mask256;
+    __m256i aux;
+    __m256i i256;
     uint64_t bloc, pos, bit64;
     uint8_t inc;
-    size_t i, j;
+    size_t i, j, k;
 
     i = 0;
     j = random_bytes_size;
@@ -58,7 +62,7 @@ void PQCLEAN_HQC192_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint6
         tmp[i] = tmp[i] % PARAM_N;
 
         inc = 1;
-        for (uint32_t k = 0; k < i; k++) {
+        for (k = 0; k < i; k++) {
             if (tmp[k] == tmp[i]) {
                 inc = 0;
             }
@@ -71,19 +75,18 @@ void PQCLEAN_HQC192_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint6
         bloc = tmp[i] >> 6;
         bloc256[i] = _mm256_set1_epi64x(bloc >> 2);
         pos = (bloc & 0x3UL);
-        __m256i pos256 = _mm256_set1_epi64x(pos);
-        __m256i mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
+        pos256 = _mm256_set1_epi64x(pos);
+        mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
         bit64 = 1ULL << (tmp[i] & 0x3f);
-        __m256i bloc256 = _mm256_set1_epi64x(bit64);
-        bit256[i] = bloc256 & mask256;
+        bit256[i] = _mm256_set1_epi64x(bit64)&mask256;
     }
 
     for (i = 0; i < CEIL_DIVIDE(PARAM_N, 256); i++) {
-        __m256i aux = _mm256_loadu_si256(((__m256i *)v) + i);
-        __m256i i256 = _mm256_set1_epi64x(i);
+        aux = _mm256_loadu_si256(((__m256i *)v) + i);
+        i256 = _mm256_set1_epi64x(i);
 
         for (j = 0; j < weight; j++) {
-            __m256i mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
+            mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
             aux ^= bit256[j] & mask256;
         }
         _mm256_storeu_si256(((__m256i *)v) + i, aux);

--- a/crypto_kem/hqc-192/clean/Makefile
+++ b/crypto_kem/hqc-192/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-192_clean.a
 HEADERS=api.h bch.h code.h fft.h gf2x.h gf.h hqc.h parameters.h parsing.h repetition.h vector.h 
 OBJECTS=bch.o code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o repetition.o vector.o 
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wshadow -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-256/META.yml
+++ b/crypto_kem/hqc-256/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:
@@ -33,4 +33,4 @@ implementations:
             required_flags:
                 - avx2
                 - bmi1
-                - pclmul
+                - pclmulqdq

--- a/crypto_kem/hqc-256/META.yml
+++ b/crypto_kem/hqc-256/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-256/avx2/Makefile
+++ b/crypto_kem/hqc-256/avx2/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-256_avx2.a
 HEADERS=alpha_table.h api.h bch.h code.h fft.h gen_matrix.h gf2x.h gf.h hqc.h parameters.h parsing.h repetition.h vector.h 
 OBJECTS=bch.o code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o repetition.o vector.o 
 
-CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wshadow -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-256/avx2/bch.c
+++ b/crypto_kem/hqc-256/avx2/bch.c
@@ -146,7 +146,7 @@ void compute_syndromes(__m256i *syndromes, const uint64_t *rcv) {
     __m256i tmp_repeat;
     uint32_t *aux;
     int16_t *alpha_tmp;
-    uint32_t i;
+    size_t i, j;
     uint32_t nzflag;
     // static variable so that it is stored in the DATA segment
     // not in the STACK segment
@@ -167,11 +167,11 @@ void compute_syndromes(__m256i *syndromes, const uint64_t *rcv) {
     }
 
     // Evaluation of the polynomial corresponding to the vector v in alpha^i for i in {1, ..., 2 * PARAM_DELTA}
-    for (size_t j = 0; j < SYND_SIZE_256; ++j) {
+    for (j = 0; j < SYND_SIZE_256; ++j) {
         S = zero_256;
         alpha_tmp = table_alpha_ij + (j << 4);
 
-        for (size_t i = 0; i < PARAM_N1; ++i) {
+        for (i = 0; i < PARAM_N1; ++i) {
             nzflag = ((-(int32_t) tmp_array[i]) >> 31) & 1;
             tmp_repeat = _mm256_set1_epi64x(nzflag);
             L = _mm256_cmpeq_epi64(tmp_repeat, un_256);

--- a/crypto_kem/hqc-256/avx2/code.c
+++ b/crypto_kem/hqc-256/avx2/code.c
@@ -35,10 +35,10 @@ static inline uint64_t mux(uint64_t a, uint64_t b, int64_t bit) {
  */
 void PQCLEAN_HQC256_AVX2_code_encode(uint64_t *em, const uint64_t *m) {
     const uint64_t mask[2][3] = {{0x0UL, 0x0UL, 0x0UL}, {0xFFFFFFFFFFFFFFFFUL, 0xFFFFFFFFFFFFFFFFUL, 0x3FFFFFUL}};
-    size_t i, pos_r;
+    size_t i, j, pos_r;
     uint64_t bit;
-    uint64_t idx_r;
-    uint64_t idx_2;
+    uint16_t idx_r;
+    uint16_t idx_2;
     uint64_t select;
 
 
@@ -76,8 +76,8 @@ void PQCLEAN_HQC256_AVX2_code_encode(uint64_t *em, const uint64_t *m) {
     /* now we add the message m */
     /* systematic encoding */
     pos_r = PARAM_N2 * (PARAM_N1 - PARAM_K);
-    for (int32_t i = 0; i < 4; i++) {
-        for (int32_t j = 0; j < 64; j++) {
+    for (i = 0; i < 4; i++) {
+        for (j = 0; j < 64; j++) {
             bit = (m[i] >> j) & 0x1;
 
 

--- a/crypto_kem/hqc-256/avx2/code.c
+++ b/crypto_kem/hqc-256/avx2/code.c
@@ -37,8 +37,8 @@ void PQCLEAN_HQC256_AVX2_code_encode(uint64_t *em, const uint64_t *m) {
     const uint64_t mask[2][3] = {{0x0UL, 0x0UL, 0x0UL}, {0xFFFFFFFFFFFFFFFFUL, 0xFFFFFFFFFFFFFFFFUL, 0x3FFFFFUL}};
     size_t i, j, pos_r;
     uint64_t bit;
-    uint16_t idx_r;
-    uint16_t idx_2;
+    uint64_t idx_r;
+    uint64_t idx_2;
     uint64_t select;
 
 

--- a/crypto_kem/hqc-256/avx2/vector.c
+++ b/crypto_kem/hqc-256/avx2/vector.c
@@ -36,9 +36,13 @@ void PQCLEAN_HQC256_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint6
     __m256i bit256[PARAM_OMEGA_R];
     __m256i bloc256[PARAM_OMEGA_R];
     __m256i posCmp256 = _mm256_set_epi64x(3, 2, 1, 0);
+    __m256i pos256;
+    __m256i mask256;
+    __m256i aux;
+    __m256i i256;
     uint64_t bloc, pos, bit64;
     uint8_t inc;
-    size_t i, j;
+    size_t i, j, k;
 
     i = 0;
     j = random_bytes_size;
@@ -58,7 +62,7 @@ void PQCLEAN_HQC256_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint6
         tmp[i] = tmp[i] % PARAM_N;
 
         inc = 1;
-        for (uint32_t k = 0; k < i; k++) {
+        for (k = 0; k < i; k++) {
             if (tmp[k] == tmp[i]) {
                 inc = 0;
             }
@@ -71,19 +75,18 @@ void PQCLEAN_HQC256_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint6
         bloc = tmp[i] >> 6;
         bloc256[i] = _mm256_set1_epi64x(bloc >> 2);
         pos = (bloc & 0x3UL);
-        __m256i pos256 = _mm256_set1_epi64x(pos);
-        __m256i mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
+        pos256 = _mm256_set1_epi64x(pos);
+        mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
         bit64 = 1ULL << (tmp[i] & 0x3f);
-        __m256i bloc256 = _mm256_set1_epi64x(bit64);
-        bit256[i] = bloc256 & mask256;
+        bit256[i] = _mm256_set1_epi64x(bit64)&mask256;
     }
 
     for (i = 0; i < CEIL_DIVIDE(PARAM_N, 256); i++) {
-        __m256i aux = _mm256_loadu_si256(((__m256i *)v) + i);
-        __m256i i256 = _mm256_set1_epi64x(i);
+        aux = _mm256_loadu_si256(((__m256i *)v) + i);
+        i256 = _mm256_set1_epi64x(i);
 
         for (j = 0; j < weight; j++) {
-            __m256i mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
+            mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
             aux ^= bit256[j] & mask256;
         }
         _mm256_storeu_si256(((__m256i *)v) + i, aux);

--- a/crypto_kem/hqc-256/clean/Makefile
+++ b/crypto_kem/hqc-256/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-256_clean.a
 HEADERS=api.h bch.h code.h fft.h gf2x.h gf.h hqc.h parameters.h parsing.h repetition.h vector.h 
 OBJECTS=bch.o code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o repetition.o vector.o 
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wshadow -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-rmrs-128/META.yml
+++ b/crypto_kem/hqc-rmrs-128/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:
@@ -33,4 +33,4 @@ implementations:
             required_flags:
                 - avx2
                 - bmi1
-                - pclmul
+                - pclmulqdq

--- a/crypto_kem/hqc-rmrs-128/META.yml
+++ b/crypto_kem/hqc-rmrs-128/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-rmrs-128/avx2/Makefile
+++ b/crypto_kem/hqc-rmrs-128/avx2/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-rmrs-128_avx2.a
 HEADERS=api.h code.h fft.h gf2x.h gf.h hqc.h parameters.h parsing.h reed_muller.h reed_solomon.h vector.h 
 OBJECTS=code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o reed_muller.o reed_solomon.o vector.o 
 
-CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wshadow -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-rmrs-128/avx2/vector.c
+++ b/crypto_kem/hqc-rmrs-128/avx2/vector.c
@@ -36,9 +36,13 @@ void PQCLEAN_HQCRMRS128_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, u
     __m256i bit256[PARAM_OMEGA_R];
     __m256i bloc256[PARAM_OMEGA_R];
     __m256i posCmp256 = _mm256_set_epi64x(3, 2, 1, 0);
+    __m256i pos256;
+    __m256i mask256;
+    __m256i aux;
+    __m256i i256;
     uint64_t bloc, pos, bit64;
     uint8_t inc;
-    size_t i, j;
+    size_t i, j, k;
 
     i = 0;
     j = random_bytes_size;
@@ -58,7 +62,7 @@ void PQCLEAN_HQCRMRS128_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, u
         tmp[i] = tmp[i] % PARAM_N;
 
         inc = 1;
-        for (uint32_t k = 0; k < i; k++) {
+        for (k = 0; k < i; k++) {
             if (tmp[k] == tmp[i]) {
                 inc = 0;
             }
@@ -71,19 +75,18 @@ void PQCLEAN_HQCRMRS128_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, u
         bloc = tmp[i] >> 6;
         bloc256[i] = _mm256_set1_epi64x(bloc >> 2);
         pos = (bloc & 0x3UL);
-        __m256i pos256 = _mm256_set1_epi64x(pos);
-        __m256i mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
+        pos256 = _mm256_set1_epi64x(pos);
+        mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
         bit64 = 1ULL << (tmp[i] & 0x3f);
-        __m256i bloc256 = _mm256_set1_epi64x(bit64);
-        bit256[i] = bloc256 & mask256;
+        bit256[i] = _mm256_set1_epi64x(bit64)&mask256;
     }
 
     for (i = 0; i < CEIL_DIVIDE(PARAM_N, 256); i++) {
-        __m256i aux = _mm256_loadu_si256(((__m256i *)v) + i);
-        __m256i i256 = _mm256_set1_epi64x(i);
+        aux = _mm256_loadu_si256(((__m256i *)v) + i);
+        i256 = _mm256_set1_epi64x(i);
 
         for (j = 0; j < weight; j++) {
-            __m256i mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
+            mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
             aux ^= bit256[j] & mask256;
         }
         _mm256_storeu_si256(((__m256i *)v) + i, aux);
@@ -145,7 +148,6 @@ uint8_t PQCLEAN_HQCRMRS128_AVX2_vect_compare(const uint8_t *v1, const uint8_t *v
     r = (~r + 1) >> 63;
     return (uint8_t) r;
 }
-
 
 
 

--- a/crypto_kem/hqc-rmrs-128/clean/Makefile
+++ b/crypto_kem/hqc-rmrs-128/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-rmrs-128_clean.a
 HEADERS=api.h code.h fft.h gf2x.h gf.h hqc.h parameters.h parsing.h reed_muller.h reed_solomon.h vector.h 
 OBJECTS=code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o reed_muller.o reed_solomon.o vector.o 
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wshadow -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-rmrs-192/META.yml
+++ b/crypto_kem/hqc-rmrs-192/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:
@@ -33,4 +33,4 @@ implementations:
             required_flags:
                 - avx2
                 - bmi1
-                - pclmul
+                - pclmulqdq

--- a/crypto_kem/hqc-rmrs-192/META.yml
+++ b/crypto_kem/hqc-rmrs-192/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-rmrs-192/avx2/Makefile
+++ b/crypto_kem/hqc-rmrs-192/avx2/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-rmrs-192_avx2.a
 HEADERS=api.h code.h fft.h gf2x.h gf.h hqc.h parameters.h parsing.h reed_muller.h reed_solomon.h vector.h 
 OBJECTS=code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o reed_muller.o reed_solomon.o vector.o 
 
-CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wshadow -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-rmrs-192/avx2/vector.c
+++ b/crypto_kem/hqc-rmrs-192/avx2/vector.c
@@ -36,9 +36,13 @@ void PQCLEAN_HQCRMRS192_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, u
     __m256i bit256[PARAM_OMEGA_R];
     __m256i bloc256[PARAM_OMEGA_R];
     __m256i posCmp256 = _mm256_set_epi64x(3, 2, 1, 0);
+    __m256i pos256;
+    __m256i mask256;
+    __m256i aux;
+    __m256i i256;
     uint64_t bloc, pos, bit64;
     uint8_t inc;
-    size_t i, j;
+    size_t i, j, k;
 
     i = 0;
     j = random_bytes_size;
@@ -58,7 +62,7 @@ void PQCLEAN_HQCRMRS192_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, u
         tmp[i] = tmp[i] % PARAM_N;
 
         inc = 1;
-        for (uint32_t k = 0; k < i; k++) {
+        for (k = 0; k < i; k++) {
             if (tmp[k] == tmp[i]) {
                 inc = 0;
             }
@@ -71,19 +75,18 @@ void PQCLEAN_HQCRMRS192_AVX2_vect_set_random_fixed_weight(AES_XOF_struct *ctx, u
         bloc = tmp[i] >> 6;
         bloc256[i] = _mm256_set1_epi64x(bloc >> 2);
         pos = (bloc & 0x3UL);
-        __m256i pos256 = _mm256_set1_epi64x(pos);
-        __m256i mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
+        pos256 = _mm256_set1_epi64x(pos);
+        mask256 = _mm256_cmpeq_epi64(pos256, posCmp256);
         bit64 = 1ULL << (tmp[i] & 0x3f);
-        __m256i bloc256 = _mm256_set1_epi64x(bit64);
-        bit256[i] = bloc256 & mask256;
+        bit256[i] = _mm256_set1_epi64x(bit64)&mask256;
     }
 
     for (i = 0; i < CEIL_DIVIDE(PARAM_N, 256); i++) {
-        __m256i aux = _mm256_loadu_si256(((__m256i *)v) + i);
-        __m256i i256 = _mm256_set1_epi64x(i);
+        aux = _mm256_loadu_si256(((__m256i *)v) + i);
+        i256 = _mm256_set1_epi64x(i);
 
         for (j = 0; j < weight; j++) {
-            __m256i mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
+            mask256 = _mm256_cmpeq_epi64(bloc256[j], i256);
             aux ^= bit256[j] & mask256;
         }
         _mm256_storeu_si256(((__m256i *)v) + i, aux);
@@ -145,7 +148,6 @@ uint8_t PQCLEAN_HQCRMRS192_AVX2_vect_compare(const uint8_t *v1, const uint8_t *v
     r = (~r + 1) >> 63;
     return (uint8_t) r;
 }
-
 
 
 

--- a/crypto_kem/hqc-rmrs-192/clean/Makefile
+++ b/crypto_kem/hqc-rmrs-192/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-rmrs-192_clean.a
 HEADERS=api.h code.h fft.h gf2x.h gf.h hqc.h parameters.h parsing.h reed_muller.h reed_solomon.h vector.h 
 OBJECTS=code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o reed_muller.o reed_solomon.o vector.o 
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wshadow -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-rmrs-256/META.yml
+++ b/crypto_kem/hqc-rmrs-256/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/8a81b2c9/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:
@@ -33,4 +33,4 @@ implementations:
             required_flags:
                 - avx2
                 - bmi1
-                - pclmul
+                - pclmulqdq

--- a/crypto_kem/hqc-rmrs-256/META.yml
+++ b/crypto_kem/hqc-rmrs-256/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
     - name: avx2
-      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/22134db4/hqc
+      version: hqc-submission_2020-05-29 via https://github.com/jschanck/package-pqclean/tree/09ab89ed/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-rmrs-256/avx2/Makefile
+++ b/crypto_kem/hqc-rmrs-256/avx2/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-rmrs-256_avx2.a
 HEADERS=api.h code.h fft.h gf2x.h gf.h hqc.h parameters.h parsing.h reed_muller.h reed_solomon.h vector.h 
 OBJECTS=code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o reed_muller.o reed_solomon.o vector.o 
 
-CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -mavx2 -mbmi -mpclmul -Wall -Wextra -Wshadow -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 

--- a/crypto_kem/hqc-rmrs-256/clean/Makefile
+++ b/crypto_kem/hqc-rmrs-256/clean/Makefile
@@ -4,7 +4,7 @@ LIB=libhqc-rmrs-256_clean.a
 HEADERS=api.h code.h fft.h gf2x.h gf.h hqc.h parameters.h parsing.h reed_muller.h reed_solomon.h vector.h 
 OBJECTS=code.o fft.o gf2x.o gf.o hqc.o kem.o parsing.o reed_muller.o reed_solomon.o vector.o 
 
-CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
+CFLAGS=-O3 -Wall -Wextra -Wpedantic -Wshadow -Wvla -Werror -Wredundant-decls -Wmissing-prototypes -std=c99 -I../../../common $(EXTRAFLAGS)
 
 all: $(LIB)
 


### PR DESCRIPTION
Resolves https://github.com/PQClean/PQClean/pull/332#issuecomment-714829999.

Just a note: adding "pclmul" flag to META.yml (1302bbbf) prevented the test suite from trying to build hqc on my development machine (even though it builds correctly there). On that machine, get_cpu_info() includes "pclmulqdq" but not "pclmul".