### PR TITLE
HQC: required flag is called pclmul not pclmulqdq

### DIFF
--- a/crypto_kem/hqc-rmrs-128/META.yml
+++ b/crypto_kem/hqc-rmrs-128/META.yml
@@ -33,4 +33,4 @@ implementations:
             required_flags:
                 - avx2
                 - bmi1
-                - pclmulqdq
+                - pclmul

--- a/crypto_kem/hqc-rmrs-192/META.yml
+++ b/crypto_kem/hqc-rmrs-192/META.yml
@@ -33,4 +33,4 @@ implementations:
             required_flags:
                 - avx2
                 - bmi1
-                - pclmulqdq
+                - pclmul

--- a/crypto_kem/hqc-rmrs-256/META.yml
+++ b/crypto_kem/hqc-rmrs-256/META.yml
@@ -33,4 +33,4 @@ implementations:
             required_flags:
                 - avx2
                 - bmi1
-                - pclmulqdq
+                - pclmul


### PR DESCRIPTION
The flag probably _should_ be called pclmulqdq, but it is not. Liboqs was not building the AVX2 implementation of HQC because of this.