### PR TITLE
NTRU: faster multiplication for reference implementations

### DIFF
--- a/crypto_kem/ntruhps2048509/META.yml
+++ b/crypto_kem/ntruhps2048509/META.yml
@@ -23,9 +23,9 @@ auxiliary-submitters:
   - Zhenfei Zhang
 implementations:
     - name: clean
-      version: https://github.com/jschanck/ntru/tree/6d1f44f5 reference implementation
+      version: https://github.com/jschanck/ntru/tree/60cc7277 reference implementation
     - name: avx2
-      version: https://github.com/jschanck/ntru/tree/6d1f44f5 avx2 implementation
+      version: https://github.com/jschanck/ntru/tree/60cc7277 avx2 implementation
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/ntruhps2048509/avx2/owcpa.h
+++ b/crypto_kem/ntruhps2048509/avx2/owcpa.h
@@ -4,12 +4,9 @@
 #include "params.h"
 #include "poly.h"
 
-void PQCLEAN_NTRUHPS2048509_AVX2_owcpa_samplemsg(unsigned char msg[NTRU_OWCPA_MSGBYTES],
-        const unsigned char seed[NTRU_SEEDBYTES]);
-
 void PQCLEAN_NTRUHPS2048509_AVX2_owcpa_keypair(unsigned char *pk,
         unsigned char *sk,
-        const unsigned char seed[NTRU_SEEDBYTES]);
+        const unsigned char seed[NTRU_SAMPLE_FG_BYTES]);
 
 void PQCLEAN_NTRUHPS2048509_AVX2_owcpa_enc(unsigned char *c,
         const poly *r,

--- a/crypto_kem/ntruhps2048509/avx2/poly.c
+++ b/crypto_kem/ntruhps2048509/avx2/poly.c
@@ -23,7 +23,15 @@ void PQCLEAN_NTRUHPS2048509_AVX2_poly_Sq_mul(poly *r, const poly *a, const poly 
 }
 
 void PQCLEAN_NTRUHPS2048509_AVX2_poly_S3_mul(poly *r, const poly *a, const poly *b) {
+    int i;
+
+    /* Our S3 multiplications do not overflow mod q,    */
+    /* so we can re-purpose PQCLEAN_NTRUHPS2048509_AVX2_poly_Rq_mul, as long as we  */
+    /* follow with an explicit reduction mod q.         */
     PQCLEAN_NTRUHPS2048509_AVX2_poly_Rq_mul(r, a, b);
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = MODQ(r->coeffs[i]);
+    }
     PQCLEAN_NTRUHPS2048509_AVX2_poly_mod_3_Phi_n(r);
 }
 

--- a/crypto_kem/ntruhps2048509/avx2/poly_rq_mul.s
+++ b/crypto_kem/ntruhps2048509/avx2/poly_rq_mul.s
@@ -253,23 +253,6 @@ mask_keephigh:
 .word 65535
 .word 65535
 .word 65535
-mask_mod2048:
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
 .text
 .global PQCLEAN_NTRUHPS2048509_AVX2_poly_Rq_mul
 .global _PQCLEAN_NTRUHPS2048509_AVX2_poly_Rq_mul
@@ -3597,13 +3580,9 @@ vpand mask_keephigh(%rip), %ymm9, %ymm10
 vpor %ymm10, %ymm5, %ymm5
 vpaddw %ymm5, %ymm3, %ymm3
 vmovdqa %xmm9, 2560(%rsp)
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 0(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 256(%rdi)
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqa %ymm3, 512(%rdi)
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqa %ymm4, 768(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -3693,13 +3672,9 @@ vpand mask_keephigh(%rip), %ymm7, %ymm8
 vpor %ymm8, %ymm11, %ymm11
 vpaddw %ymm11, %ymm10, %ymm10
 vmovdqa %xmm7, 2592(%rsp)
-vpand mask_mod2048(%rip), %ymm5, %ymm5
 vmovdqa %ymm5, 64(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 320(%rdi)
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqa %ymm10, 576(%rdi)
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqa %ymm9, 832(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm4
@@ -3789,13 +3764,9 @@ vpand mask_keephigh(%rip), %ymm3, %ymm4
 vpor %ymm4, %ymm5, %ymm5
 vpaddw %ymm5, %ymm8, %ymm8
 vmovdqa %xmm3, 2624(%rsp)
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 128(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 384(%rdi)
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqa %ymm8, 640(%rdi)
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqa %ymm7, 896(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -3885,13 +3856,9 @@ vpand mask_keephigh(%rip), %ymm10, %ymm9
 vpor %ymm9, %ymm11, %ymm11
 vpaddw %ymm11, %ymm4, %ymm4
 vmovdqa %xmm10, 2656(%rsp)
-vpand mask_mod2048(%rip), %ymm5, %ymm5
 vmovdqa %ymm5, 192(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 448(%rdi)
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqa %ymm4, 704(%rdi)
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqa %ymm3, 960(%rdi)
 vmovdqa 128(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm7
@@ -3971,7 +3938,6 @@ vpand mask_keephigh(%rip), %ymm2, %ymm7
 vpor %ymm7, %ymm10, %ymm10
 vmovdqa 0(%rdi), %ymm7
 vpaddw %ymm10, %ymm7, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqa %ymm7, 0(%rdi)
 vmovdqa %xmm2, 1920(%rsp)
 vpshufb shuf48_16(%rip), %ymm4, %ymm4
@@ -3998,11 +3964,8 @@ vpand mask_keephigh(%rip), %ymm2, %ymm7
 vpor %ymm7, %ymm5, %ymm5
 vpaddw %ymm5, %ymm9, %ymm9
 vmovdqa %xmm2, 2688(%rsp)
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 256(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 512(%rdi)
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqa %ymm9, 768(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -4082,7 +4045,6 @@ vpand mask_keephigh(%rip), %ymm8, %ymm3
 vpor %ymm3, %ymm2, %ymm2
 vmovdqa 64(%rdi), %ymm3
 vpaddw %ymm2, %ymm3, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqa %ymm3, 64(%rdi)
 vmovdqa %xmm8, 1952(%rsp)
 vpshufb shuf48_16(%rip), %ymm9, %ymm9
@@ -4109,11 +4071,8 @@ vpand mask_keephigh(%rip), %ymm8, %ymm3
 vpor %ymm3, %ymm11, %ymm11
 vpaddw %ymm11, %ymm7, %ymm7
 vmovdqa %xmm8, 2720(%rsp)
-vpand mask_mod2048(%rip), %ymm5, %ymm5
 vmovdqa %ymm5, 320(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 576(%rdi)
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqa %ymm7, 832(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm10
@@ -4193,7 +4152,6 @@ vpand mask_keephigh(%rip), %ymm4, %ymm10
 vpor %ymm10, %ymm8, %ymm8
 vmovdqa 128(%rdi), %ymm10
 vpaddw %ymm8, %ymm10, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqa %ymm10, 128(%rdi)
 vmovdqa %xmm4, 1984(%rsp)
 vpshufb shuf48_16(%rip), %ymm7, %ymm7
@@ -4220,11 +4178,8 @@ vpand mask_keephigh(%rip), %ymm4, %ymm10
 vpor %ymm10, %ymm5, %ymm5
 vpaddw %ymm5, %ymm3, %ymm3
 vmovdqa %xmm4, 2752(%rsp)
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 384(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 640(%rdi)
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqa %ymm3, 896(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm2
@@ -4304,7 +4259,6 @@ vpand mask_keephigh(%rip), %ymm9, %ymm2
 vpor %ymm2, %ymm4, %ymm4
 vmovdqa 192(%rdi), %ymm2
 vpaddw %ymm4, %ymm2, %ymm2
-vpand mask_mod2048(%rip), %ymm2, %ymm2
 vmovdqa %ymm2, 192(%rdi)
 vmovdqa %xmm9, 2016(%rsp)
 vpshufb shuf48_16(%rip), %ymm3, %ymm3
@@ -4331,11 +4285,8 @@ vpand mask_keephigh(%rip), %ymm9, %ymm2
 vpor %ymm2, %ymm11, %ymm11
 vpaddw %ymm11, %ymm10, %ymm10
 vmovdqa %xmm9, 2784(%rsp)
-vpand mask_mod2048(%rip), %ymm5, %ymm5
 vmovdqa %ymm5, 448(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 704(%rdi)
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqa %ymm10, 960(%rdi)
 vmovdqa 96(%r12), %ymm0
 vpsubw 160(%r12), %ymm0, %ymm0
@@ -4729,13 +4680,9 @@ vpor %ymm8, %ymm5, %ymm5
 vpaddw 2560(%rsp), %ymm2, %ymm2
 vpaddw %ymm5, %ymm2, %ymm2
 vmovdqa %xmm3, 2560(%rsp)
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 32(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 288(%rdi)
-vpand mask_mod2048(%rip), %ymm2, %ymm2
 vmovdqa %ymm2, 544(%rdi)
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqa %ymm9, 800(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm4
@@ -4828,13 +4775,9 @@ vpor %ymm4, %ymm11, %ymm11
 vpaddw 2592(%rsp), %ymm8, %ymm8
 vpaddw %ymm11, %ymm8, %ymm8
 vmovdqa %xmm10, 2592(%rsp)
-vpand mask_mod2048(%rip), %ymm5, %ymm5
 vmovdqa %ymm5, 96(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 352(%rdi)
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqa %ymm8, 608(%rdi)
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqa %ymm3, 864(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm9
@@ -4927,13 +4870,9 @@ vpor %ymm9, %ymm5, %ymm5
 vpaddw 2624(%rsp), %ymm4, %ymm4
 vpaddw %ymm5, %ymm4, %ymm4
 vmovdqa %xmm2, 2624(%rsp)
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 160(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 416(%rdi)
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqa %ymm4, 672(%rdi)
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqa %ymm10, 928(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -5026,22 +4965,18 @@ vpor %ymm3, %ymm11, %ymm11
 vpaddw 2656(%rsp), %ymm9, %ymm9
 vpaddw %ymm11, %ymm9, %ymm9
 vmovdqa %xmm8, 2656(%rsp)
-vpand mask_mod2048(%rip), %ymm5, %ymm5
 vmovdqa %ymm5, 224(%rdi)
 vextracti128 $1, %ymm5, %xmm5
 vpshufb shufmin5_mask3(%rip), %ymm5, %ymm5
 vmovdqa %xmm5, 1792(%rsp)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 480(%rdi)
 vextracti128 $1, %ymm6, %xmm6
 vpshufb shufmin5_mask3(%rip), %ymm6, %ymm6
 vmovdqa %xmm6, 1824(%rsp)
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqa %ymm9, 736(%rdi)
 vextracti128 $1, %ymm9, %xmm9
 vpshufb shufmin5_mask3(%rip), %ymm9, %ymm9
 vmovdqa %xmm9, 1856(%rsp)
-vpand mask_mod2048(%rip), %ymm2, %ymm2
 vmovdqa %ymm2, 992(%rdi)
 vextracti128 $1, %ymm2, %xmm2
 vpshufb shufmin5_mask3(%rip), %ymm2, %ymm2
@@ -5125,7 +5060,6 @@ vpor %ymm10, %ymm8, %ymm8
 vmovdqa 32(%rdi), %ymm10
 vpaddw 1920(%rsp), %ymm10, %ymm10
 vpaddw %ymm8, %ymm10, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqa %ymm10, 32(%rdi)
 vmovdqa %xmm7, 1920(%rsp)
 vpshufb shuf48_16(%rip), %ymm9, %ymm9
@@ -5155,11 +5089,8 @@ vpor %ymm10, %ymm5, %ymm5
 vpaddw 2688(%rsp), %ymm3, %ymm3
 vpaddw %ymm5, %ymm3, %ymm3
 vmovdqa %xmm7, 2688(%rsp)
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 288(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 544(%rdi)
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqa %ymm3, 800(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm2
@@ -5240,7 +5171,6 @@ vpor %ymm2, %ymm7, %ymm7
 vmovdqa 96(%rdi), %ymm2
 vpaddw 1952(%rsp), %ymm2, %ymm2
 vpaddw %ymm7, %ymm2, %ymm2
-vpand mask_mod2048(%rip), %ymm2, %ymm2
 vmovdqa %ymm2, 96(%rdi)
 vmovdqa %xmm4, 1952(%rsp)
 vpshufb shuf48_16(%rip), %ymm3, %ymm3
@@ -5270,11 +5200,8 @@ vpor %ymm2, %ymm11, %ymm11
 vpaddw 2720(%rsp), %ymm10, %ymm10
 vpaddw %ymm11, %ymm10, %ymm10
 vmovdqa %xmm4, 2720(%rsp)
-vpand mask_mod2048(%rip), %ymm5, %ymm5
 vmovdqa %ymm5, 352(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 608(%rdi)
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqa %ymm10, 864(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm8
@@ -5355,7 +5282,6 @@ vpor %ymm8, %ymm4, %ymm4
 vmovdqa 160(%rdi), %ymm8
 vpaddw 1984(%rsp), %ymm8, %ymm8
 vpaddw %ymm4, %ymm8, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqa %ymm8, 160(%rdi)
 vmovdqa %xmm9, 1984(%rsp)
 vpshufb shuf48_16(%rip), %ymm10, %ymm10
@@ -5385,11 +5311,8 @@ vpor %ymm8, %ymm5, %ymm5
 vpaddw 2752(%rsp), %ymm2, %ymm2
 vpaddw %ymm5, %ymm2, %ymm2
 vmovdqa %xmm9, 2752(%rsp)
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 416(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 672(%rdi)
-vpand mask_mod2048(%rip), %ymm2, %ymm2
 vmovdqa %ymm2, 928(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm7
@@ -5479,7 +5402,6 @@ vpor %ymm7, %ymm9, %ymm9
 vmovdqa 224(%rdi), %ymm7
 vpaddw 2016(%rsp), %ymm7, %ymm7
 vpaddw %ymm9, %ymm7, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqa %ymm7, 224(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vpshufb shufmin5_mask3(%rip), %ymm7, %ymm7
@@ -5512,113 +5434,86 @@ vpor %ymm7, %ymm11, %ymm11
 vpaddw 2784(%rsp), %ymm8, %ymm8
 vpaddw %ymm11, %ymm8, %ymm8
 vmovdqa %xmm3, 2784(%rsp)
-vpand mask_mod2048(%rip), %ymm5, %ymm5
 vmovdqa %ymm5, 480(%rdi)
-vpand mask_mod2048(%rip), %ymm6, %ymm6
 vmovdqa %ymm6, 736(%rdi)
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqa %ymm8, 992(%rdi)
 vmovdqa 0(%rdi), %ymm11
 vpaddw 1888(%rsp), %ymm11, %ymm11
 vpaddw 2816(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 0(%rdi)
 vmovdqa 256(%rdi), %ymm11
 vpaddw 2528(%rsp), %ymm11, %ymm11
 vpaddw 2848(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 256(%rdi)
 vmovdqa 512(%rdi), %ymm11
 vpaddw 2784(%rsp), %ymm11, %ymm11
 vpaddw 2880(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 512(%rdi)
 vmovdqa 64(%rdi), %ymm11
 vpaddw 2048(%rsp), %ymm11, %ymm11
 vpaddw 1920(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 64(%rdi)
 vmovdqa 320(%rdi), %ymm11
 vpaddw 2304(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 320(%rdi)
 vmovdqa 576(%rdi), %ymm11
 vpaddw 2560(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 576(%rdi)
 vmovdqa 128(%rdi), %ymm11
 vpaddw 2080(%rsp), %ymm11, %ymm11
 vpaddw 1952(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 128(%rdi)
 vmovdqa 384(%rdi), %ymm11
 vpaddw 2336(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 384(%rdi)
 vmovdqa 640(%rdi), %ymm11
 vpaddw 2592(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 640(%rdi)
 vmovdqa 192(%rdi), %ymm11
 vpaddw 2112(%rsp), %ymm11, %ymm11
 vpaddw 1984(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 192(%rdi)
 vmovdqa 448(%rdi), %ymm11
 vpaddw 2368(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 448(%rdi)
 vmovdqa 704(%rdi), %ymm11
 vpaddw 2624(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 704(%rdi)
 vmovdqa 256(%rdi), %ymm11
 vpaddw 2144(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 256(%rdi)
 vmovdqa 512(%rdi), %ymm11
 vpaddw 2400(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 512(%rdi)
 vmovdqa 768(%rdi), %ymm11
 vpaddw 2656(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 768(%rdi)
 vmovdqa 320(%rdi), %ymm11
 vpaddw 2176(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 320(%rdi)
 vmovdqa 576(%rdi), %ymm11
 vpaddw 2432(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 576(%rdi)
 vmovdqa 832(%rdi), %ymm11
 vpaddw 2688(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 832(%rdi)
 vmovdqa 384(%rdi), %ymm11
 vpaddw 2208(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 384(%rdi)
 vmovdqa 640(%rdi), %ymm11
 vpaddw 2464(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 640(%rdi)
 vmovdqa 896(%rdi), %ymm11
 vpaddw 2720(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 896(%rdi)
 vmovdqa 448(%rdi), %ymm11
 vpaddw 2240(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 448(%rdi)
 vmovdqa 704(%rdi), %ymm11
 vpaddw 2496(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 704(%rdi)
 vmovdqa 960(%rdi), %ymm11
 vpaddw 2752(%rsp), %ymm11, %ymm11
-vpand mask_mod2048(%rip), %ymm11, %ymm11
 vmovdqa %ymm11, 960(%rdi)
 mov %r8, %rsp
 pop %r12

--- a/crypto_kem/ntruhps2048509/clean/owcpa.h
+++ b/crypto_kem/ntruhps2048509/clean/owcpa.h
@@ -4,12 +4,9 @@
 #include "params.h"
 #include "poly.h"
 
-void PQCLEAN_NTRUHPS2048509_CLEAN_owcpa_samplemsg(unsigned char msg[NTRU_OWCPA_MSGBYTES],
-        const unsigned char seed[NTRU_SEEDBYTES]);
-
 void PQCLEAN_NTRUHPS2048509_CLEAN_owcpa_keypair(unsigned char *pk,
         unsigned char *sk,
-        const unsigned char seed[NTRU_SEEDBYTES]);
+        const unsigned char seed[NTRU_SAMPLE_FG_BYTES]);
 
 void PQCLEAN_NTRUHPS2048509_CLEAN_owcpa_enc(unsigned char *c,
         const poly *r,

--- a/crypto_kem/ntruhps2048509/clean/poly.c
+++ b/crypto_kem/ntruhps2048509/clean/poly.c
@@ -23,7 +23,15 @@ void PQCLEAN_NTRUHPS2048509_CLEAN_poly_Sq_mul(poly *r, const poly *a, const poly
 }
 
 void PQCLEAN_NTRUHPS2048509_CLEAN_poly_S3_mul(poly *r, const poly *a, const poly *b) {
+    int i;
+
+    /* Our S3 multiplications do not overflow mod q,    */
+    /* so we can re-purpose PQCLEAN_NTRUHPS2048509_CLEAN_poly_Rq_mul, as long as we  */
+    /* follow with an explicit reduction mod q.         */
     PQCLEAN_NTRUHPS2048509_CLEAN_poly_Rq_mul(r, a, b);
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = MODQ(r->coeffs[i]);
+    }
     PQCLEAN_NTRUHPS2048509_CLEAN_poly_mod_3_Phi_n(r);
 }
 

--- a/crypto_kem/ntruhps2048509/clean/poly_rq_mul.c
+++ b/crypto_kem/ntruhps2048509/clean/poly_rq_mul.c
@@ -1,15 +1,284 @@
 #include "poly.h"
 
-void PQCLEAN_NTRUHPS2048509_CLEAN_poly_Rq_mul(poly *r, const poly *a, const poly *b) {
-    int k, i;
+/* Polynomial multiplication using     */
+/* Toom-4 and two layers of Karatsuba. */
 
-    for (k = 0; k < NTRU_N; k++) {
-        r->coeffs[k] = 0;
-        for (i = 1; i < NTRU_N - k; i++) {
-            r->coeffs[k] += a->coeffs[k + i] * b->coeffs[NTRU_N - i];
-        }
-        for (i = 0; i < k + 1; i++) {
-            r->coeffs[k] += a->coeffs[k - i] * b->coeffs[i];
-        }
+#define L PAD32(NTRU_N)
+#define M (L/4)
+#define K (L/16)
+
+static void toom4_k2x2_mul(uint16_t ab[2 * L], const uint16_t a[L], const uint16_t b[L]);
+
+static void toom4_k2x2_eval_0(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p1(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_m1(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p2(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_m2(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p3(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_inf(uint16_t r[9 * K], const uint16_t a[M]);
+static inline void k2x2_eval(uint16_t r[9 * K]);
+
+static void toom4_k2x2_basemul(uint16_t r[18 * K], const uint16_t a[9 * K], const uint16_t b[9 * K]);
+static inline void schoolbook_KxK(uint16_t r[2 * K], const uint16_t a[K], const uint16_t b[K]);
+
+static void toom4_k2x2_interpolate(uint16_t r[2 * M], const uint16_t a[63 * 2 * K]);
+static inline void k2x2_interpolate(uint16_t r[M], const uint16_t a[9 * K]);
+
+void PQCLEAN_NTRUHPS2048509_CLEAN_poly_Rq_mul(poly *r, const poly *a, const poly *b) {
+    size_t i;
+    uint16_t ab[2 * L];
+
+    for (i = 0; i < NTRU_N; i++) {
+        ab[i] = a->coeffs[i];
+        ab[L + i] = b->coeffs[i];
+    }
+    for (i = NTRU_N; i < L; i++) {
+        ab[i] = 0;
+        ab[L + i] = 0;
+    }
+
+    toom4_k2x2_mul(ab, ab, ab + L);
+
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = ab[i] + ab[NTRU_N + i];
     }
 }
+
+static void toom4_k2x2_mul(uint16_t ab[2 * L], const uint16_t a[L], const uint16_t b[L]) {
+    uint16_t tmpA[9 * K];
+    uint16_t tmpB[9 * K];
+    uint16_t eC[63 * 2 * K];
+
+    toom4_k2x2_eval_0(tmpA, a);
+    toom4_k2x2_eval_0(tmpB, b);
+    toom4_k2x2_basemul(eC + 0 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p1(tmpA, a);
+    toom4_k2x2_eval_p1(tmpB, b);
+    toom4_k2x2_basemul(eC + 1 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_m1(tmpA, a);
+    toom4_k2x2_eval_m1(tmpB, b);
+    toom4_k2x2_basemul(eC + 2 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p2(tmpA, a);
+    toom4_k2x2_eval_p2(tmpB, b);
+    toom4_k2x2_basemul(eC + 3 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_m2(tmpA, a);
+    toom4_k2x2_eval_m2(tmpB, b);
+    toom4_k2x2_basemul(eC + 4 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p3(tmpA, a);
+    toom4_k2x2_eval_p3(tmpB, b);
+    toom4_k2x2_basemul(eC + 5 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_inf(tmpA, a);
+    toom4_k2x2_eval_inf(tmpB, b);
+    toom4_k2x2_basemul(eC + 6 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_interpolate(ab, eC);
+}
+
+
+static void toom4_k2x2_eval_0(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i] = a[i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p1(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += a[1 * M + i];
+        r[i] += a[2 * M + i];
+        r[i] += a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_m1(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] -= a[1 * M + i];
+        r[i] += a[2 * M + i];
+        r[i] -= a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p2(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += 2 * a[1 * M + i];
+        r[i] += 4 * a[2 * M + i];
+        r[i] += 8 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_m2(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] -= 2 * a[1 * M + i];
+        r[i] += 4 * a[2 * M + i];
+        r[i] -= 8 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p3(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += 3 * a[1 * M + i];
+        r[i] += 9 * a[2 * M + i];
+        r[i] += 27 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_inf(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i] = a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static inline void k2x2_eval(uint16_t r[9 * K]) {
+    /* Input:  e + f.Y + g.Y^2 + h.Y^3                              */
+    /* Output: [ e | f | g | h | e+f | f+h | g+e | h+g | e+f+g+h ]  */
+
+    size_t i;
+    for (i = 0; i < 4 * K; i++) {
+        r[4 * K + i] = r[i];
+    }
+    for (i = 0; i < K; i++) {
+        r[4 * K + i] += r[1 * K + i];
+        r[5 * K + i] += r[3 * K + i];
+        r[6 * K + i] += r[0 * K + i];
+        r[7 * K + i] += r[2 * K + i];
+        r[8 * K + i] = r[5 * K + i];
+        r[8 * K + i] += r[6 * K + i];
+    }
+}
+
+static void toom4_k2x2_basemul(uint16_t r[18 * K], const uint16_t a[9 * K], const uint16_t b[9 * K]) {
+    schoolbook_KxK(r + 0 * 2 * K, a + 0 * K, b + 0 * K);
+    schoolbook_KxK(r + 1 * 2 * K, a + 1 * K, b + 1 * K);
+    schoolbook_KxK(r + 2 * 2 * K, a + 2 * K, b + 2 * K);
+    schoolbook_KxK(r + 3 * 2 * K, a + 3 * K, b + 3 * K);
+    schoolbook_KxK(r + 4 * 2 * K, a + 4 * K, b + 4 * K);
+    schoolbook_KxK(r + 5 * 2 * K, a + 5 * K, b + 5 * K);
+    schoolbook_KxK(r + 6 * 2 * K, a + 6 * K, b + 6 * K);
+    schoolbook_KxK(r + 7 * 2 * K, a + 7 * K, b + 7 * K);
+    schoolbook_KxK(r + 8 * 2 * K, a + 8 * K, b + 8 * K);
+}
+
+static inline void schoolbook_KxK(uint16_t r[2 * K], const uint16_t a[K], const uint16_t b[K]) {
+    size_t i, j;
+    for (j = 0; j < K; j++) {
+        r[j] = a[0] * b[j];
+    }
+    for (i = 1; i < K; i++) {
+        for (j = 0; j < K - 1; j++) {
+            r[i + j] += a[i] * b[j];
+        }
+        r[i + K - 1] = a[i] * b[K - 1];
+    }
+    r[2 * K - 1] = 0;
+}
+
+static void toom4_k2x2_interpolate(uint16_t r[2 * M], const uint16_t a[7 * 18 * K]) {
+    size_t i;
+
+    uint16_t P1[2 * M];
+    uint16_t Pm1[2 * M];
+    uint16_t P2[2 * M];
+    uint16_t Pm2[2 * M];
+
+    uint16_t *C0 = r;
+    uint16_t *C2 = r + 2 * M;
+    uint16_t *C4 = r + 4 * M;
+    uint16_t *C6 = r + 6 * M;
+
+    uint16_t V0, V1, V2;
+
+    k2x2_interpolate(C0, a + 0 * 9 * 2 * K);
+    k2x2_interpolate(P1, a + 1 * 9 * 2 * K);
+    k2x2_interpolate(Pm1, a + 2 * 9 * 2 * K);
+    k2x2_interpolate(P2, a + 3 * 9 * 2 * K);
+    k2x2_interpolate(Pm2, a + 4 * 9 * 2 * K);
+    k2x2_interpolate(C6, a + 6 * 9 * 2 * K);
+
+    for (i = 0; i < 2 * M; i++) {
+        V0 = ((uint32_t)(P1[i] + Pm1[i])) >> 1;
+        V0 = V0 - C0[i] - C6[i];
+        V1 = ((uint32_t)(P2[i] + Pm2[i] - 2 * C0[i] - 128 * C6[i])) >> 3;
+        C4[i] = 43691 * (V1 - V0);
+        C2[i] = V0 - C4[i];
+        P1[i] = ((uint32_t)(P1[i] - Pm1[i])) >> 1;
+    }
+
+    /* reuse Pm1 for P3 */
+#define P3 Pm1
+    k2x2_interpolate(P3, a + 5 * 9 * 2 * K);
+
+    for (i = 0; i < 2 * M; i++) {
+        V0 = P1[i];
+        V1 = 43691 * ((((uint32_t)(P2[i] - Pm2[i])) >> 2) - V0);
+        V2 = 43691 * (P3[i] - C0[i] - 9 * (C2[i] + 9 * (C4[i] + 9 * C6[i])));
+        V2 = ((uint32_t)(V2 - V0)) >> 3;
+        V2 -= V1;
+        P3[i] = 52429 * V2;
+        P2[i] = V1 - V2;
+        P1[i] = V0 - P2[i] - P3[i];
+    }
+
+    for (i = 0; i < 2 * M; i++) {
+        r[1 * M + i] += P1[i];
+        r[3 * M + i] += P2[i];
+        r[5 * M + i] += P3[i];
+    }
+}
+
+static inline void k2x2_interpolate(uint16_t r[M], const uint16_t a[9 * K]) {
+    size_t i;
+    uint16_t tmp[4 * K];
+
+    for (i = 0; i < 2 * K; i++) {
+        r[0 * K + i] = a[0 * K + i];
+        r[2 * K + i] = a[2 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[1 * K + i] += a[8 * K + i] - a[0 * K + i] - a[2 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[4 * K + i] = a[4 * K + i];
+        r[6 * K + i] = a[6 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[5 * K + i] += a[14 * K + i] - a[4 * K + i] - a[6 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        tmp[0 * K + i] = a[12 * K + i];
+        tmp[2 * K + i] = a[10 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        tmp[K + i] += a[16 * K + i] - a[12 * K + i] - a[10 * K + i];
+    }
+
+    for (i = 0; i < 4 * K; i++) {
+        tmp[0 * K + i] = tmp[0 * K + i] - r[0 * K + i] - r[4 * K + i];
+    }
+
+    for (i = 0; i < 4 * K; i++) {
+        r[2 * K + i] += tmp[0 * K + i];
+    }
+}
+

--- a/crypto_kem/ntruhps2048677/META.yml
+++ b/crypto_kem/ntruhps2048677/META.yml
@@ -23,9 +23,9 @@ auxiliary-submitters:
   - Zhenfei Zhang
 implementations:
     - name: clean
-      version: https://github.com/jschanck/ntru/tree/6d1f44f5 reference implementation
+      version: https://github.com/jschanck/ntru/tree/60cc7277 reference implementation
     - name: avx2
-      version: https://github.com/jschanck/ntru/tree/6d1f44f5 avx2 implementation
+      version: https://github.com/jschanck/ntru/tree/60cc7277 avx2 implementation
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/ntruhps2048677/avx2/owcpa.h
+++ b/crypto_kem/ntruhps2048677/avx2/owcpa.h
@@ -4,12 +4,9 @@
 #include "params.h"
 #include "poly.h"
 
-void PQCLEAN_NTRUHPS2048677_AVX2_owcpa_samplemsg(unsigned char msg[NTRU_OWCPA_MSGBYTES],
-        const unsigned char seed[NTRU_SEEDBYTES]);
-
 void PQCLEAN_NTRUHPS2048677_AVX2_owcpa_keypair(unsigned char *pk,
         unsigned char *sk,
-        const unsigned char seed[NTRU_SEEDBYTES]);
+        const unsigned char seed[NTRU_SAMPLE_FG_BYTES]);
 
 void PQCLEAN_NTRUHPS2048677_AVX2_owcpa_enc(unsigned char *c,
         const poly *r,

--- a/crypto_kem/ntruhps2048677/avx2/poly.c
+++ b/crypto_kem/ntruhps2048677/avx2/poly.c
@@ -23,7 +23,15 @@ void PQCLEAN_NTRUHPS2048677_AVX2_poly_Sq_mul(poly *r, const poly *a, const poly 
 }
 
 void PQCLEAN_NTRUHPS2048677_AVX2_poly_S3_mul(poly *r, const poly *a, const poly *b) {
+    int i;
+
+    /* Our S3 multiplications do not overflow mod q,    */
+    /* so we can re-purpose PQCLEAN_NTRUHPS2048677_AVX2_poly_Rq_mul, as long as we  */
+    /* follow with an explicit reduction mod q.         */
     PQCLEAN_NTRUHPS2048677_AVX2_poly_Rq_mul(r, a, b);
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = MODQ(r->coeffs[i]);
+    }
     PQCLEAN_NTRUHPS2048677_AVX2_poly_mod_3_Phi_n(r);
 }
 

--- a/crypto_kem/ntruhps2048677/avx2/poly_rq_mul.s
+++ b/crypto_kem/ntruhps2048677/avx2/poly_rq_mul.s
@@ -237,23 +237,6 @@ mask_15_1:
 .word 65535
 .word 65535
 .word 0
-mask_mod2048:
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
-.word 2047
 .text
 .global PQCLEAN_NTRUHPS2048677_AVX2_poly_Rq_mul
 .global _PQCLEAN_NTRUHPS2048677_AVX2_poly_Rq_mul
@@ -5139,31 +5122,24 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 0(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 0(%rdi)
 vmovdqu 352(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 352(%rdi)
 vmovdqu 704(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 704(%rdi)
 vmovdqu 1056(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1056(%rdi)
 vmovdqu 54(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 54(%rdi)
 vmovdqu 406(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 406(%rdi)
 vmovdqu 758(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 758(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -5231,31 +5207,24 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 88(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 88(%rdi)
 vmovdqu 440(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 440(%rdi)
 vmovdqu 792(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 792(%rdi)
 vmovdqu 1144(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1144(%rdi)
 vmovdqu 142(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 142(%rdi)
 vmovdqu 494(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 494(%rdi)
 vmovdqu 846(%rdi), %ymm7
 vpaddw %ymm7, %ymm11, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 846(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm4
@@ -5323,31 +5292,24 @@ vpmullw %ymm13, %ymm9, %ymm9
 vpsubw %ymm9, %ymm6, %ymm6
 vmovdqu 176(%rdi), %ymm3
 vpaddw %ymm3, %ymm11, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 176(%rdi)
 vmovdqu 528(%rdi), %ymm3
 vpaddw %ymm3, %ymm6, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 528(%rdi)
 vmovdqu 880(%rdi), %ymm3
 vpaddw %ymm3, %ymm8, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 880(%rdi)
 vmovdqu 1232(%rdi), %ymm3
 vpaddw %ymm3, %ymm7, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1232(%rdi)
 vmovdqu 230(%rdi), %ymm3
 vpaddw %ymm3, %ymm10, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 230(%rdi)
 vmovdqu 582(%rdi), %ymm3
 vpaddw %ymm3, %ymm9, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 582(%rdi)
 vmovdqu 934(%rdi), %ymm3
 vpaddw %ymm3, %ymm5, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 934(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -5415,31 +5377,24 @@ vpmullw %ymm13, %ymm7, %ymm7
 vpsubw %ymm7, %ymm6, %ymm6
 vmovdqu 264(%rdi), %ymm10
 vpaddw %ymm10, %ymm5, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 264(%rdi)
 vmovdqu 616(%rdi), %ymm10
 vpaddw %ymm10, %ymm6, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 616(%rdi)
 vmovdqu 968(%rdi), %ymm10
 vpaddw %ymm10, %ymm4, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 968(%rdi)
 vmovdqu 1320(%rdi), %ymm10
 vpaddw %ymm10, %ymm3, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1320(%rdi)
 vmovdqu 318(%rdi), %ymm10
 vpaddw %ymm10, %ymm8, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 318(%rdi)
 vmovdqu 670(%rdi), %ymm10
 vpaddw %ymm10, %ymm7, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 670(%rdi)
 vmovdqu 1022(%rdi), %ymm10
 vpaddw %ymm10, %ymm11, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1022(%rdi)
 vmovdqa 128(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm7
@@ -5507,31 +5462,24 @@ vpmullw %ymm13, %ymm3, %ymm3
 vpsubw %ymm3, %ymm6, %ymm6
 vmovdqu 352(%rdi), %ymm8
 vpaddw %ymm8, %ymm11, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 352(%rdi)
 vmovdqu 704(%rdi), %ymm8
 vpaddw %ymm8, %ymm6, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 704(%rdi)
 vmovdqu 1056(%rdi), %ymm8
 vpaddw %ymm8, %ymm9, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1056(%rdi)
 vmovdqu 54(%rdi), %ymm8
 vpaddw %ymm8, %ymm10, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 54(%rdi)
 vmovdqu 406(%rdi), %ymm8
 vpaddw %ymm8, %ymm4, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 406(%rdi)
 vmovdqu 758(%rdi), %ymm8
 vpaddw %ymm8, %ymm3, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 758(%rdi)
 vmovdqu 1110(%rdi), %ymm8
 vpaddw %ymm8, %ymm5, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1110(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -5599,31 +5547,24 @@ vpmullw %ymm13, %ymm10, %ymm10
 vpsubw %ymm10, %ymm6, %ymm6
 vmovdqu 440(%rdi), %ymm4
 vpaddw %ymm4, %ymm5, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 440(%rdi)
 vmovdqu 792(%rdi), %ymm4
 vpaddw %ymm4, %ymm6, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 792(%rdi)
 vmovdqu 1144(%rdi), %ymm4
 vpaddw %ymm4, %ymm7, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1144(%rdi)
 vmovdqu 142(%rdi), %ymm4
 vpaddw %ymm4, %ymm8, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 142(%rdi)
 vmovdqu 494(%rdi), %ymm4
 vpaddw %ymm4, %ymm9, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 494(%rdi)
 vmovdqu 846(%rdi), %ymm4
 vpaddw %ymm4, %ymm10, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 846(%rdi)
 vmovdqu 1198(%rdi), %ymm4
 vpaddw %ymm4, %ymm11, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1198(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm10
@@ -5691,31 +5632,24 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 528(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 528(%rdi)
 vmovdqu 880(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 880(%rdi)
 vmovdqu 1232(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1232(%rdi)
 vmovdqu 230(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 230(%rdi)
 vmovdqu 582(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 582(%rdi)
 vmovdqu 934(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 934(%rdi)
 vmovdqu 1286(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1286(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -5783,31 +5717,24 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 616(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 616(%rdi)
 vmovdqu 968(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 968(%rdi)
 vmovdqu 1320(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1320(%rdi)
 vmovdqu 318(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 318(%rdi)
 vmovdqu 670(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 670(%rdi)
 vmovdqu 1022(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1022(%rdi)
 vmovdqu 1374(%rdi), %ymm7
 vpaddw %ymm7, %ymm11, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1374(%rdi)
 vmovdqa 128(%r12), %ymm0
 vpsubw 224(%r12), %ymm0, %ymm0
@@ -6176,31 +6103,24 @@ vpmullw %ymm13, %ymm9, %ymm9
 vpsubw %ymm9, %ymm6, %ymm6
 vmovdqu 32(%rdi), %ymm3
 vpaddw %ymm3, %ymm11, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 32(%rdi)
 vmovdqu 384(%rdi), %ymm3
 vpaddw %ymm3, %ymm6, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 384(%rdi)
 vmovdqu 736(%rdi), %ymm3
 vpaddw %ymm3, %ymm8, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 736(%rdi)
 vmovdqu 1088(%rdi), %ymm3
 vpaddw %ymm3, %ymm7, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1088(%rdi)
 vmovdqu 86(%rdi), %ymm3
 vpaddw %ymm3, %ymm10, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 86(%rdi)
 vmovdqu 438(%rdi), %ymm3
 vpaddw %ymm3, %ymm9, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 438(%rdi)
 vmovdqu 790(%rdi), %ymm3
 vpaddw %ymm3, %ymm5, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 790(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -6268,31 +6188,24 @@ vpmullw %ymm13, %ymm7, %ymm7
 vpsubw %ymm7, %ymm6, %ymm6
 vmovdqu 120(%rdi), %ymm10
 vpaddw %ymm10, %ymm5, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 120(%rdi)
 vmovdqu 472(%rdi), %ymm10
 vpaddw %ymm10, %ymm6, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 472(%rdi)
 vmovdqu 824(%rdi), %ymm10
 vpaddw %ymm10, %ymm4, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 824(%rdi)
 vmovdqu 1176(%rdi), %ymm10
 vpaddw %ymm10, %ymm3, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1176(%rdi)
 vmovdqu 174(%rdi), %ymm10
 vpaddw %ymm10, %ymm8, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 174(%rdi)
 vmovdqu 526(%rdi), %ymm10
 vpaddw %ymm10, %ymm7, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 526(%rdi)
 vmovdqu 878(%rdi), %ymm10
 vpaddw %ymm10, %ymm11, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 878(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm7
@@ -6360,31 +6273,24 @@ vpmullw %ymm13, %ymm3, %ymm3
 vpsubw %ymm3, %ymm6, %ymm6
 vmovdqu 208(%rdi), %ymm8
 vpaddw %ymm8, %ymm11, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 208(%rdi)
 vmovdqu 560(%rdi), %ymm8
 vpaddw %ymm8, %ymm6, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 560(%rdi)
 vmovdqu 912(%rdi), %ymm8
 vpaddw %ymm8, %ymm9, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 912(%rdi)
 vmovdqu 1264(%rdi), %ymm8
 vpaddw %ymm8, %ymm10, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1264(%rdi)
 vmovdqu 262(%rdi), %ymm8
 vpaddw %ymm8, %ymm4, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 262(%rdi)
 vmovdqu 614(%rdi), %ymm8
 vpaddw %ymm8, %ymm3, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 614(%rdi)
 vmovdqu 966(%rdi), %ymm8
 vpaddw %ymm8, %ymm5, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 966(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -6452,20 +6358,16 @@ vpmullw %ymm13, %ymm10, %ymm10
 vpsubw %ymm10, %ymm6, %ymm6
 vmovdqu 296(%rdi), %ymm4
 vpaddw %ymm4, %ymm5, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 296(%rdi)
 vmovdqu 648(%rdi), %ymm4
 vpaddw %ymm4, %ymm6, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 648(%rdi)
 vmovdqu 1000(%rdi), %ymm4
 vpaddw %ymm4, %ymm7, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1000(%rdi)
 vmovdqu 1352(%rdi), %ymm4
 vpand mask_1_15(%rip), %ymm8, %ymm3
 vpaddw %ymm4, %ymm3, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1352(%rdi)
 vpshufb rol_rol_16(%rip), %ymm8, %ymm8
 vpermq $216, %ymm8, %ymm8
@@ -6474,19 +6376,15 @@ vpermq $216, %ymm8, %ymm8
 vpand mask_15_1(%rip), %ymm8, %ymm8
 vmovdqu 0(%rdi), %ymm4
 vpaddw %ymm4, %ymm8, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 0(%rdi)
 vmovdqu 350(%rdi), %ymm4
 vpaddw %ymm4, %ymm9, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 350(%rdi)
 vmovdqu 702(%rdi), %ymm4
 vpaddw %ymm4, %ymm10, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 702(%rdi)
 vmovdqu 1054(%rdi), %ymm4
 vpaddw %ymm4, %ymm11, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1054(%rdi)
 vmovdqa 128(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm10
@@ -6554,31 +6452,24 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 384(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 384(%rdi)
 vmovdqu 736(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 736(%rdi)
 vmovdqu 1088(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1088(%rdi)
 vmovdqu 86(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 86(%rdi)
 vmovdqu 438(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 438(%rdi)
 vmovdqu 790(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 790(%rdi)
 vmovdqu 1142(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1142(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -6646,31 +6537,24 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 472(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 472(%rdi)
 vmovdqu 824(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 824(%rdi)
 vmovdqu 1176(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1176(%rdi)
 vmovdqu 174(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 174(%rdi)
 vmovdqu 526(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 526(%rdi)
 vmovdqu 878(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 878(%rdi)
 vmovdqu 1230(%rdi), %ymm7
 vpaddw %ymm7, %ymm11, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1230(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm4
@@ -6738,31 +6622,24 @@ vpmullw %ymm13, %ymm9, %ymm9
 vpsubw %ymm9, %ymm6, %ymm6
 vmovdqu 560(%rdi), %ymm3
 vpaddw %ymm3, %ymm11, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 560(%rdi)
 vmovdqu 912(%rdi), %ymm3
 vpaddw %ymm3, %ymm6, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 912(%rdi)
 vmovdqu 1264(%rdi), %ymm3
 vpaddw %ymm3, %ymm8, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1264(%rdi)
 vmovdqu 262(%rdi), %ymm3
 vpaddw %ymm3, %ymm7, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 262(%rdi)
 vmovdqu 614(%rdi), %ymm3
 vpaddw %ymm3, %ymm10, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 614(%rdi)
 vmovdqu 966(%rdi), %ymm3
 vpaddw %ymm3, %ymm9, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 966(%rdi)
 vmovdqu 1318(%rdi), %ymm3
 vpaddw %ymm3, %ymm5, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1318(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -6830,16 +6707,13 @@ vpmullw %ymm13, %ymm7, %ymm7
 vpsubw %ymm7, %ymm6, %ymm6
 vmovdqu 648(%rdi), %ymm10
 vpaddw %ymm10, %ymm5, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 648(%rdi)
 vmovdqu 1000(%rdi), %ymm10
 vpaddw %ymm10, %ymm6, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1000(%rdi)
 vmovdqu 1352(%rdi), %ymm10
 vpand mask_1_15(%rip), %ymm4, %ymm9
 vpaddw %ymm10, %ymm9, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1352(%rdi)
 vpshufb rol_rol_16(%rip), %ymm4, %ymm4
 vpermq $216, %ymm4, %ymm4
@@ -6848,19 +6722,15 @@ vpermq $216, %ymm4, %ymm4
 vpand mask_15_1(%rip), %ymm4, %ymm4
 vmovdqu 0(%rdi), %ymm10
 vpaddw %ymm10, %ymm4, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 0(%rdi)
 vmovdqu 350(%rdi), %ymm10
 vpaddw %ymm10, %ymm3, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 350(%rdi)
 vmovdqu 702(%rdi), %ymm10
 vpaddw %ymm10, %ymm8, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 702(%rdi)
 vmovdqu 1054(%rdi), %ymm10
 vpaddw %ymm10, %ymm7, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1054(%rdi)
 vmovdqa 160(%r12), %ymm0
 vpsubw 256(%r12), %ymm0, %ymm0
@@ -7229,43 +7099,36 @@ vpmullw %ymm13, %ymm3, %ymm3
 vpsubw %ymm3, %ymm6, %ymm6
 vmovdqu 64(%rdi), %ymm8
 vpaddw %ymm8, %ymm11, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 64(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 80(%rdi)
 vmovdqu 416(%rdi), %ymm8
 vpaddw %ymm8, %ymm6, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 416(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 432(%rdi)
 vmovdqu 768(%rdi), %ymm8
 vpaddw %ymm8, %ymm9, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 768(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 784(%rdi)
 vmovdqu 1120(%rdi), %ymm8
 vpaddw %ymm8, %ymm10, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 1120(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 1136(%rdi)
 vmovdqu 118(%rdi), %ymm8
 vpaddw %ymm8, %ymm4, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 118(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 134(%rdi)
 vmovdqu 470(%rdi), %ymm8
 vpaddw %ymm8, %ymm3, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 470(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 486(%rdi)
 vmovdqu 822(%rdi), %ymm8
 vpaddw %ymm8, %ymm5, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 822(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 838(%rdi)
@@ -7335,43 +7198,36 @@ vpmullw %ymm13, %ymm10, %ymm10
 vpsubw %ymm10, %ymm6, %ymm6
 vmovdqu 152(%rdi), %ymm4
 vpaddw %ymm4, %ymm5, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 152(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 168(%rdi)
 vmovdqu 504(%rdi), %ymm4
 vpaddw %ymm4, %ymm6, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 504(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 520(%rdi)
 vmovdqu 856(%rdi), %ymm4
 vpaddw %ymm4, %ymm7, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 856(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 872(%rdi)
 vmovdqu 1208(%rdi), %ymm4
 vpaddw %ymm4, %ymm8, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 1208(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 1224(%rdi)
 vmovdqu 206(%rdi), %ymm4
 vpaddw %ymm4, %ymm9, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 206(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 222(%rdi)
 vmovdqu 558(%rdi), %ymm4
 vpaddw %ymm4, %ymm10, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 558(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 574(%rdi)
 vmovdqu 910(%rdi), %ymm4
 vpaddw %ymm4, %ymm11, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 910(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 926(%rdi)
@@ -7441,43 +7297,36 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 240(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %xmm9, 240(%rdi)
 vextracti128 $1, %ymm9, %xmm9
 vmovq %xmm9, 256(%rdi)
 vmovdqu 592(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %xmm9, 592(%rdi)
 vextracti128 $1, %ymm9, %xmm9
 vmovq %xmm9, 608(%rdi)
 vmovdqu 944(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %xmm9, 944(%rdi)
 vextracti128 $1, %ymm9, %xmm9
 vmovq %xmm9, 960(%rdi)
 vmovdqu 1296(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %xmm9, 1296(%rdi)
 vextracti128 $1, %ymm9, %xmm9
 vmovq %xmm9, 1312(%rdi)
 vmovdqu 294(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %xmm9, 294(%rdi)
 vextracti128 $1, %ymm9, %xmm9
 vmovq %xmm9, 310(%rdi)
 vmovdqu 646(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %xmm9, 646(%rdi)
 vextracti128 $1, %ymm9, %xmm9
 vmovq %xmm9, 662(%rdi)
 vmovdqu 998(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod2048(%rip), %ymm9, %ymm9
 vmovdqu %xmm9, 998(%rdi)
 vextracti128 $1, %ymm9, %xmm9
 vmovq %xmm9, 1014(%rdi)
@@ -7547,43 +7396,36 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 328(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 328(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 344(%rdi)
 vmovdqu 680(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 680(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 696(%rdi)
 vmovdqu 1032(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 1032(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 1048(%rdi)
 vmovdqu 30(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 30(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 46(%rdi)
 vmovdqu 382(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 382(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 398(%rdi)
 vmovdqu 734(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 734(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 750(%rdi)
 vmovdqu 1086(%rdi), %ymm7
 vpaddw %ymm7, %ymm11, %ymm7
-vpand mask_mod2048(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 1086(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 1102(%rdi)
@@ -7653,43 +7495,36 @@ vpmullw %ymm13, %ymm9, %ymm9
 vpsubw %ymm9, %ymm6, %ymm6
 vmovdqu 416(%rdi), %ymm3
 vpaddw %ymm3, %ymm11, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %xmm3, 416(%rdi)
 vextracti128 $1, %ymm3, %xmm3
 vmovq %xmm3, 432(%rdi)
 vmovdqu 768(%rdi), %ymm3
 vpaddw %ymm3, %ymm6, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %xmm3, 768(%rdi)
 vextracti128 $1, %ymm3, %xmm3
 vmovq %xmm3, 784(%rdi)
 vmovdqu 1120(%rdi), %ymm3
 vpaddw %ymm3, %ymm8, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %xmm3, 1120(%rdi)
 vextracti128 $1, %ymm3, %xmm3
 vmovq %xmm3, 1136(%rdi)
 vmovdqu 118(%rdi), %ymm3
 vpaddw %ymm3, %ymm7, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %xmm3, 118(%rdi)
 vextracti128 $1, %ymm3, %xmm3
 vmovq %xmm3, 134(%rdi)
 vmovdqu 470(%rdi), %ymm3
 vpaddw %ymm3, %ymm10, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %xmm3, 470(%rdi)
 vextracti128 $1, %ymm3, %xmm3
 vmovq %xmm3, 486(%rdi)
 vmovdqu 822(%rdi), %ymm3
 vpaddw %ymm3, %ymm9, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %xmm3, 822(%rdi)
 vextracti128 $1, %ymm3, %xmm3
 vmovq %xmm3, 838(%rdi)
 vmovdqu 1174(%rdi), %ymm3
 vpaddw %ymm3, %ymm5, %ymm3
-vpand mask_mod2048(%rip), %ymm3, %ymm3
 vmovdqu %xmm3, 1174(%rdi)
 vextracti128 $1, %ymm3, %xmm3
 vmovq %xmm3, 1190(%rdi)
@@ -7759,43 +7594,36 @@ vpmullw %ymm13, %ymm7, %ymm7
 vpsubw %ymm7, %ymm6, %ymm6
 vmovdqu 504(%rdi), %ymm10
 vpaddw %ymm10, %ymm5, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %xmm10, 504(%rdi)
 vextracti128 $1, %ymm10, %xmm10
 vmovq %xmm10, 520(%rdi)
 vmovdqu 856(%rdi), %ymm10
 vpaddw %ymm10, %ymm6, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %xmm10, 856(%rdi)
 vextracti128 $1, %ymm10, %xmm10
 vmovq %xmm10, 872(%rdi)
 vmovdqu 1208(%rdi), %ymm10
 vpaddw %ymm10, %ymm4, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %xmm10, 1208(%rdi)
 vextracti128 $1, %ymm10, %xmm10
 vmovq %xmm10, 1224(%rdi)
 vmovdqu 206(%rdi), %ymm10
 vpaddw %ymm10, %ymm3, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %xmm10, 206(%rdi)
 vextracti128 $1, %ymm10, %xmm10
 vmovq %xmm10, 222(%rdi)
 vmovdqu 558(%rdi), %ymm10
 vpaddw %ymm10, %ymm8, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %xmm10, 558(%rdi)
 vextracti128 $1, %ymm10, %xmm10
 vmovq %xmm10, 574(%rdi)
 vmovdqu 910(%rdi), %ymm10
 vpaddw %ymm10, %ymm7, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %xmm10, 910(%rdi)
 vextracti128 $1, %ymm10, %xmm10
 vmovq %xmm10, 926(%rdi)
 vmovdqu 1262(%rdi), %ymm10
 vpaddw %ymm10, %ymm11, %ymm10
-vpand mask_mod2048(%rip), %ymm10, %ymm10
 vmovdqu %xmm10, 1262(%rdi)
 vextracti128 $1, %ymm10, %xmm10
 vmovq %xmm10, 1278(%rdi)
@@ -7865,43 +7693,36 @@ vpmullw %ymm13, %ymm3, %ymm3
 vpsubw %ymm3, %ymm6, %ymm6
 vmovdqu 592(%rdi), %ymm8
 vpaddw %ymm8, %ymm11, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 592(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 608(%rdi)
 vmovdqu 944(%rdi), %ymm8
 vpaddw %ymm8, %ymm6, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 944(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 960(%rdi)
 vmovdqu 1296(%rdi), %ymm8
 vpaddw %ymm8, %ymm9, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 1296(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 1312(%rdi)
 vmovdqu 294(%rdi), %ymm8
 vpaddw %ymm8, %ymm10, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 294(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 310(%rdi)
 vmovdqu 646(%rdi), %ymm8
 vpaddw %ymm8, %ymm4, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 646(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 662(%rdi)
 vmovdqu 998(%rdi), %ymm8
 vpaddw %ymm8, %ymm3, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 998(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 1014(%rdi)
 vmovdqu 1350(%rdi), %ymm8
 vpaddw %ymm8, %ymm5, %ymm8
-vpand mask_mod2048(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 1350(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 1366(%rdi)
@@ -7971,37 +7792,31 @@ vpmullw %ymm13, %ymm10, %ymm10
 vpsubw %ymm10, %ymm6, %ymm6
 vmovdqu 680(%rdi), %ymm4
 vpaddw %ymm4, %ymm5, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 680(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 696(%rdi)
 vmovdqu 1032(%rdi), %ymm4
 vpaddw %ymm4, %ymm6, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 1032(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 1048(%rdi)
 vmovdqu 30(%rdi), %ymm4
 vpaddw %ymm4, %ymm7, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 30(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 46(%rdi)
 vmovdqu 382(%rdi), %ymm4
 vpaddw %ymm4, %ymm8, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 382(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 398(%rdi)
 vmovdqu 734(%rdi), %ymm4
 vpaddw %ymm4, %ymm9, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 734(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 750(%rdi)
 vmovdqu 1086(%rdi), %ymm4
 vpaddw %ymm4, %ymm10, %ymm4
-vpand mask_mod2048(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 1086(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 1102(%rdi)

--- a/crypto_kem/ntruhps2048677/clean/owcpa.h
+++ b/crypto_kem/ntruhps2048677/clean/owcpa.h
@@ -4,12 +4,9 @@
 #include "params.h"
 #include "poly.h"
 
-void PQCLEAN_NTRUHPS2048677_CLEAN_owcpa_samplemsg(unsigned char msg[NTRU_OWCPA_MSGBYTES],
-        const unsigned char seed[NTRU_SEEDBYTES]);
-
 void PQCLEAN_NTRUHPS2048677_CLEAN_owcpa_keypair(unsigned char *pk,
         unsigned char *sk,
-        const unsigned char seed[NTRU_SEEDBYTES]);
+        const unsigned char seed[NTRU_SAMPLE_FG_BYTES]);
 
 void PQCLEAN_NTRUHPS2048677_CLEAN_owcpa_enc(unsigned char *c,
         const poly *r,

--- a/crypto_kem/ntruhps2048677/clean/poly.c
+++ b/crypto_kem/ntruhps2048677/clean/poly.c
@@ -23,7 +23,15 @@ void PQCLEAN_NTRUHPS2048677_CLEAN_poly_Sq_mul(poly *r, const poly *a, const poly
 }
 
 void PQCLEAN_NTRUHPS2048677_CLEAN_poly_S3_mul(poly *r, const poly *a, const poly *b) {
+    int i;
+
+    /* Our S3 multiplications do not overflow mod q,    */
+    /* so we can re-purpose PQCLEAN_NTRUHPS2048677_CLEAN_poly_Rq_mul, as long as we  */
+    /* follow with an explicit reduction mod q.         */
     PQCLEAN_NTRUHPS2048677_CLEAN_poly_Rq_mul(r, a, b);
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = MODQ(r->coeffs[i]);
+    }
     PQCLEAN_NTRUHPS2048677_CLEAN_poly_mod_3_Phi_n(r);
 }
 

--- a/crypto_kem/ntruhps2048677/clean/poly_rq_mul.c
+++ b/crypto_kem/ntruhps2048677/clean/poly_rq_mul.c
@@ -1,15 +1,284 @@
 #include "poly.h"
 
-void PQCLEAN_NTRUHPS2048677_CLEAN_poly_Rq_mul(poly *r, const poly *a, const poly *b) {
-    int k, i;
+/* Polynomial multiplication using     */
+/* Toom-4 and two layers of Karatsuba. */
 
-    for (k = 0; k < NTRU_N; k++) {
-        r->coeffs[k] = 0;
-        for (i = 1; i < NTRU_N - k; i++) {
-            r->coeffs[k] += a->coeffs[k + i] * b->coeffs[NTRU_N - i];
-        }
-        for (i = 0; i < k + 1; i++) {
-            r->coeffs[k] += a->coeffs[k - i] * b->coeffs[i];
-        }
+#define L PAD32(NTRU_N)
+#define M (L/4)
+#define K (L/16)
+
+static void toom4_k2x2_mul(uint16_t ab[2 * L], const uint16_t a[L], const uint16_t b[L]);
+
+static void toom4_k2x2_eval_0(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p1(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_m1(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p2(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_m2(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p3(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_inf(uint16_t r[9 * K], const uint16_t a[M]);
+static inline void k2x2_eval(uint16_t r[9 * K]);
+
+static void toom4_k2x2_basemul(uint16_t r[18 * K], const uint16_t a[9 * K], const uint16_t b[9 * K]);
+static inline void schoolbook_KxK(uint16_t r[2 * K], const uint16_t a[K], const uint16_t b[K]);
+
+static void toom4_k2x2_interpolate(uint16_t r[2 * M], const uint16_t a[63 * 2 * K]);
+static inline void k2x2_interpolate(uint16_t r[M], const uint16_t a[9 * K]);
+
+void PQCLEAN_NTRUHPS2048677_CLEAN_poly_Rq_mul(poly *r, const poly *a, const poly *b) {
+    size_t i;
+    uint16_t ab[2 * L];
+
+    for (i = 0; i < NTRU_N; i++) {
+        ab[i] = a->coeffs[i];
+        ab[L + i] = b->coeffs[i];
+    }
+    for (i = NTRU_N; i < L; i++) {
+        ab[i] = 0;
+        ab[L + i] = 0;
+    }
+
+    toom4_k2x2_mul(ab, ab, ab + L);
+
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = ab[i] + ab[NTRU_N + i];
     }
 }
+
+static void toom4_k2x2_mul(uint16_t ab[2 * L], const uint16_t a[L], const uint16_t b[L]) {
+    uint16_t tmpA[9 * K];
+    uint16_t tmpB[9 * K];
+    uint16_t eC[63 * 2 * K];
+
+    toom4_k2x2_eval_0(tmpA, a);
+    toom4_k2x2_eval_0(tmpB, b);
+    toom4_k2x2_basemul(eC + 0 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p1(tmpA, a);
+    toom4_k2x2_eval_p1(tmpB, b);
+    toom4_k2x2_basemul(eC + 1 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_m1(tmpA, a);
+    toom4_k2x2_eval_m1(tmpB, b);
+    toom4_k2x2_basemul(eC + 2 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p2(tmpA, a);
+    toom4_k2x2_eval_p2(tmpB, b);
+    toom4_k2x2_basemul(eC + 3 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_m2(tmpA, a);
+    toom4_k2x2_eval_m2(tmpB, b);
+    toom4_k2x2_basemul(eC + 4 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p3(tmpA, a);
+    toom4_k2x2_eval_p3(tmpB, b);
+    toom4_k2x2_basemul(eC + 5 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_inf(tmpA, a);
+    toom4_k2x2_eval_inf(tmpB, b);
+    toom4_k2x2_basemul(eC + 6 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_interpolate(ab, eC);
+}
+
+
+static void toom4_k2x2_eval_0(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i] = a[i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p1(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += a[1 * M + i];
+        r[i] += a[2 * M + i];
+        r[i] += a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_m1(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] -= a[1 * M + i];
+        r[i] += a[2 * M + i];
+        r[i] -= a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p2(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += 2 * a[1 * M + i];
+        r[i] += 4 * a[2 * M + i];
+        r[i] += 8 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_m2(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] -= 2 * a[1 * M + i];
+        r[i] += 4 * a[2 * M + i];
+        r[i] -= 8 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p3(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += 3 * a[1 * M + i];
+        r[i] += 9 * a[2 * M + i];
+        r[i] += 27 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_inf(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i] = a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static inline void k2x2_eval(uint16_t r[9 * K]) {
+    /* Input:  e + f.Y + g.Y^2 + h.Y^3                              */
+    /* Output: [ e | f | g | h | e+f | f+h | g+e | h+g | e+f+g+h ]  */
+
+    size_t i;
+    for (i = 0; i < 4 * K; i++) {
+        r[4 * K + i] = r[i];
+    }
+    for (i = 0; i < K; i++) {
+        r[4 * K + i] += r[1 * K + i];
+        r[5 * K + i] += r[3 * K + i];
+        r[6 * K + i] += r[0 * K + i];
+        r[7 * K + i] += r[2 * K + i];
+        r[8 * K + i] = r[5 * K + i];
+        r[8 * K + i] += r[6 * K + i];
+    }
+}
+
+static void toom4_k2x2_basemul(uint16_t r[18 * K], const uint16_t a[9 * K], const uint16_t b[9 * K]) {
+    schoolbook_KxK(r + 0 * 2 * K, a + 0 * K, b + 0 * K);
+    schoolbook_KxK(r + 1 * 2 * K, a + 1 * K, b + 1 * K);
+    schoolbook_KxK(r + 2 * 2 * K, a + 2 * K, b + 2 * K);
+    schoolbook_KxK(r + 3 * 2 * K, a + 3 * K, b + 3 * K);
+    schoolbook_KxK(r + 4 * 2 * K, a + 4 * K, b + 4 * K);
+    schoolbook_KxK(r + 5 * 2 * K, a + 5 * K, b + 5 * K);
+    schoolbook_KxK(r + 6 * 2 * K, a + 6 * K, b + 6 * K);
+    schoolbook_KxK(r + 7 * 2 * K, a + 7 * K, b + 7 * K);
+    schoolbook_KxK(r + 8 * 2 * K, a + 8 * K, b + 8 * K);
+}
+
+static inline void schoolbook_KxK(uint16_t r[2 * K], const uint16_t a[K], const uint16_t b[K]) {
+    size_t i, j;
+    for (j = 0; j < K; j++) {
+        r[j] = a[0] * b[j];
+    }
+    for (i = 1; i < K; i++) {
+        for (j = 0; j < K - 1; j++) {
+            r[i + j] += a[i] * b[j];
+        }
+        r[i + K - 1] = a[i] * b[K - 1];
+    }
+    r[2 * K - 1] = 0;
+}
+
+static void toom4_k2x2_interpolate(uint16_t r[2 * M], const uint16_t a[7 * 18 * K]) {
+    size_t i;
+
+    uint16_t P1[2 * M];
+    uint16_t Pm1[2 * M];
+    uint16_t P2[2 * M];
+    uint16_t Pm2[2 * M];
+
+    uint16_t *C0 = r;
+    uint16_t *C2 = r + 2 * M;
+    uint16_t *C4 = r + 4 * M;
+    uint16_t *C6 = r + 6 * M;
+
+    uint16_t V0, V1, V2;
+
+    k2x2_interpolate(C0, a + 0 * 9 * 2 * K);
+    k2x2_interpolate(P1, a + 1 * 9 * 2 * K);
+    k2x2_interpolate(Pm1, a + 2 * 9 * 2 * K);
+    k2x2_interpolate(P2, a + 3 * 9 * 2 * K);
+    k2x2_interpolate(Pm2, a + 4 * 9 * 2 * K);
+    k2x2_interpolate(C6, a + 6 * 9 * 2 * K);
+
+    for (i = 0; i < 2 * M; i++) {
+        V0 = ((uint32_t)(P1[i] + Pm1[i])) >> 1;
+        V0 = V0 - C0[i] - C6[i];
+        V1 = ((uint32_t)(P2[i] + Pm2[i] - 2 * C0[i] - 128 * C6[i])) >> 3;
+        C4[i] = 43691 * (V1 - V0);
+        C2[i] = V0 - C4[i];
+        P1[i] = ((uint32_t)(P1[i] - Pm1[i])) >> 1;
+    }
+
+    /* reuse Pm1 for P3 */
+#define P3 Pm1
+    k2x2_interpolate(P3, a + 5 * 9 * 2 * K);
+
+    for (i = 0; i < 2 * M; i++) {
+        V0 = P1[i];
+        V1 = 43691 * ((((uint32_t)(P2[i] - Pm2[i])) >> 2) - V0);
+        V2 = 43691 * (P3[i] - C0[i] - 9 * (C2[i] + 9 * (C4[i] + 9 * C6[i])));
+        V2 = ((uint32_t)(V2 - V0)) >> 3;
+        V2 -= V1;
+        P3[i] = 52429 * V2;
+        P2[i] = V1 - V2;
+        P1[i] = V0 - P2[i] - P3[i];
+    }
+
+    for (i = 0; i < 2 * M; i++) {
+        r[1 * M + i] += P1[i];
+        r[3 * M + i] += P2[i];
+        r[5 * M + i] += P3[i];
+    }
+}
+
+static inline void k2x2_interpolate(uint16_t r[M], const uint16_t a[9 * K]) {
+    size_t i;
+    uint16_t tmp[4 * K];
+
+    for (i = 0; i < 2 * K; i++) {
+        r[0 * K + i] = a[0 * K + i];
+        r[2 * K + i] = a[2 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[1 * K + i] += a[8 * K + i] - a[0 * K + i] - a[2 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[4 * K + i] = a[4 * K + i];
+        r[6 * K + i] = a[6 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[5 * K + i] += a[14 * K + i] - a[4 * K + i] - a[6 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        tmp[0 * K + i] = a[12 * K + i];
+        tmp[2 * K + i] = a[10 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        tmp[K + i] += a[16 * K + i] - a[12 * K + i] - a[10 * K + i];
+    }
+
+    for (i = 0; i < 4 * K; i++) {
+        tmp[0 * K + i] = tmp[0 * K + i] - r[0 * K + i] - r[4 * K + i];
+    }
+
+    for (i = 0; i < 4 * K; i++) {
+        r[2 * K + i] += tmp[0 * K + i];
+    }
+}
+

--- a/crypto_kem/ntruhps4096821/META.yml
+++ b/crypto_kem/ntruhps4096821/META.yml
@@ -23,9 +23,9 @@ auxiliary-submitters:
   - Zhenfei Zhang
 implementations:
     - name: clean
-      version: https://github.com/jschanck/ntru/tree/6d1f44f5 reference implementation
+      version: https://github.com/jschanck/ntru/tree/60cc7277 reference implementation
     - name: avx2
-      version: https://github.com/jschanck/ntru/tree/6d1f44f5 avx2 implementation
+      version: https://github.com/jschanck/ntru/tree/60cc7277 avx2 implementation
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/ntruhps4096821/avx2/owcpa.h
+++ b/crypto_kem/ntruhps4096821/avx2/owcpa.h
@@ -4,12 +4,9 @@
 #include "params.h"
 #include "poly.h"
 
-void PQCLEAN_NTRUHPS4096821_AVX2_owcpa_samplemsg(unsigned char msg[NTRU_OWCPA_MSGBYTES],
-        const unsigned char seed[NTRU_SEEDBYTES]);
-
 void PQCLEAN_NTRUHPS4096821_AVX2_owcpa_keypair(unsigned char *pk,
         unsigned char *sk,
-        const unsigned char seed[NTRU_SEEDBYTES]);
+        const unsigned char seed[NTRU_SAMPLE_FG_BYTES]);
 
 void PQCLEAN_NTRUHPS4096821_AVX2_owcpa_enc(unsigned char *c,
         const poly *r,

--- a/crypto_kem/ntruhps4096821/avx2/poly.c
+++ b/crypto_kem/ntruhps4096821/avx2/poly.c
@@ -23,7 +23,15 @@ void PQCLEAN_NTRUHPS4096821_AVX2_poly_Sq_mul(poly *r, const poly *a, const poly 
 }
 
 void PQCLEAN_NTRUHPS4096821_AVX2_poly_S3_mul(poly *r, const poly *a, const poly *b) {
+    int i;
+
+    /* Our S3 multiplications do not overflow mod q,    */
+    /* so we can re-purpose PQCLEAN_NTRUHPS4096821_AVX2_poly_Rq_mul, as long as we  */
+    /* follow with an explicit reduction mod q.         */
     PQCLEAN_NTRUHPS4096821_AVX2_poly_Rq_mul(r, a, b);
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = MODQ(r->coeffs[i]);
+    }
     PQCLEAN_NTRUHPS4096821_AVX2_poly_mod_3_Phi_n(r);
 }
 

--- a/crypto_kem/ntruhps4096821/avx2/poly_rq_mul.s
+++ b/crypto_kem/ntruhps4096821/avx2/poly_rq_mul.s
@@ -203,23 +203,6 @@ mask_7_9:
 .word 0
 .word 0
 .word 0
-mask_mod4096:
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
-.word 4095
 .text
 .global PQCLEAN_NTRUHPS4096821_AVX2_poly_Rq_mul
 .global _PQCLEAN_NTRUHPS4096821_AVX2_poly_Rq_mul
@@ -7099,31 +7082,24 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 0(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 0(%rdi)
 vmovdqu 416(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 416(%rdi)
 vmovdqu 832(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 832(%rdi)
 vmovdqu 1248(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1248(%rdi)
 vmovdqu 22(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 22(%rdi)
 vmovdqu 438(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 438(%rdi)
 vmovdqu 854(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 854(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -7191,31 +7167,24 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 104(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 104(%rdi)
 vmovdqu 520(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 520(%rdi)
 vmovdqu 936(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 936(%rdi)
 vmovdqu 1352(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1352(%rdi)
 vmovdqu 126(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 126(%rdi)
 vmovdqu 542(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 542(%rdi)
 vmovdqu 958(%rdi), %ymm7
 vpaddw %ymm7, %ymm11, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 958(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm4
@@ -7283,31 +7252,24 @@ vpmullw %ymm13, %ymm9, %ymm9
 vpsubw %ymm9, %ymm6, %ymm6
 vmovdqu 208(%rdi), %ymm3
 vpaddw %ymm3, %ymm11, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 208(%rdi)
 vmovdqu 624(%rdi), %ymm3
 vpaddw %ymm3, %ymm6, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 624(%rdi)
 vmovdqu 1040(%rdi), %ymm3
 vpaddw %ymm3, %ymm8, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1040(%rdi)
 vmovdqu 1456(%rdi), %ymm3
 vpaddw %ymm3, %ymm7, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1456(%rdi)
 vmovdqu 230(%rdi), %ymm3
 vpaddw %ymm3, %ymm10, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 230(%rdi)
 vmovdqu 646(%rdi), %ymm3
 vpaddw %ymm3, %ymm9, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 646(%rdi)
 vmovdqu 1062(%rdi), %ymm3
 vpaddw %ymm3, %ymm5, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1062(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -7375,31 +7337,24 @@ vpmullw %ymm13, %ymm7, %ymm7
 vpsubw %ymm7, %ymm6, %ymm6
 vmovdqu 312(%rdi), %ymm10
 vpaddw %ymm10, %ymm5, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 312(%rdi)
 vmovdqu 728(%rdi), %ymm10
 vpaddw %ymm10, %ymm6, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 728(%rdi)
 vmovdqu 1144(%rdi), %ymm10
 vpaddw %ymm10, %ymm4, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1144(%rdi)
 vmovdqu 1560(%rdi), %ymm10
 vpaddw %ymm10, %ymm3, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1560(%rdi)
 vmovdqu 334(%rdi), %ymm10
 vpaddw %ymm10, %ymm8, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 334(%rdi)
 vmovdqu 750(%rdi), %ymm10
 vpaddw %ymm10, %ymm7, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 750(%rdi)
 vmovdqu 1166(%rdi), %ymm10
 vpaddw %ymm10, %ymm11, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1166(%rdi)
 vmovdqa 128(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm7
@@ -7467,31 +7422,24 @@ vpmullw %ymm13, %ymm3, %ymm3
 vpsubw %ymm3, %ymm6, %ymm6
 vmovdqu 416(%rdi), %ymm8
 vpaddw %ymm8, %ymm11, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 416(%rdi)
 vmovdqu 832(%rdi), %ymm8
 vpaddw %ymm8, %ymm6, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 832(%rdi)
 vmovdqu 1248(%rdi), %ymm8
 vpaddw %ymm8, %ymm9, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1248(%rdi)
 vmovdqu 22(%rdi), %ymm8
 vpaddw %ymm8, %ymm10, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 22(%rdi)
 vmovdqu 438(%rdi), %ymm8
 vpaddw %ymm8, %ymm4, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 438(%rdi)
 vmovdqu 854(%rdi), %ymm8
 vpaddw %ymm8, %ymm3, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 854(%rdi)
 vmovdqu 1270(%rdi), %ymm8
 vpaddw %ymm8, %ymm5, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1270(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -7559,31 +7507,24 @@ vpmullw %ymm13, %ymm10, %ymm10
 vpsubw %ymm10, %ymm6, %ymm6
 vmovdqu 520(%rdi), %ymm4
 vpaddw %ymm4, %ymm5, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 520(%rdi)
 vmovdqu 936(%rdi), %ymm4
 vpaddw %ymm4, %ymm6, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 936(%rdi)
 vmovdqu 1352(%rdi), %ymm4
 vpaddw %ymm4, %ymm7, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1352(%rdi)
 vmovdqu 126(%rdi), %ymm4
 vpaddw %ymm4, %ymm8, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 126(%rdi)
 vmovdqu 542(%rdi), %ymm4
 vpaddw %ymm4, %ymm9, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 542(%rdi)
 vmovdqu 958(%rdi), %ymm4
 vpaddw %ymm4, %ymm10, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 958(%rdi)
 vmovdqu 1374(%rdi), %ymm4
 vpaddw %ymm4, %ymm11, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1374(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm10
@@ -7651,31 +7592,24 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 624(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 624(%rdi)
 vmovdqu 1040(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1040(%rdi)
 vmovdqu 1456(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1456(%rdi)
 vmovdqu 230(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 230(%rdi)
 vmovdqu 646(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 646(%rdi)
 vmovdqu 1062(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1062(%rdi)
 vmovdqu 1478(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1478(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -7743,31 +7677,24 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 728(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 728(%rdi)
 vmovdqu 1144(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1144(%rdi)
 vmovdqu 1560(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1560(%rdi)
 vmovdqu 334(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 334(%rdi)
 vmovdqu 750(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 750(%rdi)
 vmovdqu 1166(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1166(%rdi)
 vmovdqu 1582(%rdi), %ymm7
 vpaddw %ymm7, %ymm11, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1582(%rdi)
 vmovdqa 160(%r12), %ymm0
 vpsubw 288(%r12), %ymm0, %ymm0
@@ -8136,31 +8063,24 @@ vpmullw %ymm13, %ymm9, %ymm9
 vpsubw %ymm9, %ymm6, %ymm6
 vmovdqu 32(%rdi), %ymm3
 vpaddw %ymm3, %ymm11, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 32(%rdi)
 vmovdqu 448(%rdi), %ymm3
 vpaddw %ymm3, %ymm6, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 448(%rdi)
 vmovdqu 864(%rdi), %ymm3
 vpaddw %ymm3, %ymm8, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 864(%rdi)
 vmovdqu 1280(%rdi), %ymm3
 vpaddw %ymm3, %ymm7, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1280(%rdi)
 vmovdqu 54(%rdi), %ymm3
 vpaddw %ymm3, %ymm10, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 54(%rdi)
 vmovdqu 470(%rdi), %ymm3
 vpaddw %ymm3, %ymm9, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 470(%rdi)
 vmovdqu 886(%rdi), %ymm3
 vpaddw %ymm3, %ymm5, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 886(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -8228,31 +8148,24 @@ vpmullw %ymm13, %ymm7, %ymm7
 vpsubw %ymm7, %ymm6, %ymm6
 vmovdqu 136(%rdi), %ymm10
 vpaddw %ymm10, %ymm5, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 136(%rdi)
 vmovdqu 552(%rdi), %ymm10
 vpaddw %ymm10, %ymm6, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 552(%rdi)
 vmovdqu 968(%rdi), %ymm10
 vpaddw %ymm10, %ymm4, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 968(%rdi)
 vmovdqu 1384(%rdi), %ymm10
 vpaddw %ymm10, %ymm3, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1384(%rdi)
 vmovdqu 158(%rdi), %ymm10
 vpaddw %ymm10, %ymm8, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 158(%rdi)
 vmovdqu 574(%rdi), %ymm10
 vpaddw %ymm10, %ymm7, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 574(%rdi)
 vmovdqu 990(%rdi), %ymm10
 vpaddw %ymm10, %ymm11, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 990(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm7
@@ -8320,31 +8233,24 @@ vpmullw %ymm13, %ymm3, %ymm3
 vpsubw %ymm3, %ymm6, %ymm6
 vmovdqu 240(%rdi), %ymm8
 vpaddw %ymm8, %ymm11, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 240(%rdi)
 vmovdqu 656(%rdi), %ymm8
 vpaddw %ymm8, %ymm6, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 656(%rdi)
 vmovdqu 1072(%rdi), %ymm8
 vpaddw %ymm8, %ymm9, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1072(%rdi)
 vmovdqu 1488(%rdi), %ymm8
 vpaddw %ymm8, %ymm10, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1488(%rdi)
 vmovdqu 262(%rdi), %ymm8
 vpaddw %ymm8, %ymm4, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 262(%rdi)
 vmovdqu 678(%rdi), %ymm8
 vpaddw %ymm8, %ymm3, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 678(%rdi)
 vmovdqu 1094(%rdi), %ymm8
 vpaddw %ymm8, %ymm5, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1094(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -8412,31 +8318,24 @@ vpmullw %ymm13, %ymm10, %ymm10
 vpsubw %ymm10, %ymm6, %ymm6
 vmovdqu 344(%rdi), %ymm4
 vpaddw %ymm4, %ymm5, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 344(%rdi)
 vmovdqu 760(%rdi), %ymm4
 vpaddw %ymm4, %ymm6, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 760(%rdi)
 vmovdqu 1176(%rdi), %ymm4
 vpaddw %ymm4, %ymm7, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1176(%rdi)
 vmovdqu 1592(%rdi), %ymm4
 vpaddw %ymm4, %ymm8, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1592(%rdi)
 vmovdqu 366(%rdi), %ymm4
 vpaddw %ymm4, %ymm9, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 366(%rdi)
 vmovdqu 782(%rdi), %ymm4
 vpaddw %ymm4, %ymm10, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 782(%rdi)
 vmovdqu 1198(%rdi), %ymm4
 vpaddw %ymm4, %ymm11, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1198(%rdi)
 vmovdqa 128(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm10
@@ -8504,31 +8403,24 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 448(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 448(%rdi)
 vmovdqu 864(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 864(%rdi)
 vmovdqu 1280(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1280(%rdi)
 vmovdqu 54(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 54(%rdi)
 vmovdqu 470(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 470(%rdi)
 vmovdqu 886(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 886(%rdi)
 vmovdqu 1302(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1302(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -8596,31 +8488,24 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 552(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 552(%rdi)
 vmovdqu 968(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 968(%rdi)
 vmovdqu 1384(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1384(%rdi)
 vmovdqu 158(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 158(%rdi)
 vmovdqu 574(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 574(%rdi)
 vmovdqu 990(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 990(%rdi)
 vmovdqu 1406(%rdi), %ymm7
 vpaddw %ymm7, %ymm11, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1406(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm4
@@ -8688,31 +8573,24 @@ vpmullw %ymm13, %ymm9, %ymm9
 vpsubw %ymm9, %ymm6, %ymm6
 vmovdqu 656(%rdi), %ymm3
 vpaddw %ymm3, %ymm11, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 656(%rdi)
 vmovdqu 1072(%rdi), %ymm3
 vpaddw %ymm3, %ymm6, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1072(%rdi)
 vmovdqu 1488(%rdi), %ymm3
 vpaddw %ymm3, %ymm8, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1488(%rdi)
 vmovdqu 262(%rdi), %ymm3
 vpaddw %ymm3, %ymm7, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 262(%rdi)
 vmovdqu 678(%rdi), %ymm3
 vpaddw %ymm3, %ymm10, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 678(%rdi)
 vmovdqu 1094(%rdi), %ymm3
 vpaddw %ymm3, %ymm9, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1094(%rdi)
 vmovdqu 1510(%rdi), %ymm3
 vpaddw %ymm3, %ymm5, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1510(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -8780,31 +8658,24 @@ vpmullw %ymm13, %ymm7, %ymm7
 vpsubw %ymm7, %ymm6, %ymm6
 vmovdqu 760(%rdi), %ymm10
 vpaddw %ymm10, %ymm5, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 760(%rdi)
 vmovdqu 1176(%rdi), %ymm10
 vpaddw %ymm10, %ymm6, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1176(%rdi)
 vmovdqu 1592(%rdi), %ymm10
 vpaddw %ymm10, %ymm4, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1592(%rdi)
 vmovdqu 366(%rdi), %ymm10
 vpaddw %ymm10, %ymm3, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 366(%rdi)
 vmovdqu 782(%rdi), %ymm10
 vpaddw %ymm10, %ymm8, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 782(%rdi)
 vmovdqu 1198(%rdi), %ymm10
 vpaddw %ymm10, %ymm7, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1198(%rdi)
 vmovdqu 1614(%rdi), %ymm10
 vpaddw %ymm10, %ymm11, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1614(%rdi)
 vmovdqa 192(%r12), %ymm0
 vpsubw 320(%r12), %ymm0, %ymm0
@@ -9173,31 +9044,24 @@ vpmullw %ymm13, %ymm3, %ymm3
 vpsubw %ymm3, %ymm6, %ymm6
 vmovdqu 64(%rdi), %ymm8
 vpaddw %ymm8, %ymm11, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 64(%rdi)
 vmovdqu 480(%rdi), %ymm8
 vpaddw %ymm8, %ymm6, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 480(%rdi)
 vmovdqu 896(%rdi), %ymm8
 vpaddw %ymm8, %ymm9, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 896(%rdi)
 vmovdqu 1312(%rdi), %ymm8
 vpaddw %ymm8, %ymm10, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1312(%rdi)
 vmovdqu 86(%rdi), %ymm8
 vpaddw %ymm8, %ymm4, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 86(%rdi)
 vmovdqu 502(%rdi), %ymm8
 vpaddw %ymm8, %ymm3, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 502(%rdi)
 vmovdqu 918(%rdi), %ymm8
 vpaddw %ymm8, %ymm5, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 918(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -9265,31 +9129,24 @@ vpmullw %ymm13, %ymm10, %ymm10
 vpsubw %ymm10, %ymm6, %ymm6
 vmovdqu 168(%rdi), %ymm4
 vpaddw %ymm4, %ymm5, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 168(%rdi)
 vmovdqu 584(%rdi), %ymm4
 vpaddw %ymm4, %ymm6, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 584(%rdi)
 vmovdqu 1000(%rdi), %ymm4
 vpaddw %ymm4, %ymm7, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1000(%rdi)
 vmovdqu 1416(%rdi), %ymm4
 vpaddw %ymm4, %ymm8, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1416(%rdi)
 vmovdqu 190(%rdi), %ymm4
 vpaddw %ymm4, %ymm9, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 190(%rdi)
 vmovdqu 606(%rdi), %ymm4
 vpaddw %ymm4, %ymm10, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 606(%rdi)
 vmovdqu 1022(%rdi), %ymm4
 vpaddw %ymm4, %ymm11, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1022(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm10
@@ -9357,31 +9214,24 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 272(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 272(%rdi)
 vmovdqu 688(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 688(%rdi)
 vmovdqu 1104(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1104(%rdi)
 vmovdqu 1520(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1520(%rdi)
 vmovdqu 294(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 294(%rdi)
 vmovdqu 710(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 710(%rdi)
 vmovdqu 1126(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1126(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -9449,39 +9299,31 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 376(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 376(%rdi)
 vmovdqu 792(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 792(%rdi)
 vmovdqu 1208(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1208(%rdi)
 vmovdqu 1624(%rdi), %ymm7
 vpand mask_9_7(%rip), %ymm9, %ymm8
 vpaddw %ymm7, %ymm8, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1624(%rdi)
 vpshufb rol_rol_16(%rip), %ymm9, %ymm9
 vextracti128 $1, %ymm9, %xmm9
 vpand mask_7_9(%rip), %ymm9, %ymm9
 vmovdqu 0(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 0(%rdi)
 vmovdqu 398(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 398(%rdi)
 vmovdqu 814(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 814(%rdi)
 vmovdqu 1230(%rdi), %ymm7
 vpaddw %ymm7, %ymm11, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1230(%rdi)
 vmovdqa 128(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm4
@@ -9549,31 +9391,24 @@ vpmullw %ymm13, %ymm9, %ymm9
 vpsubw %ymm9, %ymm6, %ymm6
 vmovdqu 480(%rdi), %ymm3
 vpaddw %ymm3, %ymm11, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 480(%rdi)
 vmovdqu 896(%rdi), %ymm3
 vpaddw %ymm3, %ymm6, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 896(%rdi)
 vmovdqu 1312(%rdi), %ymm3
 vpaddw %ymm3, %ymm8, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1312(%rdi)
 vmovdqu 86(%rdi), %ymm3
 vpaddw %ymm3, %ymm7, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 86(%rdi)
 vmovdqu 502(%rdi), %ymm3
 vpaddw %ymm3, %ymm10, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 502(%rdi)
 vmovdqu 918(%rdi), %ymm3
 vpaddw %ymm3, %ymm9, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 918(%rdi)
 vmovdqu 1334(%rdi), %ymm3
 vpaddw %ymm3, %ymm5, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1334(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -9641,31 +9476,24 @@ vpmullw %ymm13, %ymm7, %ymm7
 vpsubw %ymm7, %ymm6, %ymm6
 vmovdqu 584(%rdi), %ymm10
 vpaddw %ymm10, %ymm5, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 584(%rdi)
 vmovdqu 1000(%rdi), %ymm10
 vpaddw %ymm10, %ymm6, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1000(%rdi)
 vmovdqu 1416(%rdi), %ymm10
 vpaddw %ymm10, %ymm4, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1416(%rdi)
 vmovdqu 190(%rdi), %ymm10
 vpaddw %ymm10, %ymm3, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 190(%rdi)
 vmovdqu 606(%rdi), %ymm10
 vpaddw %ymm10, %ymm8, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 606(%rdi)
 vmovdqu 1022(%rdi), %ymm10
 vpaddw %ymm10, %ymm7, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1022(%rdi)
 vmovdqu 1438(%rdi), %ymm10
 vpaddw %ymm10, %ymm11, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1438(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm7
@@ -9733,31 +9561,24 @@ vpmullw %ymm13, %ymm3, %ymm3
 vpsubw %ymm3, %ymm6, %ymm6
 vmovdqu 688(%rdi), %ymm8
 vpaddw %ymm8, %ymm11, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 688(%rdi)
 vmovdqu 1104(%rdi), %ymm8
 vpaddw %ymm8, %ymm6, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1104(%rdi)
 vmovdqu 1520(%rdi), %ymm8
 vpaddw %ymm8, %ymm9, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1520(%rdi)
 vmovdqu 294(%rdi), %ymm8
 vpaddw %ymm8, %ymm10, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 294(%rdi)
 vmovdqu 710(%rdi), %ymm8
 vpaddw %ymm8, %ymm4, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 710(%rdi)
 vmovdqu 1126(%rdi), %ymm8
 vpaddw %ymm8, %ymm3, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1126(%rdi)
 vmovdqu 1542(%rdi), %ymm8
 vpaddw %ymm8, %ymm5, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1542(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -9825,35 +9646,28 @@ vpmullw %ymm13, %ymm10, %ymm10
 vpsubw %ymm10, %ymm6, %ymm6
 vmovdqu 792(%rdi), %ymm4
 vpaddw %ymm4, %ymm5, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 792(%rdi)
 vmovdqu 1208(%rdi), %ymm4
 vpaddw %ymm4, %ymm6, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1208(%rdi)
 vmovdqu 1624(%rdi), %ymm4
 vpand mask_9_7(%rip), %ymm7, %ymm3
 vpaddw %ymm4, %ymm3, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1624(%rdi)
 vpshufb rol_rol_16(%rip), %ymm7, %ymm7
 vextracti128 $1, %ymm7, %xmm7
 vpand mask_7_9(%rip), %ymm7, %ymm7
 vmovdqu 0(%rdi), %ymm4
 vpaddw %ymm4, %ymm7, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 0(%rdi)
 vmovdqu 398(%rdi), %ymm4
 vpaddw %ymm4, %ymm8, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 398(%rdi)
 vmovdqu 814(%rdi), %ymm4
 vpaddw %ymm4, %ymm9, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 814(%rdi)
 vmovdqu 1230(%rdi), %ymm4
 vpaddw %ymm4, %ymm10, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1230(%rdi)
 vmovdqa 224(%r12), %ymm0
 vpsubw 352(%r12), %ymm0, %ymm0
@@ -10222,31 +10036,24 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 96(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 96(%rdi)
 vmovdqu 512(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 512(%rdi)
 vmovdqu 928(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 928(%rdi)
 vmovdqu 1344(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 1344(%rdi)
 vmovdqu 118(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 118(%rdi)
 vmovdqu 534(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 534(%rdi)
 vmovdqu 950(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 950(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -10314,31 +10121,24 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 200(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 200(%rdi)
 vmovdqu 616(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 616(%rdi)
 vmovdqu 1032(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 1032(%rdi)
 vmovdqu 1448(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 1448(%rdi)
 vmovdqu 222(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 222(%rdi)
 vmovdqu 638(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 638(%rdi)
 vmovdqu 1054(%rdi), %ymm7
 vpaddw %ymm7, %ymm11, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 1054(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm4
@@ -10406,31 +10206,24 @@ vpmullw %ymm13, %ymm9, %ymm9
 vpsubw %ymm9, %ymm6, %ymm6
 vmovdqu 304(%rdi), %ymm3
 vpaddw %ymm3, %ymm11, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovq %xmm3, 304(%rdi)
 vmovdqu 720(%rdi), %ymm3
 vpaddw %ymm3, %ymm6, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovq %xmm3, 720(%rdi)
 vmovdqu 1136(%rdi), %ymm3
 vpaddw %ymm3, %ymm8, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovq %xmm3, 1136(%rdi)
 vmovdqu 1552(%rdi), %ymm3
 vpaddw %ymm3, %ymm7, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovq %xmm3, 1552(%rdi)
 vmovdqu 326(%rdi), %ymm3
 vpaddw %ymm3, %ymm10, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovq %xmm3, 326(%rdi)
 vmovdqu 742(%rdi), %ymm3
 vpaddw %ymm3, %ymm9, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovq %xmm3, 742(%rdi)
 vmovdqu 1158(%rdi), %ymm3
 vpaddw %ymm3, %ymm5, %ymm3
-vpand mask_mod4096(%rip), %ymm3, %ymm3
 vmovq %xmm3, 1158(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -10498,31 +10291,24 @@ vpmullw %ymm13, %ymm7, %ymm7
 vpsubw %ymm7, %ymm6, %ymm6
 vmovdqu 408(%rdi), %ymm10
 vpaddw %ymm10, %ymm5, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovq %xmm10, 408(%rdi)
 vmovdqu 824(%rdi), %ymm10
 vpaddw %ymm10, %ymm6, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovq %xmm10, 824(%rdi)
 vmovdqu 1240(%rdi), %ymm10
 vpaddw %ymm10, %ymm4, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovq %xmm10, 1240(%rdi)
 vmovdqu 14(%rdi), %ymm10
 vpaddw %ymm10, %ymm3, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovq %xmm10, 14(%rdi)
 vmovdqu 430(%rdi), %ymm10
 vpaddw %ymm10, %ymm8, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovq %xmm10, 430(%rdi)
 vmovdqu 846(%rdi), %ymm10
 vpaddw %ymm10, %ymm7, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovq %xmm10, 846(%rdi)
 vmovdqu 1262(%rdi), %ymm10
 vpaddw %ymm10, %ymm11, %ymm10
-vpand mask_mod4096(%rip), %ymm10, %ymm10
 vmovq %xmm10, 1262(%rdi)
 vmovdqa 128(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm7
@@ -10590,31 +10376,24 @@ vpmullw %ymm13, %ymm3, %ymm3
 vpsubw %ymm3, %ymm6, %ymm6
 vmovdqu 512(%rdi), %ymm8
 vpaddw %ymm8, %ymm11, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovq %xmm8, 512(%rdi)
 vmovdqu 928(%rdi), %ymm8
 vpaddw %ymm8, %ymm6, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovq %xmm8, 928(%rdi)
 vmovdqu 1344(%rdi), %ymm8
 vpaddw %ymm8, %ymm9, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovq %xmm8, 1344(%rdi)
 vmovdqu 118(%rdi), %ymm8
 vpaddw %ymm8, %ymm10, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovq %xmm8, 118(%rdi)
 vmovdqu 534(%rdi), %ymm8
 vpaddw %ymm8, %ymm4, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovq %xmm8, 534(%rdi)
 vmovdqu 950(%rdi), %ymm8
 vpaddw %ymm8, %ymm3, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovq %xmm8, 950(%rdi)
 vmovdqu 1366(%rdi), %ymm8
 vpaddw %ymm8, %ymm5, %ymm8
-vpand mask_mod4096(%rip), %ymm8, %ymm8
 vmovq %xmm8, 1366(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -10682,31 +10461,24 @@ vpmullw %ymm13, %ymm10, %ymm10
 vpsubw %ymm10, %ymm6, %ymm6
 vmovdqu 616(%rdi), %ymm4
 vpaddw %ymm4, %ymm5, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovq %xmm4, 616(%rdi)
 vmovdqu 1032(%rdi), %ymm4
 vpaddw %ymm4, %ymm6, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovq %xmm4, 1032(%rdi)
 vmovdqu 1448(%rdi), %ymm4
 vpaddw %ymm4, %ymm7, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovq %xmm4, 1448(%rdi)
 vmovdqu 222(%rdi), %ymm4
 vpaddw %ymm4, %ymm8, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovq %xmm4, 222(%rdi)
 vmovdqu 638(%rdi), %ymm4
 vpaddw %ymm4, %ymm9, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovq %xmm4, 638(%rdi)
 vmovdqu 1054(%rdi), %ymm4
 vpaddw %ymm4, %ymm10, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovq %xmm4, 1054(%rdi)
 vmovdqu 1470(%rdi), %ymm4
 vpaddw %ymm4, %ymm11, %ymm4
-vpand mask_mod4096(%rip), %ymm4, %ymm4
 vmovq %xmm4, 1470(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm10
@@ -10774,31 +10546,24 @@ vpmullw %ymm13, %ymm8, %ymm8
 vpsubw %ymm8, %ymm6, %ymm6
 vmovdqu 720(%rdi), %ymm9
 vpaddw %ymm9, %ymm11, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 720(%rdi)
 vmovdqu 1136(%rdi), %ymm9
 vpaddw %ymm9, %ymm6, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 1136(%rdi)
 vmovdqu 1552(%rdi), %ymm9
 vpaddw %ymm9, %ymm3, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 1552(%rdi)
 vmovdqu 326(%rdi), %ymm9
 vpaddw %ymm9, %ymm4, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 326(%rdi)
 vmovdqu 742(%rdi), %ymm9
 vpaddw %ymm9, %ymm7, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 742(%rdi)
 vmovdqu 1158(%rdi), %ymm9
 vpaddw %ymm9, %ymm8, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 1158(%rdi)
 vmovdqu 1574(%rdi), %ymm9
 vpaddw %ymm9, %ymm5, %ymm9
-vpand mask_mod4096(%rip), %ymm9, %ymm9
 vmovq %xmm9, 1574(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -10866,27 +10631,21 @@ vpmullw %ymm13, %ymm4, %ymm4
 vpsubw %ymm4, %ymm6, %ymm6
 vmovdqu 824(%rdi), %ymm7
 vpaddw %ymm7, %ymm5, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 824(%rdi)
 vmovdqu 1240(%rdi), %ymm7
 vpaddw %ymm7, %ymm6, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 1240(%rdi)
 vmovdqu 14(%rdi), %ymm7
 vpaddw %ymm7, %ymm10, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 14(%rdi)
 vmovdqu 430(%rdi), %ymm7
 vpaddw %ymm7, %ymm9, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 430(%rdi)
 vmovdqu 846(%rdi), %ymm7
 vpaddw %ymm7, %ymm3, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 846(%rdi)
 vmovdqu 1262(%rdi), %ymm7
 vpaddw %ymm7, %ymm4, %ymm7
-vpand mask_mod4096(%rip), %ymm7, %ymm7
 vmovq %xmm7, 1262(%rdi)
 mov %r8, %rsp
 pop %r12

--- a/crypto_kem/ntruhps4096821/clean/owcpa.h
+++ b/crypto_kem/ntruhps4096821/clean/owcpa.h
@@ -4,12 +4,9 @@
 #include "params.h"
 #include "poly.h"
 
-void PQCLEAN_NTRUHPS4096821_CLEAN_owcpa_samplemsg(unsigned char msg[NTRU_OWCPA_MSGBYTES],
-        const unsigned char seed[NTRU_SEEDBYTES]);
-
 void PQCLEAN_NTRUHPS4096821_CLEAN_owcpa_keypair(unsigned char *pk,
         unsigned char *sk,
-        const unsigned char seed[NTRU_SEEDBYTES]);
+        const unsigned char seed[NTRU_SAMPLE_FG_BYTES]);
 
 void PQCLEAN_NTRUHPS4096821_CLEAN_owcpa_enc(unsigned char *c,
         const poly *r,

--- a/crypto_kem/ntruhps4096821/clean/poly.c
+++ b/crypto_kem/ntruhps4096821/clean/poly.c
@@ -23,7 +23,15 @@ void PQCLEAN_NTRUHPS4096821_CLEAN_poly_Sq_mul(poly *r, const poly *a, const poly
 }
 
 void PQCLEAN_NTRUHPS4096821_CLEAN_poly_S3_mul(poly *r, const poly *a, const poly *b) {
+    int i;
+
+    /* Our S3 multiplications do not overflow mod q,    */
+    /* so we can re-purpose PQCLEAN_NTRUHPS4096821_CLEAN_poly_Rq_mul, as long as we  */
+    /* follow with an explicit reduction mod q.         */
     PQCLEAN_NTRUHPS4096821_CLEAN_poly_Rq_mul(r, a, b);
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = MODQ(r->coeffs[i]);
+    }
     PQCLEAN_NTRUHPS4096821_CLEAN_poly_mod_3_Phi_n(r);
 }
 

--- a/crypto_kem/ntruhps4096821/clean/poly_rq_mul.c
+++ b/crypto_kem/ntruhps4096821/clean/poly_rq_mul.c
@@ -1,15 +1,284 @@
 #include "poly.h"
 
-void PQCLEAN_NTRUHPS4096821_CLEAN_poly_Rq_mul(poly *r, const poly *a, const poly *b) {
-    int k, i;
+/* Polynomial multiplication using     */
+/* Toom-4 and two layers of Karatsuba. */
 
-    for (k = 0; k < NTRU_N; k++) {
-        r->coeffs[k] = 0;
-        for (i = 1; i < NTRU_N - k; i++) {
-            r->coeffs[k] += a->coeffs[k + i] * b->coeffs[NTRU_N - i];
-        }
-        for (i = 0; i < k + 1; i++) {
-            r->coeffs[k] += a->coeffs[k - i] * b->coeffs[i];
-        }
+#define L PAD32(NTRU_N)
+#define M (L/4)
+#define K (L/16)
+
+static void toom4_k2x2_mul(uint16_t ab[2 * L], const uint16_t a[L], const uint16_t b[L]);
+
+static void toom4_k2x2_eval_0(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p1(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_m1(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p2(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_m2(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p3(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_inf(uint16_t r[9 * K], const uint16_t a[M]);
+static inline void k2x2_eval(uint16_t r[9 * K]);
+
+static void toom4_k2x2_basemul(uint16_t r[18 * K], const uint16_t a[9 * K], const uint16_t b[9 * K]);
+static inline void schoolbook_KxK(uint16_t r[2 * K], const uint16_t a[K], const uint16_t b[K]);
+
+static void toom4_k2x2_interpolate(uint16_t r[2 * M], const uint16_t a[63 * 2 * K]);
+static inline void k2x2_interpolate(uint16_t r[M], const uint16_t a[9 * K]);
+
+void PQCLEAN_NTRUHPS4096821_CLEAN_poly_Rq_mul(poly *r, const poly *a, const poly *b) {
+    size_t i;
+    uint16_t ab[2 * L];
+
+    for (i = 0; i < NTRU_N; i++) {
+        ab[i] = a->coeffs[i];
+        ab[L + i] = b->coeffs[i];
+    }
+    for (i = NTRU_N; i < L; i++) {
+        ab[i] = 0;
+        ab[L + i] = 0;
+    }
+
+    toom4_k2x2_mul(ab, ab, ab + L);
+
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = ab[i] + ab[NTRU_N + i];
     }
 }
+
+static void toom4_k2x2_mul(uint16_t ab[2 * L], const uint16_t a[L], const uint16_t b[L]) {
+    uint16_t tmpA[9 * K];
+    uint16_t tmpB[9 * K];
+    uint16_t eC[63 * 2 * K];
+
+    toom4_k2x2_eval_0(tmpA, a);
+    toom4_k2x2_eval_0(tmpB, b);
+    toom4_k2x2_basemul(eC + 0 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p1(tmpA, a);
+    toom4_k2x2_eval_p1(tmpB, b);
+    toom4_k2x2_basemul(eC + 1 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_m1(tmpA, a);
+    toom4_k2x2_eval_m1(tmpB, b);
+    toom4_k2x2_basemul(eC + 2 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p2(tmpA, a);
+    toom4_k2x2_eval_p2(tmpB, b);
+    toom4_k2x2_basemul(eC + 3 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_m2(tmpA, a);
+    toom4_k2x2_eval_m2(tmpB, b);
+    toom4_k2x2_basemul(eC + 4 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p3(tmpA, a);
+    toom4_k2x2_eval_p3(tmpB, b);
+    toom4_k2x2_basemul(eC + 5 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_inf(tmpA, a);
+    toom4_k2x2_eval_inf(tmpB, b);
+    toom4_k2x2_basemul(eC + 6 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_interpolate(ab, eC);
+}
+
+
+static void toom4_k2x2_eval_0(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i] = a[i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p1(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += a[1 * M + i];
+        r[i] += a[2 * M + i];
+        r[i] += a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_m1(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] -= a[1 * M + i];
+        r[i] += a[2 * M + i];
+        r[i] -= a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p2(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += 2 * a[1 * M + i];
+        r[i] += 4 * a[2 * M + i];
+        r[i] += 8 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_m2(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] -= 2 * a[1 * M + i];
+        r[i] += 4 * a[2 * M + i];
+        r[i] -= 8 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p3(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += 3 * a[1 * M + i];
+        r[i] += 9 * a[2 * M + i];
+        r[i] += 27 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_inf(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i] = a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static inline void k2x2_eval(uint16_t r[9 * K]) {
+    /* Input:  e + f.Y + g.Y^2 + h.Y^3                              */
+    /* Output: [ e | f | g | h | e+f | f+h | g+e | h+g | e+f+g+h ]  */
+
+    size_t i;
+    for (i = 0; i < 4 * K; i++) {
+        r[4 * K + i] = r[i];
+    }
+    for (i = 0; i < K; i++) {
+        r[4 * K + i] += r[1 * K + i];
+        r[5 * K + i] += r[3 * K + i];
+        r[6 * K + i] += r[0 * K + i];
+        r[7 * K + i] += r[2 * K + i];
+        r[8 * K + i] = r[5 * K + i];
+        r[8 * K + i] += r[6 * K + i];
+    }
+}
+
+static void toom4_k2x2_basemul(uint16_t r[18 * K], const uint16_t a[9 * K], const uint16_t b[9 * K]) {
+    schoolbook_KxK(r + 0 * 2 * K, a + 0 * K, b + 0 * K);
+    schoolbook_KxK(r + 1 * 2 * K, a + 1 * K, b + 1 * K);
+    schoolbook_KxK(r + 2 * 2 * K, a + 2 * K, b + 2 * K);
+    schoolbook_KxK(r + 3 * 2 * K, a + 3 * K, b + 3 * K);
+    schoolbook_KxK(r + 4 * 2 * K, a + 4 * K, b + 4 * K);
+    schoolbook_KxK(r + 5 * 2 * K, a + 5 * K, b + 5 * K);
+    schoolbook_KxK(r + 6 * 2 * K, a + 6 * K, b + 6 * K);
+    schoolbook_KxK(r + 7 * 2 * K, a + 7 * K, b + 7 * K);
+    schoolbook_KxK(r + 8 * 2 * K, a + 8 * K, b + 8 * K);
+}
+
+static inline void schoolbook_KxK(uint16_t r[2 * K], const uint16_t a[K], const uint16_t b[K]) {
+    size_t i, j;
+    for (j = 0; j < K; j++) {
+        r[j] = a[0] * b[j];
+    }
+    for (i = 1; i < K; i++) {
+        for (j = 0; j < K - 1; j++) {
+            r[i + j] += a[i] * b[j];
+        }
+        r[i + K - 1] = a[i] * b[K - 1];
+    }
+    r[2 * K - 1] = 0;
+}
+
+static void toom4_k2x2_interpolate(uint16_t r[2 * M], const uint16_t a[7 * 18 * K]) {
+    size_t i;
+
+    uint16_t P1[2 * M];
+    uint16_t Pm1[2 * M];
+    uint16_t P2[2 * M];
+    uint16_t Pm2[2 * M];
+
+    uint16_t *C0 = r;
+    uint16_t *C2 = r + 2 * M;
+    uint16_t *C4 = r + 4 * M;
+    uint16_t *C6 = r + 6 * M;
+
+    uint16_t V0, V1, V2;
+
+    k2x2_interpolate(C0, a + 0 * 9 * 2 * K);
+    k2x2_interpolate(P1, a + 1 * 9 * 2 * K);
+    k2x2_interpolate(Pm1, a + 2 * 9 * 2 * K);
+    k2x2_interpolate(P2, a + 3 * 9 * 2 * K);
+    k2x2_interpolate(Pm2, a + 4 * 9 * 2 * K);
+    k2x2_interpolate(C6, a + 6 * 9 * 2 * K);
+
+    for (i = 0; i < 2 * M; i++) {
+        V0 = ((uint32_t)(P1[i] + Pm1[i])) >> 1;
+        V0 = V0 - C0[i] - C6[i];
+        V1 = ((uint32_t)(P2[i] + Pm2[i] - 2 * C0[i] - 128 * C6[i])) >> 3;
+        C4[i] = 43691 * (V1 - V0);
+        C2[i] = V0 - C4[i];
+        P1[i] = ((uint32_t)(P1[i] - Pm1[i])) >> 1;
+    }
+
+    /* reuse Pm1 for P3 */
+#define P3 Pm1
+    k2x2_interpolate(P3, a + 5 * 9 * 2 * K);
+
+    for (i = 0; i < 2 * M; i++) {
+        V0 = P1[i];
+        V1 = 43691 * ((((uint32_t)(P2[i] - Pm2[i])) >> 2) - V0);
+        V2 = 43691 * (P3[i] - C0[i] - 9 * (C2[i] + 9 * (C4[i] + 9 * C6[i])));
+        V2 = ((uint32_t)(V2 - V0)) >> 3;
+        V2 -= V1;
+        P3[i] = 52429 * V2;
+        P2[i] = V1 - V2;
+        P1[i] = V0 - P2[i] - P3[i];
+    }
+
+    for (i = 0; i < 2 * M; i++) {
+        r[1 * M + i] += P1[i];
+        r[3 * M + i] += P2[i];
+        r[5 * M + i] += P3[i];
+    }
+}
+
+static inline void k2x2_interpolate(uint16_t r[M], const uint16_t a[9 * K]) {
+    size_t i;
+    uint16_t tmp[4 * K];
+
+    for (i = 0; i < 2 * K; i++) {
+        r[0 * K + i] = a[0 * K + i];
+        r[2 * K + i] = a[2 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[1 * K + i] += a[8 * K + i] - a[0 * K + i] - a[2 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[4 * K + i] = a[4 * K + i];
+        r[6 * K + i] = a[6 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[5 * K + i] += a[14 * K + i] - a[4 * K + i] - a[6 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        tmp[0 * K + i] = a[12 * K + i];
+        tmp[2 * K + i] = a[10 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        tmp[K + i] += a[16 * K + i] - a[12 * K + i] - a[10 * K + i];
+    }
+
+    for (i = 0; i < 4 * K; i++) {
+        tmp[0 * K + i] = tmp[0 * K + i] - r[0 * K + i] - r[4 * K + i];
+    }
+
+    for (i = 0; i < 4 * K; i++) {
+        r[2 * K + i] += tmp[0 * K + i];
+    }
+}
+

--- a/crypto_kem/ntruhrss701/META.yml
+++ b/crypto_kem/ntruhrss701/META.yml
@@ -23,9 +23,9 @@ auxiliary-submitters:
   - Zhenfei Zhang
 implementations:
     - name: clean
-      version: https://github.com/jschanck/ntru/tree/6d1f44f5 reference implementation
+      version: https://github.com/jschanck/ntru/tree/60cc7277 reference implementation
     - name: avx2
-      version: https://github.com/jschanck/ntru/tree/6d1f44f5 avx2 implementation
+      version: https://github.com/jschanck/ntru/tree/60cc7277 avx2 implementation
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/ntruhrss701/avx2/owcpa.h
+++ b/crypto_kem/ntruhrss701/avx2/owcpa.h
@@ -4,12 +4,9 @@
 #include "params.h"
 #include "poly.h"
 
-void PQCLEAN_NTRUHRSS701_AVX2_owcpa_samplemsg(unsigned char msg[NTRU_OWCPA_MSGBYTES],
-        const unsigned char seed[NTRU_SEEDBYTES]);
-
 void PQCLEAN_NTRUHRSS701_AVX2_owcpa_keypair(unsigned char *pk,
         unsigned char *sk,
-        const unsigned char seed[NTRU_SEEDBYTES]);
+        const unsigned char seed[NTRU_SAMPLE_FG_BYTES]);
 
 void PQCLEAN_NTRUHRSS701_AVX2_owcpa_enc(unsigned char *c,
                                         const poly *r,

--- a/crypto_kem/ntruhrss701/avx2/poly.c
+++ b/crypto_kem/ntruhrss701/avx2/poly.c
@@ -23,7 +23,15 @@ void PQCLEAN_NTRUHRSS701_AVX2_poly_Sq_mul(poly *r, const poly *a, const poly *b)
 }
 
 void PQCLEAN_NTRUHRSS701_AVX2_poly_S3_mul(poly *r, const poly *a, const poly *b) {
+    int i;
+
+    /* Our S3 multiplications do not overflow mod q,    */
+    /* so we can re-purpose PQCLEAN_NTRUHRSS701_AVX2_poly_Rq_mul, as long as we  */
+    /* follow with an explicit reduction mod q.         */
     PQCLEAN_NTRUHRSS701_AVX2_poly_Rq_mul(r, a, b);
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = MODQ(r->coeffs[i]);
+    }
     PQCLEAN_NTRUHRSS701_AVX2_poly_mod_3_Phi_n(r);
 }
 

--- a/crypto_kem/ntruhrss701/avx2/poly_lift.s
+++ b/crypto_kem/ntruhrss701/avx2/poly_lift.s
@@ -237,23 +237,6 @@ shuf_128_to_64:
 .byte 255
 .byte 255
 .byte 255
-const_1s:
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
-.word 1
 const_modq:
 .word 8191
 .word 8191
@@ -288,57 +271,23 @@ mask_n:
 .word 0
 .word 0
 .word 0
-mask_mod8192:
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-mask_mod8192_omit_lowest:
+mask_omit_lowest:
 .word 0
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-mask_mod8192_only_lowest:
-.word 8191
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
-.word 0
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
+.word 0xFFFF
 shuf_5_to_0_zerorest:
 .byte 10
 .byte 11
@@ -2161,7 +2110,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 0(%rsp)
 vpaddw 32(%rsp), %ymm1, %ymm2
@@ -2185,7 +2133,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 32(%rsp)
 vpaddw 64(%rsp), %ymm1, %ymm2
@@ -2209,7 +2156,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 64(%rsp)
 vpaddw 96(%rsp), %ymm1, %ymm2
@@ -2233,7 +2179,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 96(%rsp)
 vpaddw 128(%rsp), %ymm1, %ymm2
@@ -2257,7 +2202,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 128(%rsp)
 vpaddw 160(%rsp), %ymm1, %ymm2
@@ -2281,7 +2225,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 160(%rsp)
 vpaddw 192(%rsp), %ymm1, %ymm2
@@ -2305,7 +2248,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 192(%rsp)
 vpaddw 224(%rsp), %ymm1, %ymm2
@@ -2329,7 +2271,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 224(%rsp)
 vpaddw 256(%rsp), %ymm1, %ymm2
@@ -2353,7 +2294,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 256(%rsp)
 vpaddw 288(%rsp), %ymm1, %ymm2
@@ -2377,7 +2317,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 288(%rsp)
 vpaddw 320(%rsp), %ymm1, %ymm2
@@ -2401,7 +2340,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 320(%rsp)
 vpaddw 352(%rsp), %ymm1, %ymm2
@@ -2425,7 +2363,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 352(%rsp)
 vpaddw 384(%rsp), %ymm1, %ymm2
@@ -2449,7 +2386,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 384(%rsp)
 vpaddw 416(%rsp), %ymm1, %ymm2
@@ -2473,7 +2409,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 416(%rsp)
 vpaddw 448(%rsp), %ymm1, %ymm2
@@ -2497,7 +2432,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 448(%rsp)
 vpaddw 480(%rsp), %ymm1, %ymm2
@@ -2521,7 +2455,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 480(%rsp)
 vpaddw 512(%rsp), %ymm1, %ymm2
@@ -2545,7 +2478,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 512(%rsp)
 vpaddw 544(%rsp), %ymm1, %ymm2
@@ -2569,7 +2501,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 544(%rsp)
 vpaddw 576(%rsp), %ymm1, %ymm2
@@ -2593,7 +2524,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 576(%rsp)
 vpaddw 608(%rsp), %ymm1, %ymm2
@@ -2617,7 +2547,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 608(%rsp)
 vpaddw 640(%rsp), %ymm1, %ymm2
@@ -2641,7 +2570,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 640(%rsp)
 vpaddw 672(%rsp), %ymm1, %ymm2
@@ -2665,7 +2593,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 672(%rsp)
 vpaddw 704(%rsp), %ymm1, %ymm2
@@ -2689,7 +2616,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 704(%rsp)
 vpaddw 736(%rsp), %ymm1, %ymm2
@@ -2713,7 +2639,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 736(%rsp)
 vpaddw 768(%rsp), %ymm1, %ymm2
@@ -2737,7 +2662,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 768(%rsp)
 vpaddw 800(%rsp), %ymm1, %ymm2
@@ -2761,7 +2685,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 800(%rsp)
 vpaddw 832(%rsp), %ymm1, %ymm2
@@ -2785,7 +2708,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 832(%rsp)
 vpaddw 864(%rsp), %ymm1, %ymm2
@@ -2809,7 +2731,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 864(%rsp)
 vpaddw 896(%rsp), %ymm1, %ymm2
@@ -2833,7 +2754,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 896(%rsp)
 vpaddw 928(%rsp), %ymm1, %ymm2
@@ -2857,7 +2777,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 928(%rsp)
 vpaddw 960(%rsp), %ymm1, %ymm2
@@ -2881,7 +2800,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 960(%rsp)
 vpaddw 992(%rsp), %ymm1, %ymm2
@@ -2905,7 +2823,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 992(%rsp)
 vpaddw 1024(%rsp), %ymm1, %ymm2
@@ -2929,7 +2846,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1024(%rsp)
 vpaddw 1056(%rsp), %ymm1, %ymm2
@@ -2953,7 +2869,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1056(%rsp)
 vpaddw 1088(%rsp), %ymm1, %ymm2
@@ -2977,7 +2892,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1088(%rsp)
 vpaddw 1120(%rsp), %ymm1, %ymm2
@@ -3001,7 +2915,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1120(%rsp)
 vpaddw 1152(%rsp), %ymm1, %ymm2
@@ -3025,7 +2938,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1152(%rsp)
 vpaddw 1184(%rsp), %ymm1, %ymm2
@@ -3049,7 +2961,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1184(%rsp)
 vpaddw 1216(%rsp), %ymm1, %ymm2
@@ -3073,7 +2984,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1216(%rsp)
 vpaddw 1248(%rsp), %ymm1, %ymm2
@@ -3097,7 +3007,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1248(%rsp)
 vpaddw 1280(%rsp), %ymm1, %ymm2
@@ -3121,7 +3030,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1280(%rsp)
 vpaddw 1312(%rsp), %ymm1, %ymm2
@@ -3145,7 +3053,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1312(%rsp)
 vpaddw 1344(%rsp), %ymm1, %ymm2
@@ -3169,7 +3076,6 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1344(%rsp)
 vpaddw 1376(%rsp), %ymm1, %ymm2
@@ -3193,184 +3099,140 @@ vpxor %ymm14, %ymm2, %ymm3
 vpsrlq $1, %ymm3, %ymm2
 vpsubw %ymm2, %ymm0, %ymm2
 vpand const_modq(%rip), %ymm2, %ymm2
-vpand const_1s(%rip), %ymm3, %ymm3
 vpor %ymm3, %ymm2, %ymm3
 vmovdqa %ymm3, 1376(%rsp)
 vmovdqu 1374(%rsp), %ymm0
 vpsubw 1376(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1376(%rdi)
 vextracti128 $1, %ymm0, %xmm4
 vpshufb shuf_5_to_0_zerorest(%rip), %ymm4, %ymm4
 vpsubw 0(%rsp), %ymm4, %ymm4
-vpand mask_mod8192_only_lowest(%rip), %ymm4, %ymm4
+vpand coeff_0(%rip), %ymm4, %ymm4
 vmovdqu 1342(%rsp), %ymm0
 vpsubw 1344(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1344(%rdi)
 vmovdqu 1310(%rsp), %ymm0
 vpsubw 1312(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1312(%rdi)
 vmovdqu 1278(%rsp), %ymm0
 vpsubw 1280(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1280(%rdi)
 vmovdqu 1246(%rsp), %ymm0
 vpsubw 1248(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1248(%rdi)
 vmovdqu 1214(%rsp), %ymm0
 vpsubw 1216(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1216(%rdi)
 vmovdqu 1182(%rsp), %ymm0
 vpsubw 1184(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1184(%rdi)
 vmovdqu 1150(%rsp), %ymm0
 vpsubw 1152(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1152(%rdi)
 vmovdqu 1118(%rsp), %ymm0
 vpsubw 1120(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1120(%rdi)
 vmovdqu 1086(%rsp), %ymm0
 vpsubw 1088(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1088(%rdi)
 vmovdqu 1054(%rsp), %ymm0
 vpsubw 1056(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1056(%rdi)
 vmovdqu 1022(%rsp), %ymm0
 vpsubw 1024(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 1024(%rdi)
 vmovdqu 990(%rsp), %ymm0
 vpsubw 992(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 992(%rdi)
 vmovdqu 958(%rsp), %ymm0
 vpsubw 960(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 960(%rdi)
 vmovdqu 926(%rsp), %ymm0
 vpsubw 928(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 928(%rdi)
 vmovdqu 894(%rsp), %ymm0
 vpsubw 896(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 896(%rdi)
 vmovdqu 862(%rsp), %ymm0
 vpsubw 864(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 864(%rdi)
 vmovdqu 830(%rsp), %ymm0
 vpsubw 832(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 832(%rdi)
 vmovdqu 798(%rsp), %ymm0
 vpsubw 800(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 800(%rdi)
 vmovdqu 766(%rsp), %ymm0
 vpsubw 768(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 768(%rdi)
 vmovdqu 734(%rsp), %ymm0
 vpsubw 736(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 736(%rdi)
 vmovdqu 702(%rsp), %ymm0
 vpsubw 704(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 704(%rdi)
 vmovdqu 670(%rsp), %ymm0
 vpsubw 672(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 672(%rdi)
 vmovdqu 638(%rsp), %ymm0
 vpsubw 640(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 640(%rdi)
 vmovdqu 606(%rsp), %ymm0
 vpsubw 608(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 608(%rdi)
 vmovdqu 574(%rsp), %ymm0
 vpsubw 576(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 576(%rdi)
 vmovdqu 542(%rsp), %ymm0
 vpsubw 544(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 544(%rdi)
 vmovdqu 510(%rsp), %ymm0
 vpsubw 512(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 512(%rdi)
 vmovdqu 478(%rsp), %ymm0
 vpsubw 480(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 480(%rdi)
 vmovdqu 446(%rsp), %ymm0
 vpsubw 448(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 448(%rdi)
 vmovdqu 414(%rsp), %ymm0
 vpsubw 416(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 416(%rdi)
 vmovdqu 382(%rsp), %ymm0
 vpsubw 384(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 384(%rdi)
 vmovdqu 350(%rsp), %ymm0
 vpsubw 352(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 352(%rdi)
 vmovdqu 318(%rsp), %ymm0
 vpsubw 320(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 320(%rdi)
 vmovdqu 286(%rsp), %ymm0
 vpsubw 288(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 288(%rdi)
 vmovdqu 254(%rsp), %ymm0
 vpsubw 256(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 256(%rdi)
 vmovdqu 222(%rsp), %ymm0
 vpsubw 224(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 224(%rdi)
 vmovdqu 190(%rsp), %ymm0
 vpsubw 192(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 192(%rdi)
 vmovdqu 158(%rsp), %ymm0
 vpsubw 160(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 160(%rdi)
 vmovdqu 126(%rsp), %ymm0
 vpsubw 128(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 128(%rdi)
 vmovdqu 94(%rsp), %ymm0
 vpsubw 96(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 96(%rdi)
 vmovdqu 62(%rsp), %ymm0
 vpsubw 64(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 64(%rdi)
 vmovdqu 30(%rsp), %ymm0
 vpsubw 32(%rsp), %ymm0, %ymm1
-vpand mask_mod8192(%rip), %ymm1, %ymm1
 vmovdqa %ymm1, 32(%rdi)
 vmovdqa 0(%rsp), %ymm3
 vpsrlq $48, %ymm3, %ymm0
@@ -3378,7 +3240,7 @@ vpermq $147, %ymm0, %ymm0
 vpsllq $16, %ymm3, %ymm2
 vpxor %ymm0, %ymm2, %ymm2
 vpsubw %ymm3, %ymm2, %ymm3
-vpand mask_mod8192_omit_lowest(%rip), %ymm3, %ymm3
+vpand mask_omit_lowest(%rip), %ymm3, %ymm3
 vpxor %ymm3, %ymm4, %ymm3
 vmovdqa %ymm3, 0(%rdi)
 mov %r8, %rsp

--- a/crypto_kem/ntruhrss701/avx2/poly_rq_mul.s
+++ b/crypto_kem/ntruhrss701/avx2/poly_rq_mul.s
@@ -303,23 +303,6 @@ mask_keephigh:
 .word 65535
 .word 65535
 .word 65535
-mask_mod8192:
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
-.word 8191
 .text
 .global PQCLEAN_NTRUHRSS701_AVX2_poly_Rq_mul
 .global _PQCLEAN_NTRUHRSS701_AVX2_poly_Rq_mul
@@ -5213,13 +5196,9 @@ vpand mask_keephigh(%rip), %ymm9, %ymm10
 vpor %ymm10, %ymm5, %ymm5
 vpaddw %ymm5, %ymm3, %ymm3
 vmovdqa %xmm9, 2560(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 0(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 352(%rdi)
-vpand mask_mod8192(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 704(%rdi)
-vpand mask_mod8192(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 1056(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm8
@@ -5309,13 +5288,9 @@ vpand mask_keephigh(%rip), %ymm7, %ymm8
 vpor %ymm8, %ymm11, %ymm11
 vpaddw %ymm11, %ymm10, %ymm10
 vmovdqa %xmm7, 2592(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %ymm5, 88(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 440(%rdi)
-vpand mask_mod8192(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 792(%rdi)
-vpand mask_mod8192(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1144(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm4
@@ -5405,13 +5380,9 @@ vpand mask_keephigh(%rip), %ymm3, %ymm4
 vpor %ymm4, %ymm5, %ymm5
 vpaddw %ymm5, %ymm8, %ymm8
 vmovdqa %xmm3, 2624(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 176(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 528(%rdi)
-vpand mask_mod8192(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 880(%rdi)
-vpand mask_mod8192(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1232(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm9
@@ -5501,13 +5472,9 @@ vpand mask_keephigh(%rip), %ymm10, %ymm9
 vpor %ymm9, %ymm11, %ymm11
 vpaddw %ymm11, %ymm4, %ymm4
 vmovdqa %xmm10, 2656(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %ymm5, 264(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 616(%rdi)
-vpand mask_mod8192(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 968(%rdi)
-vpand mask_mod8192(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1320(%rdi)
 vmovdqa 128(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm7
@@ -5587,7 +5554,6 @@ vpand mask_keephigh(%rip), %ymm2, %ymm7
 vpor %ymm7, %ymm10, %ymm10
 vmovdqu 0(%rdi), %ymm7
 vpaddw %ymm10, %ymm7, %ymm7
-vpand mask_mod8192(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 0(%rdi)
 vmovdqa %xmm2, 1920(%rsp)
 vpshufb shuf48_16(%rip), %ymm4, %ymm4
@@ -5614,11 +5580,8 @@ vpand mask_keephigh(%rip), %ymm2, %ymm7
 vpor %ymm7, %ymm5, %ymm5
 vpaddw %ymm5, %ymm9, %ymm9
 vmovdqa %xmm2, 2688(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 352(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 704(%rdi)
-vpand mask_mod8192(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1056(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -5698,7 +5661,6 @@ vpand mask_keephigh(%rip), %ymm8, %ymm3
 vpor %ymm3, %ymm2, %ymm2
 vmovdqu 88(%rdi), %ymm3
 vpaddw %ymm2, %ymm3, %ymm3
-vpand mask_mod8192(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 88(%rdi)
 vmovdqa %xmm8, 1952(%rsp)
 vpshufb shuf48_16(%rip), %ymm9, %ymm9
@@ -5725,11 +5687,8 @@ vpand mask_keephigh(%rip), %ymm8, %ymm3
 vpor %ymm3, %ymm11, %ymm11
 vpaddw %ymm11, %ymm7, %ymm7
 vmovdqa %xmm8, 2720(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %ymm5, 440(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 792(%rdi)
-vpand mask_mod8192(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 1144(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm10
@@ -5809,7 +5768,6 @@ vpand mask_keephigh(%rip), %ymm4, %ymm10
 vpor %ymm10, %ymm8, %ymm8
 vmovdqu 176(%rdi), %ymm10
 vpaddw %ymm8, %ymm10, %ymm10
-vpand mask_mod8192(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 176(%rdi)
 vmovdqa %xmm4, 1984(%rsp)
 vpshufb shuf48_16(%rip), %ymm7, %ymm7
@@ -5836,11 +5794,8 @@ vpand mask_keephigh(%rip), %ymm4, %ymm10
 vpor %ymm10, %ymm5, %ymm5
 vpaddw %ymm5, %ymm3, %ymm3
 vmovdqa %xmm4, 2752(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 528(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 880(%rdi)
-vpand mask_mod8192(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1232(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm2
@@ -5920,7 +5875,6 @@ vpand mask_keephigh(%rip), %ymm9, %ymm2
 vpor %ymm2, %ymm4, %ymm4
 vmovdqu 264(%rdi), %ymm2
 vpaddw %ymm4, %ymm2, %ymm2
-vpand mask_mod8192(%rip), %ymm2, %ymm2
 vmovdqu %ymm2, 264(%rdi)
 vmovdqa %xmm9, 2016(%rsp)
 vpshufb shuf48_16(%rip), %ymm3, %ymm3
@@ -5947,11 +5901,8 @@ vpand mask_keephigh(%rip), %ymm9, %ymm2
 vpor %ymm2, %ymm11, %ymm11
 vpaddw %ymm11, %ymm10, %ymm10
 vmovdqa %xmm9, 2784(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %ymm5, 616(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 968(%rdi)
-vpand mask_mod8192(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1320(%rdi)
 vmovdqa 128(%r12), %ymm0
 vpsubw 224(%r12), %ymm0, %ymm0
@@ -6345,13 +6296,9 @@ vpor %ymm8, %ymm5, %ymm5
 vpaddw 2560(%rsp), %ymm2, %ymm2
 vpaddw %ymm5, %ymm2, %ymm2
 vmovdqa %xmm3, 2560(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 32(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 384(%rdi)
-vpand mask_mod8192(%rip), %ymm2, %ymm2
 vmovdqu %ymm2, 736(%rdi)
-vpand mask_mod8192(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1088(%rdi)
 vmovdqa 32(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm4
@@ -6444,13 +6391,9 @@ vpor %ymm4, %ymm11, %ymm11
 vpaddw 2592(%rsp), %ymm8, %ymm8
 vpaddw %ymm11, %ymm8, %ymm8
 vmovdqa %xmm10, 2592(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %ymm5, 120(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 472(%rdi)
-vpand mask_mod8192(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 824(%rdi)
-vpand mask_mod8192(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1176(%rdi)
 vmovdqa 64(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm9
@@ -6543,13 +6486,9 @@ vpor %ymm9, %ymm5, %ymm5
 vpaddw 2624(%rsp), %ymm4, %ymm4
 vpaddw %ymm5, %ymm4, %ymm4
 vmovdqa %xmm2, 2624(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 208(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 560(%rdi)
-vpand mask_mod8192(%rip), %ymm4, %ymm4
 vmovdqu %ymm4, 912(%rdi)
-vpand mask_mod8192(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1264(%rdi)
 vmovdqa 96(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm3
@@ -6642,13 +6581,9 @@ vpor %ymm3, %ymm11, %ymm11
 vpaddw 2656(%rsp), %ymm9, %ymm9
 vpaddw %ymm11, %ymm9, %ymm9
 vmovdqa %xmm8, 2656(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %ymm5, 296(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 648(%rdi)
-vpand mask_mod8192(%rip), %ymm9, %ymm9
 vmovdqu %ymm9, 1000(%rdi)
-vpand mask_mod8192(%rip), %ymm2, %ymm2
 vmovdqu %ymm2, 1352(%rdi)
 vmovdqa 128(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm10
@@ -6729,7 +6664,6 @@ vpor %ymm10, %ymm8, %ymm8
 vmovdqu 32(%rdi), %ymm10
 vpaddw 1920(%rsp), %ymm10, %ymm10
 vpaddw %ymm8, %ymm10, %ymm10
-vpand mask_mod8192(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 32(%rdi)
 vmovdqa %xmm7, 1920(%rsp)
 vpshufb shuf48_16(%rip), %ymm9, %ymm9
@@ -6759,11 +6693,8 @@ vpor %ymm10, %ymm5, %ymm5
 vpaddw 2688(%rsp), %ymm3, %ymm3
 vpaddw %ymm5, %ymm3, %ymm3
 vmovdqa %xmm7, 2688(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 384(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 736(%rdi)
-vpand mask_mod8192(%rip), %ymm3, %ymm3
 vmovdqu %ymm3, 1088(%rdi)
 vmovdqa 160(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm2
@@ -6844,7 +6775,6 @@ vpor %ymm2, %ymm7, %ymm7
 vmovdqu 120(%rdi), %ymm2
 vpaddw 1952(%rsp), %ymm2, %ymm2
 vpaddw %ymm7, %ymm2, %ymm2
-vpand mask_mod8192(%rip), %ymm2, %ymm2
 vmovdqu %ymm2, 120(%rdi)
 vmovdqa %xmm4, 1952(%rsp)
 vpshufb shuf48_16(%rip), %ymm3, %ymm3
@@ -6874,11 +6804,8 @@ vpor %ymm2, %ymm11, %ymm11
 vpaddw 2720(%rsp), %ymm10, %ymm10
 vpaddw %ymm11, %ymm10, %ymm10
 vmovdqa %xmm4, 2720(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %ymm5, 472(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 824(%rdi)
-vpand mask_mod8192(%rip), %ymm10, %ymm10
 vmovdqu %ymm10, 1176(%rdi)
 vmovdqa 192(%rsp), %ymm11
 vpunpcklwd const0(%rip), %ymm11, %ymm8
@@ -6959,7 +6886,6 @@ vpor %ymm8, %ymm4, %ymm4
 vmovdqu 208(%rdi), %ymm8
 vpaddw 1984(%rsp), %ymm8, %ymm8
 vpaddw %ymm4, %ymm8, %ymm8
-vpand mask_mod8192(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 208(%rdi)
 vmovdqa %xmm9, 1984(%rsp)
 vpshufb shuf48_16(%rip), %ymm10, %ymm10
@@ -6989,11 +6915,8 @@ vpor %ymm8, %ymm5, %ymm5
 vpaddw 2752(%rsp), %ymm2, %ymm2
 vpaddw %ymm5, %ymm2, %ymm2
 vmovdqa %xmm9, 2752(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 560(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 912(%rdi)
-vpand mask_mod8192(%rip), %ymm2, %ymm2
 vmovdqu %ymm2, 1264(%rdi)
 vmovdqa 224(%rsp), %ymm5
 vpunpcklwd const0(%rip), %ymm5, %ymm7
@@ -7074,7 +6997,6 @@ vpor %ymm7, %ymm9, %ymm9
 vmovdqu 296(%rdi), %ymm7
 vpaddw 2016(%rsp), %ymm7, %ymm7
 vpaddw %ymm9, %ymm7, %ymm7
-vpand mask_mod8192(%rip), %ymm7, %ymm7
 vmovdqu %ymm7, 296(%rdi)
 vmovdqa %xmm3, 2016(%rsp)
 vpshufb shuf48_16(%rip), %ymm2, %ymm2
@@ -7104,11 +7026,8 @@ vpor %ymm7, %ymm11, %ymm11
 vpaddw 2784(%rsp), %ymm8, %ymm8
 vpaddw %ymm11, %ymm8, %ymm8
 vmovdqa %xmm3, 2784(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %ymm5, 648(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %ymm6, 1000(%rdi)
-vpand mask_mod8192(%rip), %ymm8, %ymm8
 vmovdqu %ymm8, 1352(%rdi)
 vmovdqa 160(%r12), %ymm0
 vpsubw 256(%r12), %ymm0, %ymm0
@@ -7502,19 +7421,15 @@ vpor %ymm4, %ymm5, %ymm5
 vpaddw 2560(%rsp), %ymm7, %ymm7
 vpaddw %ymm5, %ymm7, %ymm7
 vmovdqa %xmm2, 2560(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %xmm11, 64(%rdi)
 vextracti128 $1, %ymm11, %xmm11
 vmovq %xmm11, 80(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %xmm6, 416(%rdi)
 vextracti128 $1, %ymm6, %xmm6
 vmovq %xmm6, 432(%rdi)
-vpand mask_mod8192(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 768(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 784(%rdi)
-vpand mask_mod8192(%rip), %ymm3, %ymm3
 vmovdqu %xmm3, 1120(%rdi)
 vextracti128 $1, %ymm3, %xmm3
 vmovq %xmm3, 1136(%rdi)
@@ -7609,19 +7524,15 @@ vpor %ymm9, %ymm11, %ymm11
 vpaddw 2592(%rsp), %ymm4, %ymm4
 vpaddw %ymm11, %ymm4, %ymm4
 vmovdqa %xmm8, 2592(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %xmm5, 152(%rdi)
 vextracti128 $1, %ymm5, %xmm5
 vmovq %xmm5, 168(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %xmm6, 504(%rdi)
 vextracti128 $1, %ymm6, %xmm6
 vmovq %xmm6, 520(%rdi)
-vpand mask_mod8192(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 856(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 872(%rdi)
-vpand mask_mod8192(%rip), %ymm2, %ymm2
 vmovdqu %xmm2, 1208(%rdi)
 vextracti128 $1, %ymm2, %xmm2
 vmovq %xmm2, 1224(%rdi)
@@ -7716,19 +7627,15 @@ vpor %ymm3, %ymm5, %ymm5
 vpaddw 2624(%rsp), %ymm9, %ymm9
 vpaddw %ymm5, %ymm9, %ymm9
 vmovdqa %xmm7, 2624(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %xmm11, 240(%rdi)
 vextracti128 $1, %ymm11, %xmm11
 vmovq %xmm11, 256(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %xmm6, 592(%rdi)
 vextracti128 $1, %ymm6, %xmm6
 vmovq %xmm6, 608(%rdi)
-vpand mask_mod8192(%rip), %ymm9, %ymm9
 vmovdqu %xmm9, 944(%rdi)
 vextracti128 $1, %ymm9, %xmm9
 vmovq %xmm9, 960(%rdi)
-vpand mask_mod8192(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 1296(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 1312(%rdi)
@@ -7823,25 +7730,21 @@ vpor %ymm2, %ymm11, %ymm11
 vpaddw 2656(%rsp), %ymm3, %ymm3
 vpaddw %ymm11, %ymm3, %ymm3
 vmovdqa %xmm4, 2656(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %xmm5, 328(%rdi)
 vextracti128 $1, %ymm5, %xmm5
 vmovq %xmm5, 344(%rdi)
 vpshufb shufmin1_mask3(%rip), %ymm5, %ymm5
 vmovdqa %xmm5, 1792(%rsp)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %xmm6, 680(%rdi)
 vextracti128 $1, %ymm6, %xmm6
 vmovq %xmm6, 696(%rdi)
 vpshufb shufmin1_mask3(%rip), %ymm6, %ymm6
 vmovdqa %xmm6, 1824(%rsp)
-vpand mask_mod8192(%rip), %ymm3, %ymm3
 vmovdqu %xmm3, 1032(%rdi)
 vextracti128 $1, %ymm3, %xmm3
 vmovq %xmm3, 1048(%rdi)
 vpshufb shufmin1_mask3(%rip), %ymm3, %ymm3
 vmovdqa %xmm3, 1856(%rsp)
-vpand mask_mod8192(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 1384(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 1400(%rdi)
@@ -7926,7 +7829,6 @@ vpor %ymm8, %ymm4, %ymm4
 vmovdqu 64(%rdi), %ymm8
 vpaddw 1920(%rsp), %ymm8, %ymm8
 vpaddw %ymm4, %ymm8, %ymm8
-vpand mask_mod8192(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 64(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 80(%rdi)
@@ -7958,15 +7860,12 @@ vpor %ymm8, %ymm5, %ymm5
 vpaddw 2688(%rsp), %ymm2, %ymm2
 vpaddw %ymm5, %ymm2, %ymm2
 vmovdqa %xmm10, 2688(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %xmm11, 416(%rdi)
 vextracti128 $1, %ymm11, %xmm11
 vmovq %xmm11, 432(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %xmm6, 768(%rdi)
 vextracti128 $1, %ymm6, %xmm6
 vmovq %xmm6, 784(%rdi)
-vpand mask_mod8192(%rip), %ymm2, %ymm2
 vmovdqu %xmm2, 1120(%rdi)
 vextracti128 $1, %ymm2, %xmm2
 vmovq %xmm2, 1136(%rdi)
@@ -8049,7 +7948,6 @@ vpor %ymm7, %ymm10, %ymm10
 vmovdqu 152(%rdi), %ymm7
 vpaddw 1952(%rsp), %ymm7, %ymm7
 vpaddw %ymm10, %ymm7, %ymm7
-vpand mask_mod8192(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 152(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 168(%rdi)
@@ -8081,15 +7979,12 @@ vpor %ymm7, %ymm11, %ymm11
 vpaddw 2720(%rsp), %ymm8, %ymm8
 vpaddw %ymm11, %ymm8, %ymm8
 vmovdqa %xmm9, 2720(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %xmm5, 504(%rdi)
 vextracti128 $1, %ymm5, %xmm5
 vmovq %xmm5, 520(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %xmm6, 856(%rdi)
 vextracti128 $1, %ymm6, %xmm6
 vmovq %xmm6, 872(%rdi)
-vpand mask_mod8192(%rip), %ymm8, %ymm8
 vmovdqu %xmm8, 1208(%rdi)
 vextracti128 $1, %ymm8, %xmm8
 vmovq %xmm8, 1224(%rdi)
@@ -8172,7 +8067,6 @@ vpor %ymm4, %ymm9, %ymm9
 vmovdqu 240(%rdi), %ymm4
 vpaddw 1984(%rsp), %ymm4, %ymm4
 vpaddw %ymm9, %ymm4, %ymm4
-vpand mask_mod8192(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 240(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 256(%rdi)
@@ -8204,15 +8098,12 @@ vpor %ymm4, %ymm5, %ymm5
 vpaddw 2752(%rsp), %ymm7, %ymm7
 vpaddw %ymm5, %ymm7, %ymm7
 vmovdqa %xmm3, 2752(%rsp)
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %xmm11, 592(%rdi)
 vextracti128 $1, %ymm11, %xmm11
 vmovq %xmm11, 608(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %xmm6, 944(%rdi)
 vextracti128 $1, %ymm6, %xmm6
 vmovq %xmm6, 960(%rdi)
-vpand mask_mod8192(%rip), %ymm7, %ymm7
 vmovdqu %xmm7, 1296(%rdi)
 vextracti128 $1, %ymm7, %xmm7
 vmovq %xmm7, 1312(%rdi)
@@ -8304,7 +8195,6 @@ vpor %ymm10, %ymm3, %ymm3
 vmovdqu 328(%rdi), %ymm10
 vpaddw 2016(%rsp), %ymm10, %ymm10
 vpaddw %ymm3, %ymm10, %ymm10
-vpand mask_mod8192(%rip), %ymm10, %ymm10
 vmovdqu %xmm10, 328(%rdi)
 vextracti128 $1, %ymm10, %xmm10
 vmovq %xmm10, 344(%rdi)
@@ -8338,119 +8228,92 @@ vpor %ymm10, %ymm11, %ymm11
 vpaddw 2784(%rsp), %ymm4, %ymm4
 vpaddw %ymm11, %ymm4, %ymm4
 vmovdqa %xmm2, 2784(%rsp)
-vpand mask_mod8192(%rip), %ymm5, %ymm5
 vmovdqu %xmm5, 680(%rdi)
 vextracti128 $1, %ymm5, %xmm5
 vmovq %xmm5, 696(%rdi)
-vpand mask_mod8192(%rip), %ymm6, %ymm6
 vmovdqu %xmm6, 1032(%rdi)
 vextracti128 $1, %ymm6, %xmm6
 vmovq %xmm6, 1048(%rdi)
-vpand mask_mod8192(%rip), %ymm4, %ymm4
 vmovdqu %xmm4, 1384(%rdi)
 vextracti128 $1, %ymm4, %xmm4
 vmovq %xmm4, 1400(%rdi)
 vmovdqu 0(%rdi), %ymm11
 vpaddw 1888(%rsp), %ymm11, %ymm11
 vpaddw 2816(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 0(%rdi)
 vmovdqu 352(%rdi), %ymm11
 vpaddw 2528(%rsp), %ymm11, %ymm11
 vpaddw 2848(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 352(%rdi)
 vmovdqu 704(%rdi), %ymm11
 vpaddw 2784(%rsp), %ymm11, %ymm11
 vpaddw 2880(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 704(%rdi)
 vmovdqu 88(%rdi), %ymm11
 vpaddw 2048(%rsp), %ymm11, %ymm11
 vpaddw 1920(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 88(%rdi)
 vmovdqu 440(%rdi), %ymm11
 vpaddw 2304(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 440(%rdi)
 vmovdqu 792(%rdi), %ymm11
 vpaddw 2560(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 792(%rdi)
 vmovdqu 176(%rdi), %ymm11
 vpaddw 2080(%rsp), %ymm11, %ymm11
 vpaddw 1952(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 176(%rdi)
 vmovdqu 528(%rdi), %ymm11
 vpaddw 2336(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 528(%rdi)
 vmovdqu 880(%rdi), %ymm11
 vpaddw 2592(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 880(%rdi)
 vmovdqu 264(%rdi), %ymm11
 vpaddw 2112(%rsp), %ymm11, %ymm11
 vpaddw 1984(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 264(%rdi)
 vmovdqu 616(%rdi), %ymm11
 vpaddw 2368(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 616(%rdi)
 vmovdqu 968(%rdi), %ymm11
 vpaddw 2624(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 968(%rdi)
 vmovdqu 352(%rdi), %ymm11
 vpaddw 2144(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 352(%rdi)
 vmovdqu 704(%rdi), %ymm11
 vpaddw 2400(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 704(%rdi)
 vmovdqu 1056(%rdi), %ymm11
 vpaddw 2656(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 1056(%rdi)
 vmovdqu 440(%rdi), %ymm11
 vpaddw 2176(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 440(%rdi)
 vmovdqu 792(%rdi), %ymm11
 vpaddw 2432(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 792(%rdi)
 vmovdqu 1144(%rdi), %ymm11
 vpaddw 2688(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 1144(%rdi)
 vmovdqu 528(%rdi), %ymm11
 vpaddw 2208(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 528(%rdi)
 vmovdqu 880(%rdi), %ymm11
 vpaddw 2464(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 880(%rdi)
 vmovdqu 1232(%rdi), %ymm11
 vpaddw 2720(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 1232(%rdi)
 vmovdqu 616(%rdi), %ymm11
 vpaddw 2240(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 616(%rdi)
 vmovdqu 968(%rdi), %ymm11
 vpaddw 2496(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 968(%rdi)
 vmovdqu 1320(%rdi), %ymm11
 vpaddw 2752(%rsp), %ymm11, %ymm11
-vpand mask_mod8192(%rip), %ymm11, %ymm11
 vmovdqu %ymm11, 1320(%rdi)
 mov %r8, %rsp
 pop %r12

--- a/crypto_kem/ntruhrss701/clean/owcpa.h
+++ b/crypto_kem/ntruhrss701/clean/owcpa.h
@@ -4,12 +4,9 @@
 #include "params.h"
 #include "poly.h"
 
-void PQCLEAN_NTRUHRSS701_CLEAN_owcpa_samplemsg(unsigned char msg[NTRU_OWCPA_MSGBYTES],
-        const unsigned char seed[NTRU_SEEDBYTES]);
-
 void PQCLEAN_NTRUHRSS701_CLEAN_owcpa_keypair(unsigned char *pk,
         unsigned char *sk,
-        const unsigned char seed[NTRU_SEEDBYTES]);
+        const unsigned char seed[NTRU_SAMPLE_FG_BYTES]);
 
 void PQCLEAN_NTRUHRSS701_CLEAN_owcpa_enc(unsigned char *c,
         const poly *r,

--- a/crypto_kem/ntruhrss701/clean/poly.c
+++ b/crypto_kem/ntruhrss701/clean/poly.c
@@ -23,7 +23,15 @@ void PQCLEAN_NTRUHRSS701_CLEAN_poly_Sq_mul(poly *r, const poly *a, const poly *b
 }
 
 void PQCLEAN_NTRUHRSS701_CLEAN_poly_S3_mul(poly *r, const poly *a, const poly *b) {
+    int i;
+
+    /* Our S3 multiplications do not overflow mod q,    */
+    /* so we can re-purpose PQCLEAN_NTRUHRSS701_CLEAN_poly_Rq_mul, as long as we  */
+    /* follow with an explicit reduction mod q.         */
     PQCLEAN_NTRUHRSS701_CLEAN_poly_Rq_mul(r, a, b);
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = MODQ(r->coeffs[i]);
+    }
     PQCLEAN_NTRUHRSS701_CLEAN_poly_mod_3_Phi_n(r);
 }
 

--- a/crypto_kem/ntruhrss701/clean/poly_rq_mul.c
+++ b/crypto_kem/ntruhrss701/clean/poly_rq_mul.c
@@ -1,15 +1,284 @@
 #include "poly.h"
 
-void PQCLEAN_NTRUHRSS701_CLEAN_poly_Rq_mul(poly *r, const poly *a, const poly *b) {
-    int k, i;
+/* Polynomial multiplication using     */
+/* Toom-4 and two layers of Karatsuba. */
 
-    for (k = 0; k < NTRU_N; k++) {
-        r->coeffs[k] = 0;
-        for (i = 1; i < NTRU_N - k; i++) {
-            r->coeffs[k] += a->coeffs[k + i] * b->coeffs[NTRU_N - i];
-        }
-        for (i = 0; i < k + 1; i++) {
-            r->coeffs[k] += a->coeffs[k - i] * b->coeffs[i];
-        }
+#define L PAD32(NTRU_N)
+#define M (L/4)
+#define K (L/16)
+
+static void toom4_k2x2_mul(uint16_t ab[2 * L], const uint16_t a[L], const uint16_t b[L]);
+
+static void toom4_k2x2_eval_0(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p1(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_m1(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p2(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_m2(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_p3(uint16_t r[9 * K], const uint16_t a[M]);
+static void toom4_k2x2_eval_inf(uint16_t r[9 * K], const uint16_t a[M]);
+static inline void k2x2_eval(uint16_t r[9 * K]);
+
+static void toom4_k2x2_basemul(uint16_t r[18 * K], const uint16_t a[9 * K], const uint16_t b[9 * K]);
+static inline void schoolbook_KxK(uint16_t r[2 * K], const uint16_t a[K], const uint16_t b[K]);
+
+static void toom4_k2x2_interpolate(uint16_t r[2 * M], const uint16_t a[63 * 2 * K]);
+static inline void k2x2_interpolate(uint16_t r[M], const uint16_t a[9 * K]);
+
+void PQCLEAN_NTRUHRSS701_CLEAN_poly_Rq_mul(poly *r, const poly *a, const poly *b) {
+    size_t i;
+    uint16_t ab[2 * L];
+
+    for (i = 0; i < NTRU_N; i++) {
+        ab[i] = a->coeffs[i];
+        ab[L + i] = b->coeffs[i];
+    }
+    for (i = NTRU_N; i < L; i++) {
+        ab[i] = 0;
+        ab[L + i] = 0;
+    }
+
+    toom4_k2x2_mul(ab, ab, ab + L);
+
+    for (i = 0; i < NTRU_N; i++) {
+        r->coeffs[i] = ab[i] + ab[NTRU_N + i];
     }
 }
+
+static void toom4_k2x2_mul(uint16_t ab[2 * L], const uint16_t a[L], const uint16_t b[L]) {
+    uint16_t tmpA[9 * K];
+    uint16_t tmpB[9 * K];
+    uint16_t eC[63 * 2 * K];
+
+    toom4_k2x2_eval_0(tmpA, a);
+    toom4_k2x2_eval_0(tmpB, b);
+    toom4_k2x2_basemul(eC + 0 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p1(tmpA, a);
+    toom4_k2x2_eval_p1(tmpB, b);
+    toom4_k2x2_basemul(eC + 1 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_m1(tmpA, a);
+    toom4_k2x2_eval_m1(tmpB, b);
+    toom4_k2x2_basemul(eC + 2 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p2(tmpA, a);
+    toom4_k2x2_eval_p2(tmpB, b);
+    toom4_k2x2_basemul(eC + 3 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_m2(tmpA, a);
+    toom4_k2x2_eval_m2(tmpB, b);
+    toom4_k2x2_basemul(eC + 4 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_p3(tmpA, a);
+    toom4_k2x2_eval_p3(tmpB, b);
+    toom4_k2x2_basemul(eC + 5 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_eval_inf(tmpA, a);
+    toom4_k2x2_eval_inf(tmpB, b);
+    toom4_k2x2_basemul(eC + 6 * 9 * 2 * K, tmpA, tmpB);
+
+    toom4_k2x2_interpolate(ab, eC);
+}
+
+
+static void toom4_k2x2_eval_0(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i] = a[i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p1(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += a[1 * M + i];
+        r[i] += a[2 * M + i];
+        r[i] += a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_m1(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] -= a[1 * M + i];
+        r[i] += a[2 * M + i];
+        r[i] -= a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p2(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += 2 * a[1 * M + i];
+        r[i] += 4 * a[2 * M + i];
+        r[i] += 8 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_m2(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] -= 2 * a[1 * M + i];
+        r[i] += 4 * a[2 * M + i];
+        r[i] -= 8 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_p3(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i]  = a[0 * M + i];
+        r[i] += 3 * a[1 * M + i];
+        r[i] += 9 * a[2 * M + i];
+        r[i] += 27 * a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static void toom4_k2x2_eval_inf(uint16_t r[9 * K], const uint16_t a[M]) {
+    for (size_t i = 0; i < M; i++) {
+        r[i] = a[3 * M + i];
+    }
+    k2x2_eval(r);
+}
+
+static inline void k2x2_eval(uint16_t r[9 * K]) {
+    /* Input:  e + f.Y + g.Y^2 + h.Y^3                              */
+    /* Output: [ e | f | g | h | e+f | f+h | g+e | h+g | e+f+g+h ]  */
+
+    size_t i;
+    for (i = 0; i < 4 * K; i++) {
+        r[4 * K + i] = r[i];
+    }
+    for (i = 0; i < K; i++) {
+        r[4 * K + i] += r[1 * K + i];
+        r[5 * K + i] += r[3 * K + i];
+        r[6 * K + i] += r[0 * K + i];
+        r[7 * K + i] += r[2 * K + i];
+        r[8 * K + i] = r[5 * K + i];
+        r[8 * K + i] += r[6 * K + i];
+    }
+}
+
+static void toom4_k2x2_basemul(uint16_t r[18 * K], const uint16_t a[9 * K], const uint16_t b[9 * K]) {
+    schoolbook_KxK(r + 0 * 2 * K, a + 0 * K, b + 0 * K);
+    schoolbook_KxK(r + 1 * 2 * K, a + 1 * K, b + 1 * K);
+    schoolbook_KxK(r + 2 * 2 * K, a + 2 * K, b + 2 * K);
+    schoolbook_KxK(r + 3 * 2 * K, a + 3 * K, b + 3 * K);
+    schoolbook_KxK(r + 4 * 2 * K, a + 4 * K, b + 4 * K);
+    schoolbook_KxK(r + 5 * 2 * K, a + 5 * K, b + 5 * K);
+    schoolbook_KxK(r + 6 * 2 * K, a + 6 * K, b + 6 * K);
+    schoolbook_KxK(r + 7 * 2 * K, a + 7 * K, b + 7 * K);
+    schoolbook_KxK(r + 8 * 2 * K, a + 8 * K, b + 8 * K);
+}
+
+static inline void schoolbook_KxK(uint16_t r[2 * K], const uint16_t a[K], const uint16_t b[K]) {
+    size_t i, j;
+    for (j = 0; j < K; j++) {
+        r[j] = a[0] * b[j];
+    }
+    for (i = 1; i < K; i++) {
+        for (j = 0; j < K - 1; j++) {
+            r[i + j] += a[i] * b[j];
+        }
+        r[i + K - 1] = a[i] * b[K - 1];
+    }
+    r[2 * K - 1] = 0;
+}
+
+static void toom4_k2x2_interpolate(uint16_t r[2 * M], const uint16_t a[7 * 18 * K]) {
+    size_t i;
+
+    uint16_t P1[2 * M];
+    uint16_t Pm1[2 * M];
+    uint16_t P2[2 * M];
+    uint16_t Pm2[2 * M];
+
+    uint16_t *C0 = r;
+    uint16_t *C2 = r + 2 * M;
+    uint16_t *C4 = r + 4 * M;
+    uint16_t *C6 = r + 6 * M;
+
+    uint16_t V0, V1, V2;
+
+    k2x2_interpolate(C0, a + 0 * 9 * 2 * K);
+    k2x2_interpolate(P1, a + 1 * 9 * 2 * K);
+    k2x2_interpolate(Pm1, a + 2 * 9 * 2 * K);
+    k2x2_interpolate(P2, a + 3 * 9 * 2 * K);
+    k2x2_interpolate(Pm2, a + 4 * 9 * 2 * K);
+    k2x2_interpolate(C6, a + 6 * 9 * 2 * K);
+
+    for (i = 0; i < 2 * M; i++) {
+        V0 = ((uint32_t)(P1[i] + Pm1[i])) >> 1;
+        V0 = V0 - C0[i] - C6[i];
+        V1 = ((uint32_t)(P2[i] + Pm2[i] - 2 * C0[i] - 128 * C6[i])) >> 3;
+        C4[i] = 43691 * (V1 - V0);
+        C2[i] = V0 - C4[i];
+        P1[i] = ((uint32_t)(P1[i] - Pm1[i])) >> 1;
+    }
+
+    /* reuse Pm1 for P3 */
+#define P3 Pm1
+    k2x2_interpolate(P3, a + 5 * 9 * 2 * K);
+
+    for (i = 0; i < 2 * M; i++) {
+        V0 = P1[i];
+        V1 = 43691 * ((((uint32_t)(P2[i] - Pm2[i])) >> 2) - V0);
+        V2 = 43691 * (P3[i] - C0[i] - 9 * (C2[i] + 9 * (C4[i] + 9 * C6[i])));
+        V2 = ((uint32_t)(V2 - V0)) >> 3;
+        V2 -= V1;
+        P3[i] = 52429 * V2;
+        P2[i] = V1 - V2;
+        P1[i] = V0 - P2[i] - P3[i];
+    }
+
+    for (i = 0; i < 2 * M; i++) {
+        r[1 * M + i] += P1[i];
+        r[3 * M + i] += P2[i];
+        r[5 * M + i] += P3[i];
+    }
+}
+
+static inline void k2x2_interpolate(uint16_t r[M], const uint16_t a[9 * K]) {
+    size_t i;
+    uint16_t tmp[4 * K];
+
+    for (i = 0; i < 2 * K; i++) {
+        r[0 * K + i] = a[0 * K + i];
+        r[2 * K + i] = a[2 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[1 * K + i] += a[8 * K + i] - a[0 * K + i] - a[2 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[4 * K + i] = a[4 * K + i];
+        r[6 * K + i] = a[6 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        r[5 * K + i] += a[14 * K + i] - a[4 * K + i] - a[6 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        tmp[0 * K + i] = a[12 * K + i];
+        tmp[2 * K + i] = a[10 * K + i];
+    }
+
+    for (i = 0; i < 2 * K; i++) {
+        tmp[K + i] += a[16 * K + i] - a[12 * K + i] - a[10 * K + i];
+    }
+
+    for (i = 0; i < 4 * K; i++) {
+        tmp[0 * K + i] = tmp[0 * K + i] - r[0 * K + i] - r[4 * K + i];
+    }
+
+    for (i = 0; i < 4 * K; i++) {
+        r[2 * K + i] += tmp[0 * K + i];
+    }
+}
+


### PR DESCRIPTION
This replaces the reference code's schoolbook multiplication with Toom-4 + two layers of Karatsuba. I've also removed some unnecessary reductions from the AVX2 code, so that will get a bit faster too.