### PR TITLE
Compatibility shim for unaligned vector types

### DIFF
--- a/common/compat.h
+++ b/common/compat.h
@@ -1,0 +1,47 @@
+#ifndef  PQCLEAN_COMMON_COMPAT_H
+#define PQCLEAN_COMMON_COMPAT_H
+
+/* This file serves to solve compatibility issues between different
+ * versions of compilers.
+ *
+ * This file is allowed to use #ifdefs and toggle things by compiler versions.
+ */
+
+
+// From https://github.com/gcc-mirror/gcc/blob/af73a8b2027d9ab64944d7dbbb48e207d7790ce6/gcc/config/i386/avxintrin.h#L62-L71
+/* Unaligned versions of the vector types */
+#define UNALIGNED_VECTOR_POLYFILL_GCC \
+    typedef float __m256_u __attribute__ ((__vector_size__ (32), __may_alias__, __aligned__ (1))); \
+    typedef double __m256d_u __attribute__ ((__vector_size__ (32), __may_alias__, __aligned__ (1))); \
+    typedef long long __m256i_u __attribute__ ((__vector_size__ (32), __may_alias__, __aligned__ (1)));
+
+
+
+#if defined(__GNUC__) && !defined(__clang__)
+#include <features.h>
+
+#  if !__GNUC_PREREQ(7, 1) // at least GCC 7.1
+/* Versions of the GCC pre-7.1 don't have __m256*_u types */
+UNALIGNED_VECTOR_POLYFILL_GCC
+#  endif // __GNUC_PREREQ(7,1)
+
+#elif defined(__GNUC__) && defined(__clang__)
+
+#  if __clang__major__ < 9
+/* Versions of Clang pre-9.0 don't have __m256*_u types */
+UNALIGNED_VECTOR_POLYFILL_GCC
+#  endif
+
+#elif defined(MSVC)
+// MSVC simply doesn't have these types
+#define __m256_u    __m256
+#define __m256d_u   __m256d
+#define __m256i_u   __m256i
+
+#else
+#error UNSUPPORTED COMPILER!?!?
+#endif // compiler selector
+
+
+
+#endif // PQCLEAN_COMMON_COMPAT_H

--- a/crypto_kem/mceliece348864/avx/int32_sort.c
+++ b/crypto_kem/mceliece348864/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/crypto_kem/mceliece348864f/avx/int32_sort.c
+++ b/crypto_kem/mceliece348864f/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/crypto_kem/mceliece460896/avx/int32_sort.c
+++ b/crypto_kem/mceliece460896/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/crypto_kem/mceliece460896f/avx/int32_sort.c
+++ b/crypto_kem/mceliece460896f/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/crypto_kem/mceliece6688128/avx/int32_sort.c
+++ b/crypto_kem/mceliece6688128/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/crypto_kem/mceliece6688128f/avx/int32_sort.c
+++ b/crypto_kem/mceliece6688128f/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/crypto_kem/mceliece6960119/avx/int32_sort.c
+++ b/crypto_kem/mceliece6960119/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/crypto_kem/mceliece6960119f/avx/int32_sort.c
+++ b/crypto_kem/mceliece6960119f/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/crypto_kem/mceliece8192128/avx/int32_sort.c
+++ b/crypto_kem/mceliece8192128/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/crypto_kem/mceliece8192128f/avx/int32_sort.c
+++ b/crypto_kem/mceliece8192128f/avx/int32_sort.c
@@ -3,6 +3,9 @@
 
 #include <immintrin.h>
 
+// compatibility for __m256i_u
+#include "compat.h"
+
 typedef __m256i int32x8;
 #define int32x8_load(z) _mm256_loadu_si256((__m256i_u *) (z))
 #define int32x8_store(z,i) _mm256_storeu_si256((__m256i_u *) (z),(i))

--- a/test/common/compat.h
+++ b/test/common/compat.h
@@ -1,0 +1,1 @@
+/** Empty on purpose so preprocessor / compiler-specific stuff does not choke test_char.py **/

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -88,6 +88,7 @@ def test_boolean(implementation):
                 '-E',
                 '-std=c99',
                 '-nostdinc',  # pycparser cannot deal with e.g. __attribute__
+                '-I{}'.format(os.path.join(tdir, "common")),  # include test common files to overrule compat.h
                 '-I{}'.format(os.path.join(tdir, "../common")),
                 # necessary to mock e.g. <stdint.h>
                 '-I{}'.format(

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -55,6 +55,7 @@ def test_char(implementation):
                 '-E',
                 '-std=c99',
                 '-nostdinc',  # pycparser cannot deal with e.g. __attribute__
+                '-I{}'.format(os.path.join(tdir, "common")),  # include test common files to overrule compat.h
                 '-I{}'.format(os.path.join(tdir, "../common")),
                 # necessary to mock e.g. <stdint.h>
                 '-I{}'.format(


### PR DESCRIPTION
This introduces an intial version of the compatibility shim `compat.h` which will help to provide compatibility in schemes without copying too much code or worrying about compiler versions on a scheme-level.

See #383

It also patches the Classic McEliece issue mentioned in #382
