### PR TITLE
HQC-192/avx2: fix missing initialization in compute_syndromes

### DIFF
--- a/crypto_kem/hqc-rmrs-128/META.yml
+++ b/crypto_kem/hqc-rmrs-128/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/9c4e109d/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/29f79e72/hqc
     - name: avx2
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/9c4e109d/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/29f79e72/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-rmrs-192/META.yml
+++ b/crypto_kem/hqc-rmrs-192/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/9c4e109d/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/29f79e72/hqc
     - name: avx2
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/9c4e109d/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/29f79e72/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:

--- a/crypto_kem/hqc-rmrs-192/avx2/reed_solomon.c
+++ b/crypto_kem/hqc-rmrs-192/avx2/reed_solomon.c
@@ -198,6 +198,8 @@ void compute_syndromes(uint16_t *syndromes, uint8_t *cdw) {
         syndromes256[0] ^= PQCLEAN_HQCRMRS192_AVX2_gf_mul_vect(_mm256_set1_epi16(cdw[i + 1]), alpha_ij256_1[i]);
     }
 
+    syndromes256[1] = _mm256_set1_epi16(cdw[0]);
+
     for (size_t i = 0; i < PARAM_N1 - 1; ++i) {
         syndromes256[1] ^= PQCLEAN_HQCRMRS192_AVX2_gf_mul_vect(_mm256_set1_epi16(cdw[i + 1]), alpha_ij256_2[i]);
     }

--- a/crypto_kem/hqc-rmrs-256/META.yml
+++ b/crypto_kem/hqc-rmrs-256/META.yml
@@ -22,9 +22,9 @@ principal-submitters:
   - Loïc Bidoux
 implementations:
     - name: clean
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/9c4e109d/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/29f79e72/hqc
     - name: avx2
-      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/9c4e109d/hqc
+      version: hqc-submission_2020-10-01 via https://github.com/jschanck/package-pqclean/tree/29f79e72/hqc
       supported_platforms:
           - architecture: x86_64
             operating_systems:


### PR DESCRIPTION
Resolves https://github.com/open-quantum-safe/liboqs/issues/990