### PR TITLE
Saber aarch64: Resolve stack pointer corruption

### DIFF
--- a/crypto_kem/firesaber/META.yml
+++ b/crypto_kem/firesaber/META.yml
@@ -25,7 +25,7 @@ implementations:
             required_flags:
                 - avx2
     - name: aarch64
-      version: https://github.com/neon-ntt/neon-ntt/tree/b011eeff3515fb168aa4dbaa671d760009d98dbb
+      version: https://github.com/neon-ntt/neon-ntt/tree/b24c6d429124cd9f06e2cb1ee4e3f0e7cf4a511b
       supported_platforms:
           - architecture: arm_8
             operating_systems:

--- a/crypto_kem/firesaber/aarch64/__asm_mul.S
+++ b/crypto_kem/firesaber/aarch64/__asm_mul.S
@@ -14,10 +14,10 @@ _PQCLEAN_FIRESABER_AARCH64_asm_asymmetric_mul:
     push_all
 
     ldr w28, [x3, #0]
-    ldr w29, [x3, #4]
+    ldr w27, [x3, #4]
 
     dup v28.4S, w28
-    dup v29.4S, w29
+    dup v29.4S, w27
 
     add x11,  x0, #0
 

--- a/crypto_kem/lightsaber/META.yml
+++ b/crypto_kem/lightsaber/META.yml
@@ -25,7 +25,7 @@ implementations:
             required_flags:
                 - avx2
     - name: aarch64
-      version: https://github.com/neon-ntt/neon-ntt/tree/b011eeff3515fb168aa4dbaa671d760009d98dbb
+      version: https://github.com/neon-ntt/neon-ntt/tree/b24c6d429124cd9f06e2cb1ee4e3f0e7cf4a511b
       supported_platforms:
           - architecture: arm_8
             operating_systems:

--- a/crypto_kem/lightsaber/aarch64/__asm_mul.S
+++ b/crypto_kem/lightsaber/aarch64/__asm_mul.S
@@ -14,10 +14,10 @@ _PQCLEAN_LIGHTSABER_AARCH64_asm_asymmetric_mul:
     push_all
 
     ldr w28, [x3, #0]
-    ldr w29, [x3, #4]
+    ldr w27, [x3, #4]
 
     dup v28.4S, w28
-    dup v29.4S, w29
+    dup v29.4S, w27
 
     add x11,  x0, #0
 

--- a/crypto_kem/saber/META.yml
+++ b/crypto_kem/saber/META.yml
@@ -25,7 +25,7 @@ implementations:
             required_flags:
                 - avx2
     - name: aarch64
-      version: https://github.com/neon-ntt/neon-ntt/tree/b011eeff3515fb168aa4dbaa671d760009d98dbb
+      version: https://github.com/neon-ntt/neon-ntt/tree/b24c6d429124cd9f06e2cb1ee4e3f0e7cf4a511b
       supported_platforms:
           - architecture: arm_8
             operating_systems:

--- a/crypto_kem/saber/aarch64/__asm_mul.S
+++ b/crypto_kem/saber/aarch64/__asm_mul.S
@@ -14,10 +14,10 @@ _PQCLEAN_SABER_AARCH64_asm_asymmetric_mul:
     push_all
 
     ldr w28, [x3, #0]
-    ldr w29, [x3, #4]
+    ldr w27, [x3, #4]
 
     dup v28.4S, w28
-    dup v29.4S, w29
+    dup v29.4S, w27
 
     add x11,  x0, #0
 


### PR DESCRIPTION
Resolves #431.
Resolves stack pointer corruption by not using w29 (frame pointer).
See https://github.com/neon-ntt/neon-ntt/commit/b24c6d429124cd9f06e2cb1ee4e3f0e7cf4a511b
