### PR TITLE
Added a randomnumber generator function for WASI to support WebAssembly PQ crypto

### DIFF
--- a/common/randombytes.c
+++ b/common/randombytes.c
@@ -130,6 +130,13 @@ static int randombytes_linux_randombytes_getrandom(void *buf, size_t n) {
 }
 #endif /* defined(__linux__) && defined(SYS_getrandom) */
 
+#if defined(__wasi__)
+static int randombytes_wasi_randombytes(void *buf, size_t n) {
+    getentropy(buf, n);
+    return 0;
+}
+#endif /* defined(__linux__) && defined(SYS_getrandom) */
+
 #if defined(__linux__) && !defined(SYS_getrandom)
 static int randombytes_linux_read_entropy_ioctl(int device, int *entropy) {
     return ioctl(device, RNDGETENTCNT, entropy);
@@ -319,6 +326,9 @@ int randombytes(uint8_t *buf, size_t n) {
     #elif defined(_WIN32)
     /* Use windows API */
     return randombytes_win32_randombytes(buf, n);
+    #elif defined(__wasi__)
+    /* Use WASI */
+    return randombytes_wasi_randombytes(buf, n);
     #else
 #error "randombytes(...) is not supported on this platform"
     #endif

--- a/common/randombytes.c
+++ b/common/randombytes.c
@@ -38,6 +38,10 @@ THE SOFTWARE.
 #include <wincrypt.h> /* CryptAcquireContext, CryptGenRandom */
 #endif /* defined(_WIN32) */
 
+#if defined(__wasi__)
+#include <stdlib.h>
+#endif
+
 #if defined(__linux__)
 /* Linux */
 // We would need to include <linux/random.h>, but not every target has access
@@ -132,7 +136,7 @@ static int randombytes_linux_randombytes_getrandom(void *buf, size_t n) {
 
 #if defined(__wasi__)
 static int randombytes_wasi_randombytes(void *buf, size_t n) {
-    getentropy(buf, n);
+    arc4random_buf(buf, n);
     return 0;
 }
 #endif /* defined(__linux__) && defined(SYS_getrandom) */


### PR DESCRIPTION
As a part of a project I am working on there is a heavy use of quantum resistant crypto.

Now that I am porting the library (https://github.com/john-sharratt/ate) over to WebAssembly so that it can run in a web browser I need the same crypto functions to work in wasm32 under wasi however there are no known libraries in rust that support such routines other than pqcrypto - hence I started porting it....

Thus, given that pqcrypto did not yet work on wasi I forked it to add support for compiling to target=wasm32-wasi (https://github.com/john-sharratt/pqcrypto-wasi) - most of it compiles except for the random generator which is runtime specific thus I have added a function within WASI.

The pull request over at pqcrypto is here:
https://github.com/rustpq/pqcrypto/pull/22

The new function only impacts builds that target wasi hence it is fully forwards and backwards compatible.

To compile you need to use target wasm32-wasi and must have wasi-libc - take a look at this repo for an example on how to compile it:
https://github.com/john-sharratt/pqcrypto-wasi