### PR TITLE
Skip overly restrictive clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-google-readability-casting,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-valist.*'
+Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-google-readability-casting,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-valist.*,-llvmlibc-*,-bugprone-reserved-identifier,-cert-dcl37-c,-cert-dcl51-cpp'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
My new clang-tidy version comes with some quite restrictive checks that fail on current code in PQClean.

I have disabled the following three:
https://releases.llvm.org/11.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/llvmlibc-restrict-system-libc-headers.html
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-init-variables.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone-reserved-identifier.html
