### PR TITLE
Remove hardcoded CPU flags for MacOS

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -282,16 +282,4 @@ def get_cpu_info():
         import cpuinfo
         the_info = cpuinfo.get_cpu_info()
 
-        # CPUINFO is unreliable on Travis CI Macs
-        if 'CI' in os.environ and sys.platform == 'darwin':
-            the_info['flags'] = [
-                'aes', 'apic', 'avx1.0', 'clfsh', 'cmov', 'cx16', 'cx8', 'de',
-                'em64t', 'erms', 'f16c', 'fpu', 'fxsr', 'lahf', 'mca', 'mce',
-                'mmx', 'mon', 'msr', 'mtrr', 'osxsave', 'pae', 'pat', 'pcid',
-                'pclmulqdq', 'pge', 'popcnt', 'pse', 'pse36', 'rdrand',
-                'rdtscp', 'rdwrfsgs', 'sep', 'smep', 'ss', 'sse', 'sse2',
-                'sse3', 'sse4.1', 'sse4.2', 'ssse3', 'syscall', 'tsc',
-                'tsc_thread_offset', 'tsci', 'tsctmr', 'vme', 'vmm', 'x2apic',
-                'xd', 'xsave']
-
     return the_info


### PR DESCRIPTION
We're no longer running on Travis and I can't reproduce this issue anymore.

