### PR TITLE
hqc-rmrs-256: remove unused static vars

### DIFF
--- a/crypto_kem/hqc-rmrs-128/META.yml
+++ b/crypto_kem/hqc-rmrs-128/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/4924a647/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/c9181076/hqc
     - name: avx2
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/4924a647/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/c9181076/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-rmrs-192/META.yml
+++ b/crypto_kem/hqc-rmrs-192/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/4924a647/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/c9181076/hqc
     - name: avx2
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/4924a647/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/c9181076/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-rmrs-256/META.yml
+++ b/crypto_kem/hqc-rmrs-256/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/4924a647/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/c9181076/hqc
     - name: avx2
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/4924a647/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/c9181076/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-rmrs-256/avx2/gf2x.c
+++ b/crypto_kem/hqc-rmrs-256/avx2/gf2x.c
@@ -23,9 +23,6 @@
 #define T2_5W_256 (2 * T_5W_256)
 #define t5 (5 * T_5W / 64)
 
-uint64_t bloc64[PARAM_OMEGA_R]; // Allocation with the biggest possible weight
-uint64_t bit64[PARAM_OMEGA_R]; // Allocation with the biggest possible weight
-
 static inline void reduce(uint64_t *o, const __m256i *a);
 static inline void karat_mult_1(__m128i *C, const __m128i *A, const __m128i *B);
 static inline void karat_mult_2(__m256i *C, const __m256i *A, const __m256i *B);


### PR DESCRIPTION
Remove two unused static variables. Fixes part of https://github.com/PQClean/PQClean/issues/355#issuecomment-729970705