### PR TITLE
Use hash_to_point_ct for both Falcon-512 and 1024

### DIFF
--- a/crypto_sign/falcon-1024/META.yml
+++ b/crypto_sign/falcon-1024/META.yml
@@ -20,9 +20,9 @@ auxiliary-submitters:
   - Zhenfei Zhang
 implementations:
     - name: clean
-      version: supercop-20201018 via https://github.com/jschanck/package-pqclean/tree/78831f03/falcon
+      version: supercop-20201018 via https://github.com/jschanck/package-pqclean/tree/cea1fa5a/falcon
     - name: avx2
-      version: supercop-20201018 via https://github.com/jschanck/package-pqclean/tree/78831f03/falcon
+      version: supercop-20201018 via https://github.com/jschanck/package-pqclean/tree/cea1fa5a/falcon
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_sign/falcon-1024/avx2/pqclean.c
+++ b/crypto_sign/falcon-1024/avx2/pqclean.c
@@ -187,7 +187,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
     inner_shake256_inject(&sc, nonce, NONCELEN);
     inner_shake256_inject(&sc, m, mlen);
     inner_shake256_flip(&sc);
-    PQCLEAN_FALCON1024_AVX2_hash_to_point_vartime(&sc, r.hm, 10);
+    PQCLEAN_FALCON1024_AVX2_hash_to_point_ct(&sc, r.hm, 10, tmp.b);
     inner_shake256_ctx_release(&sc);
 
     /*

--- a/crypto_sign/falcon-1024/clean/pqclean.c
+++ b/crypto_sign/falcon-1024/clean/pqclean.c
@@ -187,7 +187,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
     inner_shake256_inject(&sc, nonce, NONCELEN);
     inner_shake256_inject(&sc, m, mlen);
     inner_shake256_flip(&sc);
-    PQCLEAN_FALCON1024_CLEAN_hash_to_point_vartime(&sc, r.hm, 10);
+    PQCLEAN_FALCON1024_CLEAN_hash_to_point_ct(&sc, r.hm, 10, tmp.b);
     inner_shake256_ctx_release(&sc);
 
     /*

--- a/crypto_sign/falcon-512/META.yml
+++ b/crypto_sign/falcon-512/META.yml
@@ -20,9 +20,9 @@ auxiliary-submitters:
   - Zhenfei Zhang
 implementations:
     - name: clean
-      version: supercop-20201018 via https://github.com/jschanck/package-pqclean/tree/78831f03/falcon
+      version: supercop-20201018 via https://github.com/jschanck/package-pqclean/tree/cea1fa5a/falcon
     - name: avx2
-      version: supercop-20201018 via https://github.com/jschanck/package-pqclean/tree/78831f03/falcon
+      version: supercop-20201018 via https://github.com/jschanck/package-pqclean/tree/cea1fa5a/falcon
       supported_platforms:
           - architecture: x86_64
             operating_systems:


### PR DESCRIPTION
The upstream code hashes the message to a vector using a variable-time procedure "hash_to_point_vartime", but upstream provides a constant time alternative "hash_to_point_ct".

I previously swapped in the _ct version in Falcon-512, but forgot to do it for Falcon-1024.

While most use cases for signatures do not need to preserve the secrecy of the message, my thinking is that we should use the more conservative option for PQClean.