### PR TITLE
FrodoKEM: Fix bug in the output of the ct_verify function

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,9 @@ Use at your own risk.
 ### 2019-XX-XX
 -->
 
+### 2020-12-11
+* The fix of the timing leak in the CCA transform of FrodoKEM in [PR #303](https://github.com/PQClean/PQClean/pull/303) was ineffective. The FrodoKEM team released another [fix](https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db) which was ported to PQClean in [PR #367](https://github.com/PQClean/PQClean/pull/367).
+
 ### 2020-06-19
 * A potential timing leak was present in the FrodoKEM decapsulation routine, as identified by [Guo, Johansson, and Nilsson](https://eprint.iacr.org/2020/743).  This was fixed in [PR #303](https://github.com/PQClean/PQClean/pull/303).
 

--- a/crypto_kem/frodokem1344aes/META.yml
+++ b/crypto_kem/frodokem1344aes/META.yml
@@ -23,6 +23,6 @@ auxiliary-submitters:
 - Brian LaMacchia, Microsoft Research
 implementations:
 - name: clean
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db
 - name: opt
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db

--- a/crypto_kem/frodokem1344aes/clean/util.c
+++ b/crypto_kem/frodokem1344aes/clean/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM1344AES_CLEAN_ct_verify(const uint16_t *a, const uint16_t
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem1344aes/opt/util.c
+++ b/crypto_kem/frodokem1344aes/opt/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM1344AES_OPT_ct_verify(const uint16_t *a, const uint16_t *
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem1344shake/META.yml
+++ b/crypto_kem/frodokem1344shake/META.yml
@@ -23,6 +23,6 @@ auxiliary-submitters:
 - Brian LaMacchia, Microsoft Research
 implementations:
 - name: clean
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db
 - name: opt
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db

--- a/crypto_kem/frodokem1344shake/clean/util.c
+++ b/crypto_kem/frodokem1344shake/clean/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM1344SHAKE_CLEAN_ct_verify(const uint16_t *a, const uint16
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem1344shake/opt/util.c
+++ b/crypto_kem/frodokem1344shake/opt/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM1344SHAKE_OPT_ct_verify(const uint16_t *a, const uint16_t
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem640aes/META.yml
+++ b/crypto_kem/frodokem640aes/META.yml
@@ -23,6 +23,6 @@ auxiliary-submitters:
 - Brian LaMacchia, Microsoft Research
 implementations:
 - name: clean
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db
 - name: opt
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db

--- a/crypto_kem/frodokem640aes/clean/util.c
+++ b/crypto_kem/frodokem640aes/clean/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM640AES_CLEAN_ct_verify(const uint16_t *a, const uint16_t 
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem640aes/opt/util.c
+++ b/crypto_kem/frodokem640aes/opt/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM640AES_OPT_ct_verify(const uint16_t *a, const uint16_t *b
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem640shake/META.yml
+++ b/crypto_kem/frodokem640shake/META.yml
@@ -23,6 +23,6 @@ auxiliary-submitters:
 - Brian LaMacchia, Microsoft Research
 implementations:
 - name: clean
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db
 - name: opt
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db

--- a/crypto_kem/frodokem640shake/clean/util.c
+++ b/crypto_kem/frodokem640shake/clean/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM640SHAKE_CLEAN_ct_verify(const uint16_t *a, const uint16_
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem640shake/opt/util.c
+++ b/crypto_kem/frodokem640shake/opt/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM640SHAKE_OPT_ct_verify(const uint16_t *a, const uint16_t 
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem976aes/META.yml
+++ b/crypto_kem/frodokem976aes/META.yml
@@ -23,6 +23,6 @@ auxiliary-submitters:
 - Brian LaMacchia, Microsoft Research
 implementations:
 - name: clean
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db
 - name: opt
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db

--- a/crypto_kem/frodokem976aes/clean/util.c
+++ b/crypto_kem/frodokem976aes/clean/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM976AES_CLEAN_ct_verify(const uint16_t *a, const uint16_t 
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem976aes/opt/util.c
+++ b/crypto_kem/frodokem976aes/opt/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM976AES_OPT_ct_verify(const uint16_t *a, const uint16_t *b
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem976shake/META.yml
+++ b/crypto_kem/frodokem976shake/META.yml
@@ -23,6 +23,6 @@ auxiliary-submitters:
 - Brian LaMacchia, Microsoft Research
 implementations:
 - name: clean
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db
 - name: opt
-  version: https://github.com/Microsoft/PQCrypto-LWEKE/commit/d5bbd0417ba111b08a959c0042a1dcc65fb14a89
+  version: https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db

--- a/crypto_kem/frodokem976shake/clean/util.c
+++ b/crypto_kem/frodokem976shake/clean/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM976SHAKE_CLEAN_ct_verify(const uint16_t *a, const uint16_
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 

--- a/crypto_kem/frodokem976shake/opt/util.c
+++ b/crypto_kem/frodokem976shake/opt/util.c
@@ -238,7 +238,7 @@ int8_t PQCLEAN_FRODOKEM976SHAKE_OPT_ct_verify(const uint16_t *a, const uint16_t 
         r |= a[i] ^ b[i];
     }
 
-    r = (-(int16_t)r) >> (8 * sizeof(uint16_t) -1);
+    r = (-(int16_t)(r >> 1) | -(int16_t)(r & 1)) >> (8 * sizeof(uint16_t) -1);
     return (int8_t)r;
 }
 


### PR DESCRIPTION
A bug in the CCA transformation was reported on the pqc-forum on 2020-12-10:
https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/kSUKzDNc5ME

It was fixed today in https://github.com/microsoft/PQCrypto-LWEKE/commit/669522db63850fa64d1a24a47e138e80a59349db.
This PR ports that fix to PQClean.

