### PR TITLE
Use valgrind to check for non-constant-time behavior (draft)

### DIFF
--- a/crypto_kem/kyber768/clean/indcpa.c
+++ b/crypto_kem/kyber768/clean/indcpa.c
@@ -121,6 +121,7 @@ static size_t rej_uniform(int16_t *r, size_t len, const uint8_t *buf, size_t buf
         val = (uint16_t)(buf[pos] | ((uint16_t)buf[pos + 1] << 8));
         pos += 2;
 
+        //+PQCLEAN_TIMECOP_DECLASSIFY(&val, sizeof val);
         if (val < 19 * KYBER_Q) {
             val -= (uint16_t)((val >> 12) * KYBER_Q); // Barrett reduction
             r[ctr++] = (int16_t)val;

--- a/crypto_sign/dilithium3/clean/poly.c
+++ b/crypto_sign/dilithium3/clean/poly.c
@@ -234,6 +234,7 @@ int PQCLEAN_DILITHIUM3_CLEAN_poly_chknorm(const poly *a, uint32_t B) {
         t ^= (t >> 31);
         t = (Q - 1) / 2 - t;
 
+        //+PQCLEAN_TIMECOP_DECLASSIFY(&t, sizeof t);
         if ((uint32_t)t >= B) {
             return 1;
         }
@@ -270,6 +271,7 @@ static size_t rej_uniform(
         t |= (uint32_t)buf[pos++] << 16;
         t &= 0x7FFFFF;
 
+        //+PQCLEAN_TIMECOP_DECLASSIFY(&t, sizeof t);
         if (t < Q) {
             a[ctr++] = t;
         }
@@ -345,6 +347,8 @@ static size_t rej_eta(
         t0 = buf[pos] & 0x0F;
         t1 = buf[pos++] >> 4;
 
+        //+PQCLEAN_TIMECOP_DECLASSIFY(&t0, sizeof t0);
+        //+PQCLEAN_TIMECOP_DECLASSIFY(&t1, sizeof t1);
         if (t0 <= 2 * ETA) {
             a[ctr++] = Q + ETA - t0;
         }
@@ -426,6 +430,8 @@ static size_t rej_gamma1m1(
 
         pos += 5;
 
+        //+PQCLEAN_TIMECOP_DECLASSIFY(&t0, sizeof t0);
+        //+PQCLEAN_TIMECOP_DECLASSIFY(&t1, sizeof t1);
         if (t0 <= 2 * GAMMA1 - 2) {
             a[ctr++] = Q + GAMMA1 - 1 - t0;
         }

--- a/crypto_sign/dilithium3/clean/rounding.c
+++ b/crypto_sign/dilithium3/clean/rounding.c
@@ -76,6 +76,8 @@ uint32_t PQCLEAN_DILITHIUM3_CLEAN_decompose(uint32_t a, uint32_t *a0) {
 * Returns 1 if high bits of a and b differ and 0 otherwise.
 **************************************************/
 unsigned int PQCLEAN_DILITHIUM3_CLEAN_make_hint(uint32_t a0, uint32_t a1) {
+    //+PQCLEAN_TIMECOP_DECLASSIFY(&a0, sizeof a0);
+    //+PQCLEAN_TIMECOP_DECLASSIFY(&a1, sizeof a1);
     if (a0 <= GAMMA2 || a0 > Q - GAMMA2 || (a0 == Q - GAMMA2 && a1 == 0)) {
         return 0;
     }

--- a/crypto_sign/dilithium3/clean/sign.c
+++ b/crypto_sign/dilithium3/clean/sign.c
@@ -78,6 +78,7 @@ void PQCLEAN_DILITHIUM3_CLEAN_challenge(poly *c,
             }
 
             b = outbuf[pos++];
+            //+PQCLEAN_TIMECOP_DECLASSIFY(&b, sizeof b);
         } while (b > i);
 
         c->coeffs[i] = c->coeffs[b];
@@ -261,12 +262,15 @@ rej:
 
     PQCLEAN_DILITHIUM3_CLEAN_polyveck_add(&w0, &w0, &ct0);
     PQCLEAN_DILITHIUM3_CLEAN_polyveck_csubq(&w0);
+
     n = PQCLEAN_DILITHIUM3_CLEAN_polyveck_make_hint(&h, &w0, &w1);
     if (n > OMEGA) {
         goto rej;
     }
 
     /* Write signature */
+    //+PQCLEAN_TIMECOP_DECLASSIFY(&h, sizeof h);
+    //+PQCLEAN_TIMECOP_DECLASSIFY(&c, sizeof c);
     PQCLEAN_DILITHIUM3_CLEAN_pack_sig(sig, &z, &h, &c);
     *siglen = PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES;
     return 0;

--- a/test/Makefile
+++ b/test/Makefile
@@ -44,6 +44,9 @@ clean-scheme:
 .PHONY: functest
 functest: $(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION)
 
+.PHONY: timecop
+timecop: $(DEST_DIR)/timecop_$(SCHEME)_$(IMPLEMENTATION)
+
 .PHONY: testvectors
 testvectors: $(DEST_DIR)/testvectors_$(SCHEME)_$(IMPLEMENTATION)
 
@@ -73,6 +76,10 @@ $(DEST_DIR)/test_common_nistseedexpander: test_common/sp800-185.c $(COMMON_FILES
 $(DEST_DIR)/functest_$(SCHEME)_$(IMPLEMENTATION): $(SCHEME_LIBRARY) crypto_$(TYPE)/functest.c $(COMMON_FILES) $(COMMON_DIR)/randombytes.c $(COMMON_HEADERS)
 	mkdir -p $(DEST_DIR)
 	$(CC) $(CFLAGS) -DNTESTS=$(NTESTS) -DPQCLEAN_NAMESPACE=PQCLEAN_$(SCHEME_UPPERCASE)_$(IMPLEMENTATION_UPPERCASE) -I$(SCHEME_DIR) crypto_$(TYPE)/functest.c $(COMMON_FILES) $(COMMON_DIR)/randombytes.c -o $@ -L$(SCHEME_DIR) -l$(SCHEME)_$(IMPLEMENTATION)
+
+$(DEST_DIR)/timecop_$(SCHEME)_$(IMPLEMENTATION): $(SCHEME_LIBRARY) crypto_$(TYPE)/timecop.c $(COMMON_FILES) $(TEST_COMMON_DIR)/poisonbytes.c $(TEST_COMMON_DIR)/crypto_declassify.c $(COMMON_HEADERS)
+	mkdir -p $(DEST_DIR)
+	$(CC) $(CFLAGS) -DNTESTS=$(NTESTS) -DPQCLEAN_NAMESPACE=PQCLEAN_$(SCHEME_UPPERCASE)_$(IMPLEMENTATION_UPPERCASE) -I$(SCHEME_DIR) crypto_$(TYPE)/timecop.c $(COMMON_FILES) $(TEST_COMMON_DIR)/poisonbytes.c $(TEST_COMMON_DIR)/crypto_declassify.c -o $@ -L$(SCHEME_DIR) -l$(SCHEME)_$(IMPLEMENTATION)
 
 $(DEST_DIR)/testvectors_$(SCHEME)_$(IMPLEMENTATION): $(SCHEME_LIBRARY) crypto_$(TYPE)/testvectors.c $(COMMON_FILES) $(TEST_COMMON_DIR)/notrandombytes.c $(COMMON_HEADERS)
 	mkdir -p $(DEST_DIR)

--- a/test/common/crypto_declassify.c
+++ b/test/common/crypto_declassify.c
@@ -1,0 +1,8 @@
+#include "stddef.h"
+#include <valgrind/memcheck.h>
+
+void PQCLEAN_TIMECOP_DECLASSIFY(void *addr, size_t len);
+
+void PQCLEAN_TIMECOP_DECLASSIFY(void *addr, size_t len) {
+    VALGRIND_MAKE_MEM_DEFINED(addr, len);
+}

--- a/test/common/poisonbytes.c
+++ b/test/common/poisonbytes.c
@@ -1,0 +1,85 @@
+/**
+ * WARNING
+ *
+ * This file generates a PREDICTABLE and NOT AT ALL RANDOM sequence of bytes.
+ *
+ * Its purpose is to support our testing suite and it MUST NOT be used in any
+ * scenario where you are expecting actual cryptography to happen.
+ */
+
+#include "randombytes.h"
+#include <stdint.h>
+#include <valgrind/memcheck.h>
+
+static uint32_t seed[32] = { 3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3,
+                             2, 3, 8, 4, 6, 2, 6, 4, 3, 3, 8, 3, 2, 7, 9, 5
+                           };
+static uint32_t in[12];
+static uint32_t out[8];
+static int32_t outleft = 0;
+
+#define ROTATE(x, b) (((x) << (b)) | ((x) >> (32 - (b))))
+#define MUSH(i, b) x = t[i] += (((x ^ seed[i]) + sum) ^ ROTATE(x, b));
+
+static void surf(void) {
+    uint32_t t[12];
+    uint32_t x;
+    uint32_t sum = 0;
+    int32_t r;
+    int32_t i;
+    int32_t loop;
+
+    for (i = 0; i < 12; ++i) {
+        t[i] = in[i] ^ seed[12 + i];
+    }
+    for (i = 0; i < 8; ++i) {
+        out[i] = seed[24 + i];
+    }
+    x = t[11];
+    for (loop = 0; loop < 2; ++loop) {
+        for (r = 0; r < 16; ++r) {
+            sum += 0x9e3779b9;
+            MUSH(0, 5)
+            MUSH(1, 7)
+            MUSH(2, 9)
+            MUSH(3, 13)
+            MUSH(4, 5)
+            MUSH(5, 7)
+            MUSH(6, 9)
+            MUSH(7, 13)
+            MUSH(8, 5)
+            MUSH(9, 7)
+            MUSH(10, 9)
+            MUSH(11, 13)
+        }
+        for (i = 0; i < 8; ++i) {
+            out[i] ^= t[i + 4];
+        }
+    }
+}
+
+static int randombytes_internal(uint8_t *buf, size_t n) {
+    while (n > 0) {
+        if (!outleft) {
+            if (!++in[0]) {
+                if (!++in[1]) {
+                    if (!++in[2]) {
+                        ++in[3];
+                    }
+                }
+            }
+            surf();
+            outleft = 8;
+        }
+        *buf = (uint8_t) out[--outleft];
+        ++buf;
+        --n;
+    }
+    return 0;
+}
+
+int randombytes(uint8_t *buf, size_t n) {
+    randombytes_internal(buf, n);
+    VALGRIND_MAKE_MEM_UNDEFINED(buf,n);
+    return 0;
+}

--- a/test/crypto_kem/timecop.c
+++ b/test/crypto_kem/timecop.c
@@ -1,0 +1,65 @@
+#include "api.h"
+#include "randombytes.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <valgrind/memcheck.h>
+
+#define PASTER(x, y) x##_##y
+#define EVALUATOR(x, y) PASTER(x, y)
+#define NAMESPACE(fun) EVALUATOR(PQCLEAN_NAMESPACE, fun)
+
+#define CRYPTO_BYTES           NAMESPACE(CRYPTO_BYTES)
+#define CRYPTO_PUBLICKEYBYTES  NAMESPACE(CRYPTO_PUBLICKEYBYTES)
+#define CRYPTO_SECRETKEYBYTES  NAMESPACE(CRYPTO_SECRETKEYBYTES)
+#define CRYPTO_CIPHERTEXTBYTES NAMESPACE(CRYPTO_CIPHERTEXTBYTES)
+#define CRYPTO_ALGNAME NAMESPACE(CRYPTO_ALGNAME)
+
+#define crypto_kem_keypair NAMESPACE(crypto_kem_keypair)
+#define crypto_kem_enc NAMESPACE(crypto_kem_enc)
+#define crypto_kem_dec NAMESPACE(crypto_kem_dec)
+
+static void poison(void *addr, size_t len) {
+    VALGRIND_MAKE_MEM_UNDEFINED(addr, len);
+}
+
+static void unpoison(void *addr, size_t len) {
+    VALGRIND_MAKE_MEM_DEFINED(addr, len);
+}
+
+int main(void) {
+    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+    uint8_t sk[CRYPTO_SECRETKEYBYTES];
+    uint8_t c[CRYPTO_CIPHERTEXTBYTES];
+    uint8_t k[CRYPTO_BYTES];
+
+    int result;
+
+    result = crypto_kem_keypair(pk, sk);
+    unpoison(&result, sizeof result);
+    if (result) {
+        fprintf(stderr, "Error in crypto_kem_keypair\n");
+        return result;
+    }
+
+    unpoison(pk, CRYPTO_PUBLICKEYBYTES);
+    result = crypto_kem_enc(c, k, pk);
+    unpoison(&result, sizeof result);
+    if (result) {
+        fprintf(stderr, "Error in crypto_kem_enc\n");
+        return result;
+    }
+
+    poison(sk, CRYPTO_SECRETKEYBYTES);
+    unpoison(c, CRYPTO_CIPHERTEXTBYTES);
+    result = crypto_kem_dec(k, c, sk);
+    if (result) {
+        fprintf(stderr, "Error in crypto_kem_dec\n");
+        return result;
+    }
+
+    return 0;
+}

--- a/test/crypto_sign/timecop.c
+++ b/test/crypto_sign/timecop.c
@@ -1,0 +1,133 @@
+#include "api.h"
+#include "randombytes.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <valgrind/memcheck.h>
+
+#define MLEN 1024
+
+#define PASTER(x, y) x##_##y
+#define EVALUATOR(x, y) PASTER(x, y)
+#define NAMESPACE(fun) EVALUATOR(PQCLEAN_NAMESPACE, fun)
+
+#define CRYPTO_BYTES           NAMESPACE(CRYPTO_BYTES)
+#define CRYPTO_PUBLICKEYBYTES  NAMESPACE(CRYPTO_PUBLICKEYBYTES)
+#define CRYPTO_SECRETKEYBYTES  NAMESPACE(CRYPTO_SECRETKEYBYTES)
+#define CRYPTO_ALGNAME NAMESPACE(CRYPTO_ALGNAME)
+
+#define crypto_sign_keypair NAMESPACE(crypto_sign_keypair)
+#define crypto_sign NAMESPACE(crypto_sign)
+#define crypto_sign_open NAMESPACE(crypto_sign_open)
+#define crypto_sign_signature NAMESPACE(crypto_sign_signature)
+#define crypto_sign_verify NAMESPACE(crypto_sign_verify)
+
+static void poison(void *addr, size_t len) {
+    VALGRIND_MAKE_MEM_UNDEFINED(addr, len);
+}
+
+static void unpoison(void *addr, size_t len) {
+    VALGRIND_MAKE_MEM_DEFINED(addr, len);
+}
+
+static int test_sign(void) {
+    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+    uint8_t sk[CRYPTO_SECRETKEYBYTES];
+    uint8_t sm[MLEN + CRYPTO_BYTES];
+    uint8_t m[MLEN];
+
+    size_t mlen;
+    size_t smlen;
+
+    int result;
+
+    randombytes(m, MLEN);
+
+    result = crypto_sign_keypair(pk, sk);
+    unpoison(&result, sizeof result);
+    if (result) {
+        fprintf(stderr, "Error in crypto_sign_keypair\n");
+        return result;
+    }
+
+    poison(m, MLEN);
+    poison(sk, CRYPTO_SECRETKEYBYTES);
+    result = crypto_sign(sm, &smlen, m, MLEN, sk);
+    unpoison(&result, sizeof result);
+    if (result) {
+        fprintf(stderr, "Error in crypto_sign\n");
+        return result;
+    }
+
+    unpoison(sm, MLEN + CRYPTO_BYTES);
+    unpoison(pk, CRYPTO_PUBLICKEYBYTES);
+    result = crypto_sign_open(sm, &mlen, sm, smlen, pk);
+    unpoison(&result, sizeof result);
+    if (result) {
+        fprintf(stderr, "Error in crypto_sign_open\n");
+        return result;
+    }
+
+    return 0;
+}
+
+static int test_sign_detatched(void) {
+    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+    uint8_t sk[CRYPTO_SECRETKEYBYTES];
+    uint8_t sig[CRYPTO_BYTES];
+    uint8_t m[MLEN];
+
+    size_t siglen;
+    int result;
+
+    randombytes(m, MLEN);
+
+    result = crypto_sign_keypair(pk, sk);
+    unpoison(&result, sizeof result);
+    if (result) {
+        fprintf(stderr, "Error in crypto_sign_keypair\n");
+        return result;
+    }
+
+    poison(m, CRYPTO_SECRETKEYBYTES);
+    poison(sk, CRYPTO_SECRETKEYBYTES);
+    result = crypto_sign_signature(sig, &siglen, m, MLEN, sk);
+    unpoison(&result, sizeof result);
+    if (result) {
+        fprintf(stderr, "Error in crypto_sign_signature\n");
+        return result;
+    }
+
+    unpoison(&sig, CRYPTO_BYTES);
+    unpoison(&m, MLEN);
+    unpoison(&pk, CRYPTO_PUBLICKEYBYTES);
+    result = crypto_sign_verify(sig, siglen, m, MLEN, pk);
+    unpoison(&result, sizeof result);
+    if (result) {
+        fprintf(stderr, "Error in crypto_sign_verify\n");
+        return result;
+    }
+
+    return 0;
+}
+
+int main(void) {
+    int result;
+
+    result = test_sign();
+    if (result) {
+        fprintf(stderr, "Error in test_sign\n");
+        return result;
+    }
+
+    result = test_sign_detatched();
+    if (result) {
+        fprintf(stderr, "Error in test_sign_detatched\n");
+        return result;
+    }
+
+    return 0;
+}

--- a/test/test_timecop.py
+++ b/test/test_timecop.py
@@ -1,0 +1,67 @@
+import functools
+import os
+import platform
+import unittest
+
+import pytest
+
+import helpers
+import pqclean
+
+@pytest.mark.parametrize(
+    'implementation,test_dir,impl_path, init, destr',
+    [(impl, *helpers.isolate_test_files(impl.path(), 'test_timecop_'))
+     for impl in pqclean.Scheme.all_supported_implementations()],
+    ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
+)
+@helpers.slow_test
+@helpers.filtered_test
+def test_timecop(implementation: pqclean.Implementation, impl_path, test_dir,
+                  init, destr):
+    if (platform.machine() not in ('i386', 'x86_64') or
+            platform.system() != 'Linux'):
+        raise unittest.SkipTest()
+    init()
+
+    declassify = 'PQCLEAN_TIMECOP_DECLASSIFY'
+    hdr = 'extern void '+declassify+'(void *addr, unsigned long long len);\n'
+
+    test_src_dir = os.path.join(test_dir, 'crypto_bla', 'scheme', 'impl')
+    wd = os.getcwd()
+    os.chdir(test_src_dir)
+    for fname in os.listdir('.'):
+        if not fname.endswith(".c"):
+            continue
+        with open(fname, 'r') as f:
+            content = f.read()
+        if declassify not in content:
+            continue
+        content = content.replace('//+'+declassify, declassify)
+        with open(fname, 'w') as f:
+            f.write(hdr+content)
+    os.chdir(wd)
+
+    dest_dir = os.path.join(test_dir, 'bin')
+    helpers.make('timecop',
+                 TYPE=implementation.scheme.type,
+                 SCHEME=implementation.scheme.name,
+                 SCHEME_DIR=os.path.abspath(impl_path),
+                 IMPLEMENTATION=implementation.name,
+                 DEST_DIR=dest_dir,
+                 EXTRAFLAGS="-g3",
+                 working_dir=os.path.join(test_dir, 'test'))
+    test_name = './timecop_{}_{}'.format(implementation.scheme.name,
+                                                implementation.name)
+    helpers.run_subprocess(
+        ['valgrind',
+         '-q',
+         '--error-exitcode=1',
+         '--track-origins=yes',
+         test_name],
+        dest_dir)
+    destr()
+
+
+if __name__ == '__main__':
+    import sys
+    pytest.main(sys.argv)

--- a/test/test_timecop.py
+++ b/test/test_timecop.py
@@ -14,7 +14,6 @@ import pqclean
      for impl in pqclean.Scheme.all_supported_implementations()],
     ids=[str(impl) for impl in pqclean.Scheme.all_supported_implementations()],
 )
-@helpers.slow_test
 @helpers.filtered_test
 def test_timecop(implementation: pqclean.Implementation, impl_path, test_dir,
                   init, destr):


### PR DESCRIPTION
This PR adds a test that uses Valgrind to look for secret-information dependent branching and memory accesses. It potentially resolves #12 .

I've mostly followed SUPERCOP's implementation [[1]](http://bench.cr.yp.to/tips.html#timecop) of Moritz Neikes TIMECOP [[2]](https://post-apocalyptic-crypto.org/timecop/index.html). 

Each call to randombytes(buf, len) is intercepted and the len bytes at buf are marked as undefined using Valgrind's "VALGRIND_MAKE_MEM_UNDEFINED" [[3]](https://www.valgrind.org/docs/manual/mc-manual.html#mc-manual.clientreqs). Any memory that depends on this undefined memory will also be marked as undefined when the program is run through Valgrind's memcheck tool. Valgrind outputs an error if the program branches on undefined memory.

This produces some false positives. Unlike SUPERCOP and TIMECOP, I've made it so that we can flag false positives with a comment. For example, Kyber does some rejection sampling while generating the public `A` matrix. On Line [124 of indcpa.c](https://github.com/jschanck/PQClean/blob/ed8ddd7daa1ebb157c5e79750a8a0a8db3a951de/crypto_kem/kyber768/clean/indcpa.c#L124) I've added:
```        //+PQCLEAN_TIMECOP_DECLASSIFY(&val, sizeof val);```
The test_timecop.py script strips the "//+" prefix from this before compiling the program and running it through memcheck.

Some TODOs:
- Flag false positives. I've done the clean implementations of dilithium3 and kyber768 as examples.
- Flesh out test/crypto_{kem,sign}/timecop.c. We should check that failure branches are constant time We might want to test on actual random inputs, which means changing test/common/poisonbytes.c.