### PR TITLE
Dilithium aarch64: Resolve `mismatched bound` errors for gcc 11

### DIFF
--- a/crypto_sign/dilithium2/META.yml
+++ b/crypto_sign/dilithium2/META.yml
@@ -30,7 +30,7 @@ implementations:
               - avx2
               - popcnt
     - name: aarch64
-      version: https://github.com/neon-ntt/neon-ntt/tree/b011eeff3515fb168aa4dbaa671d760009d98dbb
+      version: https://github.com/neon-ntt/neon-ntt/tree/014d2a0c21d705a523b3bfd2a740f8f0a2ba7a27
       supported_platforms:
         - architecture: arm_8
           operating_systems:

--- a/crypto_sign/dilithium2/aarch64/ntt.h
+++ b/crypto_sign/dilithium2/aarch64/ntt.h
@@ -21,9 +21,9 @@ extern void PQCLEAN_DILITHIUM2_AARCH64_asm_intt_SIMD_bot(int *des, const int *ta
     }
 
 #define ntt DILITHIUM_NAMESPACE(ntt)
-void ntt(int32_t a[]);
+void ntt(int32_t a[N]);
 #define invntt_tomont DILITHIUM_NAMESPACE(invntt_tomont)
-void invntt_tomont(int32_t a[]);
+void invntt_tomont(int32_t a[N]);
 
 static const int constants[16] = {
     Q1, -Q1prime, RmodQ1_prime_half, RmodQ1_doubleprime,

--- a/crypto_sign/dilithium2/aarch64/symmetric.h
+++ b/crypto_sign/dilithium2/aarch64/symmetric.h
@@ -21,7 +21,7 @@ void dilithium_shake256_stream_init(shake256incctx *state,
 
 #define dilithium_shake128x2_stream_init DILITHIUM_NAMESPACE(dilithium_shake128x2_stream_init)
 void dilithium_shake128x2_stream_init(keccakx2_state *state,
-                                      const uint8_t seed[CRHBYTES],
+                                      const uint8_t seed[SEEDBYTES],
                                       uint16_t nonce1, uint16_t nonce2);
 #define dilithium_shake256x2_stream_init DILITHIUM_NAMESPACE(dilithium_shake256x2_stream_init)
 void dilithium_shake256x2_stream_init(keccakx2_state *state,

--- a/crypto_sign/dilithium3/META.yml
+++ b/crypto_sign/dilithium3/META.yml
@@ -30,7 +30,7 @@ implementations:
               - avx2
               - popcnt
     - name: aarch64
-      version: https://github.com/neon-ntt/neon-ntt/tree/b011eeff3515fb168aa4dbaa671d760009d98dbb
+      version: https://github.com/neon-ntt/neon-ntt/tree/014d2a0c21d705a523b3bfd2a740f8f0a2ba7a27
       supported_platforms:
         - architecture: arm_8
           operating_systems:

--- a/crypto_sign/dilithium3/aarch64/ntt.h
+++ b/crypto_sign/dilithium3/aarch64/ntt.h
@@ -21,9 +21,9 @@ extern void PQCLEAN_DILITHIUM3_AARCH64_asm_intt_SIMD_bot(int *des, const int *ta
     }
 
 #define ntt DILITHIUM_NAMESPACE(ntt)
-void ntt(int32_t a[]);
+void ntt(int32_t a[N]);
 #define invntt_tomont DILITHIUM_NAMESPACE(invntt_tomont)
-void invntt_tomont(int32_t a[]);
+void invntt_tomont(int32_t a[N]);
 
 static const int constants[16] = {
     Q1, -Q1prime, RmodQ1_prime_half, RmodQ1_doubleprime,

--- a/crypto_sign/dilithium3/aarch64/symmetric.h
+++ b/crypto_sign/dilithium3/aarch64/symmetric.h
@@ -21,7 +21,7 @@ void dilithium_shake256_stream_init(shake256incctx *state,
 
 #define dilithium_shake128x2_stream_init DILITHIUM_NAMESPACE(dilithium_shake128x2_stream_init)
 void dilithium_shake128x2_stream_init(keccakx2_state *state,
-                                      const uint8_t seed[CRHBYTES],
+                                      const uint8_t seed[SEEDBYTES],
                                       uint16_t nonce1, uint16_t nonce2);
 #define dilithium_shake256x2_stream_init DILITHIUM_NAMESPACE(dilithium_shake256x2_stream_init)
 void dilithium_shake256x2_stream_init(keccakx2_state *state,

--- a/crypto_sign/dilithium5/META.yml
+++ b/crypto_sign/dilithium5/META.yml
@@ -30,7 +30,7 @@ implementations:
               - avx2
               - popcnt
     - name: aarch64
-      version: https://github.com/neon-ntt/neon-ntt/tree/b011eeff3515fb168aa4dbaa671d760009d98dbb
+      version: https://github.com/neon-ntt/neon-ntt/tree/014d2a0c21d705a523b3bfd2a740f8f0a2ba7a27
       supported_platforms:
         - architecture: arm_8
           operating_systems:

--- a/crypto_sign/dilithium5/aarch64/ntt.h
+++ b/crypto_sign/dilithium5/aarch64/ntt.h
@@ -21,9 +21,9 @@ extern void PQCLEAN_DILITHIUM5_AARCH64_asm_intt_SIMD_bot(int *des, const int *ta
     }
 
 #define ntt DILITHIUM_NAMESPACE(ntt)
-void ntt(int32_t a[]);
+void ntt(int32_t a[N]);
 #define invntt_tomont DILITHIUM_NAMESPACE(invntt_tomont)
-void invntt_tomont(int32_t a[]);
+void invntt_tomont(int32_t a[N]);
 
 static const int constants[16] = {
     Q1, -Q1prime, RmodQ1_prime_half, RmodQ1_doubleprime,

--- a/crypto_sign/dilithium5/aarch64/symmetric.h
+++ b/crypto_sign/dilithium5/aarch64/symmetric.h
@@ -21,7 +21,7 @@ void dilithium_shake256_stream_init(shake256incctx *state,
 
 #define dilithium_shake128x2_stream_init DILITHIUM_NAMESPACE(dilithium_shake128x2_stream_init)
 void dilithium_shake128x2_stream_init(keccakx2_state *state,
-                                      const uint8_t seed[CRHBYTES],
+                                      const uint8_t seed[SEEDBYTES],
                                       uint16_t nonce1, uint16_t nonce2);
 #define dilithium_shake256x2_stream_init DILITHIUM_NAMESPACE(dilithium_shake256x2_stream_init)
 void dilithium_shake256x2_stream_init(keccakx2_state *state,


### PR DESCRIPTION
Make Dilithium aarch64 implementation compile with gcc 11.
Similar as #429. 