### PR TITLE
POSIX compliant compilation

### DIFF
--- a/common/randombytes.h
+++ b/common/randombytes.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 #ifdef _WIN32
-#include <CRTDEFS.H>
+#include <crtdefs.h>
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
When compiling the Rust variant (https://github.com/rustpq/pqcrypto) to Windows using Mingw64 on Ubuntu, we got the following error:

```
common/randombytes.o" "-c" "pqclean/common/randombytes.c"
  cargo:warning=In file included from pqclean/common/randombytes.c:32:
  cargo:warning=pqclean/common/randombytes.h:6:10: fatal error: CRTDEFS.H: No such file or directory
  cargo:warning=    6 | #include <CRTDEFS.H>
  cargo:warning=      |          ^~~~~~~~~~~
  cargo:warning=compilation terminated.
```

When checking for said file, running `find / -iname CRTDEFS.h` I got:

```
/usr/share/mingw-w64/include/crtdefs.h
/usr/i686-w64-mingw32/include/crtdefs.h
/usr/x86_64-w64-mingw32/include/crtdefs.h
```

It's clear that this file needs to be in lower-case, given the case-sensitive nature of Linux file systems. As for Windows, I don't think this will break anything, but I'm not a Windows user, so I haven't tested it, but since Windows file systems are case-insensitive by nature, it shouldn't break.