### PR TITLE
Arm-v8 test framework changes

### DIFF
--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -9,6 +9,7 @@ import os
 import pytest
 
 import helpers
+import platform
 import pqclean
 import pycparser
 
@@ -76,6 +77,12 @@ class ForbiddenOpVisitor(pycparser.c_ast.NodeVisitor):
 @helpers.filtered_test
 def test_boolean(implementation):
     errors = []
+    # pyparser's fake_libc does not support the Arm headers
+    if 'supported_platforms' in implementation.metadata():
+        for platform in implementation.metadata()['supported_platforms']:
+            if platform['architecture'] == "arm_8":
+                return
+
     for fname in os.listdir(implementation.path()):
         if not fname.endswith(".c"):
             continue

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -7,6 +7,7 @@ in assignments or function calls.
 import os
 
 import pytest
+import unittest
 
 import helpers
 import platform
@@ -81,7 +82,7 @@ def test_boolean(implementation):
     if 'supported_platforms' in implementation.metadata():
         for platform in implementation.metadata()['supported_platforms']:
             if platform['architecture'] == "arm_8":
-                return
+                raise unittest.SkipTest()
 
     for fname in os.listdir(implementation.path()):
         if not fname.endswith(".c"):

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -7,6 +7,7 @@ This is ambiguous; compilers can freely choose `signed` or `unsigned` char.
 import os
 
 import pytest
+import unittest
 
 import helpers
 import platform
@@ -48,7 +49,7 @@ def test_char(implementation):
     if 'supported_platforms' in implementation.metadata():
         for platform in implementation.metadata()['supported_platforms']:
             if platform['architecture'] == "arm_8":
-                return
+                raise unittest.SkipTest()
 
     for fname in os.listdir(implementation.path()):
         if not fname.endswith(".c"):

--- a/test/test_char.py
+++ b/test/test_char.py
@@ -9,6 +9,7 @@ import os
 import pytest
 
 import helpers
+import platform
 import pqclean
 import pycparser
 
@@ -43,6 +44,12 @@ def walk_tree(ast, parent=[]):
 @helpers.filtered_test
 def test_char(implementation):
     errors = []
+    # pyparser's fake_libc does not support the Arm headers
+    if 'supported_platforms' in implementation.metadata():
+        for platform in implementation.metadata()['supported_platforms']:
+            if platform['architecture'] == "arm_8":
+                return
+
     for fname in os.listdir(implementation.path()):
         if not fname.endswith(".c"):
             continue

--- a/test/test_valgrind.py
+++ b/test/test_valgrind.py
@@ -33,7 +33,7 @@ def valgrind_supports_exit_early():
 @helpers.filtered_test
 def test_valgrind(implementation: pqclean.Implementation, impl_path, test_dir,
                   init, destr):
-    if (platform.machine() not in ('i386', 'x86_64') or
+    if (platform.machine() not in ('i386', 'x86_64', 'aarch64') or
             platform.system() != 'Linux'):
         raise unittest.SkipTest()
     init()


### PR DESCRIPTION
I'm working on adding Neon implementations for Kyber (#416) and later also Saber and Dilithium and I ran into a problem on aarch64: pycparser's fake stdlib does not support the neon headers which results in to errors like this: 
```
/home/mjk/git/PQClean/test/test_boolean.py:83: 
...
E               subprocess.CalledProcessError: Command '['cc', '-E', '-std=c99', '-nostdinc', '-I/home/ubuntu/PQClean/test/common', '-I/home/ubuntu/PQClean/test/../common', '-I/home/ubuntu/PQClean/test/pycparser/utils/fake_libc_include', '../crypto_kem/kyber768/aarch64/kem.c']' returned non-zero exit status 1.

/usr/lib/python3.9/subprocess.py:528: CalledProcessError
---------------------------------------------------- Captured stderr call -----------------------------------------------------
In file included from ../crypto_kem/kyber768/aarch64/symmetric.h:61,
                 from ../crypto_kem/kyber768/aarch64/kem.c:6:
../crypto_kem/kyber768/aarch64/fips202x2.h:5:10: fatal error: arm_neon.h: No such file or directory
    5 | #include <arm_neon.h>
      |          ^~~~~~~~~~
 ```
 
 I don't see any way around this, so I have disabled the tests using pycparser for implementations targetting arm_8. 

Additionally, valgrind was not enabled for aarch64 even though it works perfectly fine. I've enabled it.