### PR TITLE
Update dilithium/{clean,avx}. Resolves #421

### DIFF
--- a/crypto_sign/dilithium2/META.yml
+++ b/crypto_sign/dilithium2/META.yml
@@ -17,9 +17,9 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
     - name: clean
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
     - name: avx2
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
       supported_platforms:
         - architecture: x86_64
           operating_systems:
@@ -29,6 +29,7 @@ implementations:
               - aes
               - avx2
               - popcnt
+
     - name: aarch64
       version: https://github.com/neon-ntt/neon-ntt/tree/014d2a0c21d705a523b3bfd2a740f8f0a2ba7a27
       supported_platforms:

--- a/crypto_sign/dilithium2/avx2/fips202x4.c
+++ b/crypto_sign/dilithium2/avx2/fips202x4.c
@@ -100,13 +100,13 @@ static void keccakx4_squeezeblocks(uint8_t *out0,
             t = _mm_castsi128_pd(_mm256_castsi256_si128(s[i]));
             _mm_storel_pd(&temp0, t);
             _mm_storeh_pd(&temp1, t);
-            memmove(&out0[8 * i], &temp0, sizeof(double));
-            memmove(&out1[8 * i], &temp1, sizeof(double));
+            memcpy(&out0[8 * i], &temp0, sizeof(double));
+            memcpy(&out1[8 * i], &temp1, sizeof(double));
             t = _mm_castsi128_pd(_mm256_extracti128_si256(s[i], 1));
             _mm_storel_pd(&temp0, t);
             _mm_storeh_pd(&temp1, t);
-            memmove(&out2[8 * i], &temp0, sizeof(double));
-            memmove(&out3[8 * i], &temp1, sizeof(double));
+            memcpy(&out2[8 * i], &temp0, sizeof(double));
+            memcpy(&out3[8 * i], &temp1, sizeof(double));
         }
 
         out0 += r;

--- a/crypto_sign/dilithium2/avx2/poly.c
+++ b/crypto_sign/dilithium2/avx2/poly.c
@@ -73,25 +73,6 @@ void PQCLEAN_DILITHIUM2_AVX2_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM2_AVX2_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              positive standard representatives. Assumes input
-*              coefficients to be at most 2^31 - 2^22 + 1 in
-*              absolute value.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM2_AVX2_poly_freeze(poly *a) {
-    DBENCH_START();
-
-    PQCLEAN_DILITHIUM2_AVX2_poly_reduce(a);
-    PQCLEAN_DILITHIUM2_AVX2_poly_caddq(a);
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM2_AVX2_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.
@@ -966,7 +947,7 @@ void PQCLEAN_DILITHIUM2_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *a: byte array with bit-packed polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM2_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[POLYZ_PACKEDBYTES + 14]) {
+void PQCLEAN_DILITHIUM2_AVX2_polyz_unpack(poly *restrict r, const uint8_t *a) {
     unsigned int i;
     __m256i f;
     const __m256i shufbidx = _mm256_set_epi8(-1, 9, 8, 7, -1, 7, 6, 5, -1, 5, 4, 3, -1, 3, 2, 1,
@@ -1000,7 +981,7 @@ void PQCLEAN_DILITHIUM2_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[POLY
 *                            POLYW1_PACKEDBYTES bytes
 *              - const poly *a: pointer to input polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM2_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES + 8], const poly *restrict a) {
+void PQCLEAN_DILITHIUM2_AVX2_polyw1_pack(uint8_t *r, const poly *restrict a) {
     unsigned int i;
     __m256i f0, f1, f2, f3;
     const __m256i shift1 = _mm256_set1_epi16((64 << 8) + 1);

--- a/crypto_sign/dilithium2/avx2/poly.h
+++ b/crypto_sign/dilithium2/avx2/poly.h
@@ -9,7 +9,6 @@ typedef ALIGNED_INT32(N) poly;
 
 void PQCLEAN_DILITHIUM2_AVX2_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM2_AVX2_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM2_AVX2_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM2_AVX2_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM2_AVX2_poly_sub(poly *c, const poly *a, const poly *b);
@@ -72,8 +71,8 @@ void PQCLEAN_DILITHIUM2_AVX2_polyt0_pack(uint8_t r[POLYT0_PACKEDBYTES], const po
 void PQCLEAN_DILITHIUM2_AVX2_polyt0_unpack(poly *r, const uint8_t a[POLYT0_PACKEDBYTES]);
 
 void PQCLEAN_DILITHIUM2_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly *a);
-void PQCLEAN_DILITHIUM2_AVX2_polyz_unpack(poly *r, const uint8_t a[POLYZ_PACKEDBYTES + 14]);
+void PQCLEAN_DILITHIUM2_AVX2_polyz_unpack(poly *r, const uint8_t *a);
 
-void PQCLEAN_DILITHIUM2_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES + 8], const poly *a);
+void PQCLEAN_DILITHIUM2_AVX2_polyw1_pack(uint8_t *r, const poly *a);
 
 #endif

--- a/crypto_sign/dilithium2/avx2/polyvec.c
+++ b/crypto_sign/dilithium2/avx2/polyvec.c
@@ -99,22 +99,6 @@ void PQCLEAN_DILITHIUM2_AVX2_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM2_AVX2_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM2_AVX2_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM2_AVX2_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM2_AVX2_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -244,22 +228,6 @@ void PQCLEAN_DILITHIUM2_AVX2_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM2_AVX2_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM2_AVX2_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM2_AVX2_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM2_AVX2_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium2/avx2/polyvec.h
+++ b/crypto_sign/dilithium2/avx2/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM2_AVX2_polyvecl_uniform_gamma1(polyvecl *v, const uint8_t 
 
 void PQCLEAN_DILITHIUM2_AVX2_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM2_AVX2_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM2_AVX2_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM2_AVX2_polyvecl_ntt(polyvecl *v);
@@ -37,7 +35,6 @@ void PQCLEAN_DILITHIUM2_AVX2_polyveck_uniform_eta(polyveck *v, const uint8_t see
 
 void PQCLEAN_DILITHIUM2_AVX2_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM2_AVX2_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM2_AVX2_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM2_AVX2_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM2_AVX2_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium2/avx2/rejsample.h
+++ b/crypto_sign/dilithium2/avx2/rejsample.h
@@ -14,6 +14,6 @@ extern const uint8_t PQCLEAN_DILITHIUM2_AVX2_idxlut[256][8];
 
 unsigned int PQCLEAN_DILITHIUM2_AVX2_rej_uniform_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN + 8]);
 
-unsigned int PQCLEAN_DILITHIUM2_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN]);
+unsigned int PQCLEAN_DILITHIUM2_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_ETA_BUFLEN]);
 
 #endif

--- a/crypto_sign/dilithium2/clean/poly.c
+++ b/crypto_sign/dilithium2/clean/poly.c
@@ -48,25 +48,6 @@ void PQCLEAN_DILITHIUM2_CLEAN_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM2_CLEAN_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              standard representatives.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM2_CLEAN_poly_freeze(poly *a) {
-    unsigned int i;
-    DBENCH_START();
-
-    for (i = 0; i < N; ++i) {
-        a->coeffs[i] = PQCLEAN_DILITHIUM2_CLEAN_freeze(a->coeffs[i]);
-    }
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM2_CLEAN_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.

--- a/crypto_sign/dilithium2/clean/poly.h
+++ b/crypto_sign/dilithium2/clean/poly.h
@@ -9,7 +9,6 @@ typedef struct {
 
 void PQCLEAN_DILITHIUM2_CLEAN_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM2_CLEAN_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM2_CLEAN_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM2_CLEAN_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM2_CLEAN_poly_sub(poly *c, const poly *a, const poly *b);

--- a/crypto_sign/dilithium2/clean/polyvec.c
+++ b/crypto_sign/dilithium2/clean/polyvec.c
@@ -61,22 +61,6 @@ void PQCLEAN_DILITHIUM2_CLEAN_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM2_CLEAN_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM2_CLEAN_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM2_CLEAN_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM2_CLEAN_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -215,22 +199,6 @@ void PQCLEAN_DILITHIUM2_CLEAN_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM2_CLEAN_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM2_CLEAN_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM2_CLEAN_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM2_CLEAN_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium2/clean/polyvec.h
+++ b/crypto_sign/dilithium2/clean/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM2_CLEAN_polyvecl_uniform_gamma1(polyvecl *v, const uint8_t
 
 void PQCLEAN_DILITHIUM2_CLEAN_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM2_CLEAN_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM2_CLEAN_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM2_CLEAN_polyvecl_ntt(polyvecl *v);
@@ -40,7 +38,6 @@ void PQCLEAN_DILITHIUM2_CLEAN_polyveck_uniform_eta(polyveck *v, const uint8_t se
 
 void PQCLEAN_DILITHIUM2_CLEAN_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM2_CLEAN_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM2_CLEAN_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM2_CLEAN_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM2_CLEAN_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium2aes/META.yml
+++ b/crypto_sign/dilithium2aes/META.yml
@@ -17,9 +17,9 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
     - name: clean
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
     - name: avx2
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
       supported_platforms:
         - architecture: x86_64
           operating_systems:

--- a/crypto_sign/dilithium2aes/avx2/aes256ctr.c
+++ b/crypto_sign/dilithium2aes/avx2/aes256ctr.c
@@ -116,27 +116,3 @@ void PQCLEAN_DILITHIUM2AES_AVX2_aes256ctr_squeezeblocks(uint8_t *out,
         out += 64;
     }
 }
-
-void PQCLEAN_DILITHIUM2AES_AVX2_aes256ctr_prf(uint8_t *out,
-        size_t outlen,
-        const uint8_t seed[32],
-        uint64_t nonce) {
-    unsigned int i;
-    uint8_t buf[64];
-    aes256ctr_ctx state;
-
-    PQCLEAN_DILITHIUM2AES_AVX2_aes256ctr_init(&state, seed, nonce);
-
-    while (outlen >= 64) {
-        aesni_encrypt4(out, &state.n, state.rkeys);
-        outlen -= 64;
-        out += 64;
-    }
-
-    if (outlen) {
-        aesni_encrypt4(buf, &state.n, state.rkeys);
-        for (i = 0; i < outlen; i++) {
-            out[i] = buf[i];
-        }
-    }
-}

--- a/crypto_sign/dilithium2aes/avx2/aes256ctr.h
+++ b/crypto_sign/dilithium2aes/avx2/aes256ctr.h
@@ -21,9 +21,4 @@ void PQCLEAN_DILITHIUM2AES_AVX2_aes256ctr_squeezeblocks(uint8_t *out,
         size_t nblocks,
         aes256ctr_ctx *state);
 
-void PQCLEAN_DILITHIUM2AES_AVX2_aes256ctr_prf(uint8_t *out,
-        size_t outlen,
-        const uint8_t seed[32],
-        uint64_t nonce);
-
 #endif

--- a/crypto_sign/dilithium2aes/avx2/poly.c
+++ b/crypto_sign/dilithium2aes/avx2/poly.c
@@ -72,25 +72,6 @@ void PQCLEAN_DILITHIUM2AES_AVX2_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM2AES_AVX2_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              positive standard representatives. Assumes input
-*              coefficients to be at most 2^31 - 2^22 + 1 in
-*              absolute value.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM2AES_AVX2_poly_freeze(poly *a) {
-    DBENCH_START();
-
-    PQCLEAN_DILITHIUM2AES_AVX2_poly_reduce(a);
-    PQCLEAN_DILITHIUM2AES_AVX2_poly_caddq(a);
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM2AES_AVX2_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.
@@ -826,7 +807,7 @@ void PQCLEAN_DILITHIUM2AES_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const p
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *a: byte array with bit-packed polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM2AES_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[POLYZ_PACKEDBYTES + 14]) {
+void PQCLEAN_DILITHIUM2AES_AVX2_polyz_unpack(poly *restrict r, const uint8_t *a) {
     unsigned int i;
     __m256i f;
     const __m256i shufbidx = _mm256_set_epi8(-1, 9, 8, 7, -1, 7, 6, 5, -1, 5, 4, 3, -1, 3, 2, 1,
@@ -860,7 +841,7 @@ void PQCLEAN_DILITHIUM2AES_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[P
 *                            POLYW1_PACKEDBYTES bytes
 *              - const poly *a: pointer to input polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM2AES_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES + 8], const poly *restrict a) {
+void PQCLEAN_DILITHIUM2AES_AVX2_polyw1_pack(uint8_t *r, const poly *restrict a) {
     unsigned int i;
     __m256i f0, f1, f2, f3;
     const __m256i shift1 = _mm256_set1_epi16((64 << 8) + 1);

--- a/crypto_sign/dilithium2aes/avx2/poly.h
+++ b/crypto_sign/dilithium2aes/avx2/poly.h
@@ -9,7 +9,6 @@ typedef ALIGNED_INT32(N) poly;
 
 void PQCLEAN_DILITHIUM2AES_AVX2_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM2AES_AVX2_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM2AES_AVX2_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM2AES_AVX2_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM2AES_AVX2_poly_sub(poly *c, const poly *a, const poly *b);
@@ -45,8 +44,8 @@ void PQCLEAN_DILITHIUM2AES_AVX2_polyt0_pack(uint8_t r[POLYT0_PACKEDBYTES], const
 void PQCLEAN_DILITHIUM2AES_AVX2_polyt0_unpack(poly *r, const uint8_t a[POLYT0_PACKEDBYTES]);
 
 void PQCLEAN_DILITHIUM2AES_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly *a);
-void PQCLEAN_DILITHIUM2AES_AVX2_polyz_unpack(poly *r, const uint8_t a[POLYZ_PACKEDBYTES + 14]);
+void PQCLEAN_DILITHIUM2AES_AVX2_polyz_unpack(poly *r, const uint8_t *a);
 
-void PQCLEAN_DILITHIUM2AES_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES + 8], const poly *a);
+void PQCLEAN_DILITHIUM2AES_AVX2_polyw1_pack(uint8_t *r, const poly *a);
 
 #endif

--- a/crypto_sign/dilithium2aes/avx2/polyvec.c
+++ b/crypto_sign/dilithium2aes/avx2/polyvec.c
@@ -74,22 +74,6 @@ void PQCLEAN_DILITHIUM2AES_AVX2_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM2AES_AVX2_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM2AES_AVX2_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM2AES_AVX2_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM2AES_AVX2_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -219,22 +203,6 @@ void PQCLEAN_DILITHIUM2AES_AVX2_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM2AES_AVX2_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM2AES_AVX2_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM2AES_AVX2_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM2AES_AVX2_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium2aes/avx2/polyvec.h
+++ b/crypto_sign/dilithium2aes/avx2/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM2AES_AVX2_polyvecl_uniform_gamma1(polyvecl *v, const uint8
 
 void PQCLEAN_DILITHIUM2AES_AVX2_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM2AES_AVX2_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM2AES_AVX2_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM2AES_AVX2_polyvecl_ntt(polyvecl *v);
@@ -37,7 +35,6 @@ void PQCLEAN_DILITHIUM2AES_AVX2_polyveck_uniform_eta(polyveck *v, const uint8_t 
 
 void PQCLEAN_DILITHIUM2AES_AVX2_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM2AES_AVX2_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM2AES_AVX2_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM2AES_AVX2_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM2AES_AVX2_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium2aes/avx2/rejsample.h
+++ b/crypto_sign/dilithium2aes/avx2/rejsample.h
@@ -14,6 +14,6 @@ extern const uint8_t PQCLEAN_DILITHIUM2AES_AVX2_idxlut[256][8];
 
 unsigned int PQCLEAN_DILITHIUM2AES_AVX2_rej_uniform_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN + 8]);
 
-unsigned int PQCLEAN_DILITHIUM2AES_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN]);
+unsigned int PQCLEAN_DILITHIUM2AES_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_ETA_BUFLEN]);
 
 #endif

--- a/crypto_sign/dilithium2aes/clean/aes256ctr.c
+++ b/crypto_sign/dilithium2aes/clean/aes256ctr.c
@@ -466,7 +466,7 @@ static void inc4_be(uint32_t *x) {
     *x = br_swap32(*x);
 }
 
-static void aes_ctr4x(uint8_t out[64], uint32_t ivw[16], uint64_t sk_exp[64]) {
+static void aes_ctr4x(uint8_t out[64], uint32_t ivw[16], uint64_t sk_exp[120]) {
     uint32_t w[16];
     uint64_t q[8];
     int i;
@@ -508,41 +508,7 @@ static void br_aes_ct64_ctr_init(uint64_t sk_exp[120], const uint8_t *key) {
     br_aes_ct64_skey_expand(sk_exp, skey);
 }
 
-static void br_aes_ct64_ctr_run(uint64_t sk_exp[120], const uint8_t *iv, uint32_t cc, uint8_t *data, size_t len) {
-    uint32_t ivw[16];
-    size_t i;
-
-    br_range_dec32le(ivw, 3, iv);
-    memcpy(ivw +  4, ivw, 3 * sizeof(uint32_t));
-    memcpy(ivw +  8, ivw, 3 * sizeof(uint32_t));
-    memcpy(ivw + 12, ivw, 3 * sizeof(uint32_t));
-    ivw[ 3] = br_swap32(cc);
-    ivw[ 7] = br_swap32(cc + 1);
-    ivw[11] = br_swap32(cc + 2);
-    ivw[15] = br_swap32(cc + 3);
-
-    while (len > 64) {
-        aes_ctr4x(data, ivw, sk_exp);
-        data += 64;
-        len -= 64;
-    }
-    if (len > 0) {
-        uint8_t tmp[64];
-        aes_ctr4x(tmp, ivw, sk_exp);
-        for (i = 0; i < len; i++) {
-            data[i] = tmp[i];
-        }
-    }
-}
-
-void PQCLEAN_DILITHIUM2AES_CLEAN_aes256ctr_prf(uint8_t *out, size_t outlen, const uint8_t *key, const uint8_t *nonce) {
-    uint64_t sk_exp[120];
-
-    br_aes_ct64_ctr_init(sk_exp, key);
-    br_aes_ct64_ctr_run(sk_exp, nonce, 0, out, outlen);
-}
-
-void PQCLEAN_DILITHIUM2AES_CLEAN_aes256ctr_init(aes256ctr_ctx *s, const uint8_t *key, const uint8_t *nonce) {
+void PQCLEAN_DILITHIUM2AES_CLEAN_aes256ctr_init(aes256ctr_ctx *s, const uint8_t key[32], const uint8_t nonce[12]) {
     br_aes_ct64_ctr_init(s->sk_exp, key);
 
     br_range_dec32le(s->ivw, 3, nonce);

--- a/crypto_sign/dilithium2aes/clean/aes256ctr.h
+++ b/crypto_sign/dilithium2aes/clean/aes256ctr.h
@@ -12,11 +12,6 @@ typedef struct {
     uint32_t ivw[16];
 } aes256ctr_ctx;
 
-void PQCLEAN_DILITHIUM2AES_CLEAN_aes256ctr_prf(uint8_t *out,
-        size_t outlen,
-        const uint8_t key[32],
-        const uint8_t nonce[12]);
-
 void PQCLEAN_DILITHIUM2AES_CLEAN_aes256ctr_init(aes256ctr_ctx *state,
         const uint8_t key[32],
         const uint8_t nonce[12]);

--- a/crypto_sign/dilithium2aes/clean/poly.c
+++ b/crypto_sign/dilithium2aes/clean/poly.c
@@ -48,25 +48,6 @@ void PQCLEAN_DILITHIUM2AES_CLEAN_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM2AES_CLEAN_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              standard representatives.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM2AES_CLEAN_poly_freeze(poly *a) {
-    unsigned int i;
-    DBENCH_START();
-
-    for (i = 0; i < N; ++i) {
-        a->coeffs[i] = PQCLEAN_DILITHIUM2AES_CLEAN_freeze(a->coeffs[i]);
-    }
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM2AES_CLEAN_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.

--- a/crypto_sign/dilithium2aes/clean/poly.h
+++ b/crypto_sign/dilithium2aes/clean/poly.h
@@ -9,7 +9,6 @@ typedef struct {
 
 void PQCLEAN_DILITHIUM2AES_CLEAN_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM2AES_CLEAN_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM2AES_CLEAN_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM2AES_CLEAN_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM2AES_CLEAN_poly_sub(poly *c, const poly *a, const poly *b);

--- a/crypto_sign/dilithium2aes/clean/polyvec.c
+++ b/crypto_sign/dilithium2aes/clean/polyvec.c
@@ -61,22 +61,6 @@ void PQCLEAN_DILITHIUM2AES_CLEAN_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM2AES_CLEAN_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM2AES_CLEAN_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM2AES_CLEAN_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM2AES_CLEAN_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -215,22 +199,6 @@ void PQCLEAN_DILITHIUM2AES_CLEAN_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM2AES_CLEAN_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM2AES_CLEAN_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM2AES_CLEAN_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM2AES_CLEAN_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium2aes/clean/polyvec.h
+++ b/crypto_sign/dilithium2aes/clean/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM2AES_CLEAN_polyvecl_uniform_gamma1(polyvecl *v, const uint
 
 void PQCLEAN_DILITHIUM2AES_CLEAN_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM2AES_CLEAN_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM2AES_CLEAN_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM2AES_CLEAN_polyvecl_ntt(polyvecl *v);
@@ -40,7 +38,6 @@ void PQCLEAN_DILITHIUM2AES_CLEAN_polyveck_uniform_eta(polyveck *v, const uint8_t
 
 void PQCLEAN_DILITHIUM2AES_CLEAN_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM2AES_CLEAN_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM2AES_CLEAN_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM2AES_CLEAN_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM2AES_CLEAN_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium3/META.yml
+++ b/crypto_sign/dilithium3/META.yml
@@ -17,9 +17,9 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
     - name: clean
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
     - name: avx2
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
       supported_platforms:
         - architecture: x86_64
           operating_systems:
@@ -29,6 +29,7 @@ implementations:
               - aes
               - avx2
               - popcnt
+
     - name: aarch64
       version: https://github.com/neon-ntt/neon-ntt/tree/014d2a0c21d705a523b3bfd2a740f8f0a2ba7a27
       supported_platforms:

--- a/crypto_sign/dilithium3/avx2/fips202x4.c
+++ b/crypto_sign/dilithium3/avx2/fips202x4.c
@@ -100,13 +100,13 @@ static void keccakx4_squeezeblocks(uint8_t *out0,
             t = _mm_castsi128_pd(_mm256_castsi256_si128(s[i]));
             _mm_storel_pd(&temp0, t);
             _mm_storeh_pd(&temp1, t);
-            memmove(&out0[8 * i], &temp0, sizeof(double));
-            memmove(&out1[8 * i], &temp1, sizeof(double));
+            memcpy(&out0[8 * i], &temp0, sizeof(double));
+            memcpy(&out1[8 * i], &temp1, sizeof(double));
             t = _mm_castsi128_pd(_mm256_extracti128_si256(s[i], 1));
             _mm_storel_pd(&temp0, t);
             _mm_storeh_pd(&temp1, t);
-            memmove(&out2[8 * i], &temp0, sizeof(double));
-            memmove(&out3[8 * i], &temp1, sizeof(double));
+            memcpy(&out2[8 * i], &temp0, sizeof(double));
+            memcpy(&out3[8 * i], &temp1, sizeof(double));
         }
 
         out0 += r;

--- a/crypto_sign/dilithium3/avx2/poly.c
+++ b/crypto_sign/dilithium3/avx2/poly.c
@@ -73,25 +73,6 @@ void PQCLEAN_DILITHIUM3_AVX2_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM3_AVX2_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              positive standard representatives. Assumes input
-*              coefficients to be at most 2^31 - 2^22 + 1 in
-*              absolute value.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM3_AVX2_poly_freeze(poly *a) {
-    DBENCH_START();
-
-    PQCLEAN_DILITHIUM3_AVX2_poly_reduce(a);
-    PQCLEAN_DILITHIUM3_AVX2_poly_caddq(a);
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM3_AVX2_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.
@@ -934,7 +915,7 @@ void PQCLEAN_DILITHIUM3_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *a: byte array with bit-packed polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM3_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[POLYZ_PACKEDBYTES + 12]) {
+void PQCLEAN_DILITHIUM3_AVX2_polyz_unpack(poly *restrict r, const uint8_t *a) {
     unsigned int i;
     __m256i f;
     const __m256i shufbidx = _mm256_set_epi8(-1, 11, 10, 9, -1, 9, 8, 7, -1, 6, 5, 4, -1, 4, 3, 2,
@@ -967,7 +948,7 @@ void PQCLEAN_DILITHIUM3_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[POLY
 *                            POLYW1_PACKEDBYTES bytes
 *              - const poly *a: pointer to input polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM3_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES], const poly *restrict a) {
+void PQCLEAN_DILITHIUM3_AVX2_polyw1_pack(uint8_t *r, const poly *restrict a) {
     unsigned int i;
     __m256i f0, f1, f2, f3, f4, f5, f6, f7;
     const __m256i shift = _mm256_set1_epi16((16 << 8) + 1);

--- a/crypto_sign/dilithium3/avx2/poly.h
+++ b/crypto_sign/dilithium3/avx2/poly.h
@@ -9,7 +9,6 @@ typedef ALIGNED_INT32(N) poly;
 
 void PQCLEAN_DILITHIUM3_AVX2_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM3_AVX2_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM3_AVX2_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM3_AVX2_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM3_AVX2_poly_sub(poly *c, const poly *a, const poly *b);
@@ -72,8 +71,8 @@ void PQCLEAN_DILITHIUM3_AVX2_polyt0_pack(uint8_t r[POLYT0_PACKEDBYTES], const po
 void PQCLEAN_DILITHIUM3_AVX2_polyt0_unpack(poly *r, const uint8_t a[POLYT0_PACKEDBYTES]);
 
 void PQCLEAN_DILITHIUM3_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly *a);
-void PQCLEAN_DILITHIUM3_AVX2_polyz_unpack(poly *r, const uint8_t a[POLYZ_PACKEDBYTES + 14]);
+void PQCLEAN_DILITHIUM3_AVX2_polyz_unpack(poly *r, const uint8_t *a);
 
-void PQCLEAN_DILITHIUM3_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES + 8], const poly *a);
+void PQCLEAN_DILITHIUM3_AVX2_polyw1_pack(uint8_t *r, const poly *a);
 
 #endif

--- a/crypto_sign/dilithium3/avx2/polyvec.c
+++ b/crypto_sign/dilithium3/avx2/polyvec.c
@@ -123,22 +123,6 @@ void PQCLEAN_DILITHIUM3_AVX2_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM3_AVX2_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM3_AVX2_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM3_AVX2_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM3_AVX2_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -268,22 +252,6 @@ void PQCLEAN_DILITHIUM3_AVX2_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM3_AVX2_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM3_AVX2_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM3_AVX2_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM3_AVX2_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium3/avx2/polyvec.h
+++ b/crypto_sign/dilithium3/avx2/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM3_AVX2_polyvecl_uniform_gamma1(polyvecl *v, const uint8_t 
 
 void PQCLEAN_DILITHIUM3_AVX2_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM3_AVX2_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM3_AVX2_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM3_AVX2_polyvecl_ntt(polyvecl *v);
@@ -37,7 +35,6 @@ void PQCLEAN_DILITHIUM3_AVX2_polyveck_uniform_eta(polyveck *v, const uint8_t see
 
 void PQCLEAN_DILITHIUM3_AVX2_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM3_AVX2_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM3_AVX2_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM3_AVX2_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM3_AVX2_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium3/avx2/rejsample.h
+++ b/crypto_sign/dilithium3/avx2/rejsample.h
@@ -14,6 +14,6 @@ extern const uint8_t PQCLEAN_DILITHIUM3_AVX2_idxlut[256][8];
 
 unsigned int PQCLEAN_DILITHIUM3_AVX2_rej_uniform_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN + 8]);
 
-unsigned int PQCLEAN_DILITHIUM3_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN]);
+unsigned int PQCLEAN_DILITHIUM3_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_ETA_BUFLEN]);
 
 #endif

--- a/crypto_sign/dilithium3/clean/poly.c
+++ b/crypto_sign/dilithium3/clean/poly.c
@@ -48,25 +48,6 @@ void PQCLEAN_DILITHIUM3_CLEAN_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM3_CLEAN_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              standard representatives.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM3_CLEAN_poly_freeze(poly *a) {
-    unsigned int i;
-    DBENCH_START();
-
-    for (i = 0; i < N; ++i) {
-        a->coeffs[i] = PQCLEAN_DILITHIUM3_CLEAN_freeze(a->coeffs[i]);
-    }
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM3_CLEAN_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.

--- a/crypto_sign/dilithium3/clean/poly.h
+++ b/crypto_sign/dilithium3/clean/poly.h
@@ -9,7 +9,6 @@ typedef struct {
 
 void PQCLEAN_DILITHIUM3_CLEAN_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM3_CLEAN_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM3_CLEAN_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM3_CLEAN_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM3_CLEAN_poly_sub(poly *c, const poly *a, const poly *b);

--- a/crypto_sign/dilithium3/clean/polyvec.c
+++ b/crypto_sign/dilithium3/clean/polyvec.c
@@ -61,22 +61,6 @@ void PQCLEAN_DILITHIUM3_CLEAN_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM3_CLEAN_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM3_CLEAN_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM3_CLEAN_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM3_CLEAN_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -215,22 +199,6 @@ void PQCLEAN_DILITHIUM3_CLEAN_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM3_CLEAN_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM3_CLEAN_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM3_CLEAN_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM3_CLEAN_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium3/clean/polyvec.h
+++ b/crypto_sign/dilithium3/clean/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM3_CLEAN_polyvecl_uniform_gamma1(polyvecl *v, const uint8_t
 
 void PQCLEAN_DILITHIUM3_CLEAN_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM3_CLEAN_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM3_CLEAN_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM3_CLEAN_polyvecl_ntt(polyvecl *v);
@@ -40,7 +38,6 @@ void PQCLEAN_DILITHIUM3_CLEAN_polyveck_uniform_eta(polyveck *v, const uint8_t se
 
 void PQCLEAN_DILITHIUM3_CLEAN_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM3_CLEAN_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM3_CLEAN_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM3_CLEAN_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM3_CLEAN_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium3aes/META.yml
+++ b/crypto_sign/dilithium3aes/META.yml
@@ -17,9 +17,9 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
     - name: clean
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
     - name: avx2
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
       supported_platforms:
         - architecture: x86_64
           operating_systems:

--- a/crypto_sign/dilithium3aes/avx2/aes256ctr.c
+++ b/crypto_sign/dilithium3aes/avx2/aes256ctr.c
@@ -116,27 +116,3 @@ void PQCLEAN_DILITHIUM3AES_AVX2_aes256ctr_squeezeblocks(uint8_t *out,
         out += 64;
     }
 }
-
-void PQCLEAN_DILITHIUM3AES_AVX2_aes256ctr_prf(uint8_t *out,
-        size_t outlen,
-        const uint8_t seed[32],
-        uint64_t nonce) {
-    unsigned int i;
-    uint8_t buf[64];
-    aes256ctr_ctx state;
-
-    PQCLEAN_DILITHIUM3AES_AVX2_aes256ctr_init(&state, seed, nonce);
-
-    while (outlen >= 64) {
-        aesni_encrypt4(out, &state.n, state.rkeys);
-        outlen -= 64;
-        out += 64;
-    }
-
-    if (outlen) {
-        aesni_encrypt4(buf, &state.n, state.rkeys);
-        for (i = 0; i < outlen; i++) {
-            out[i] = buf[i];
-        }
-    }
-}

--- a/crypto_sign/dilithium3aes/avx2/aes256ctr.h
+++ b/crypto_sign/dilithium3aes/avx2/aes256ctr.h
@@ -21,9 +21,4 @@ void PQCLEAN_DILITHIUM3AES_AVX2_aes256ctr_squeezeblocks(uint8_t *out,
         size_t nblocks,
         aes256ctr_ctx *state);
 
-void PQCLEAN_DILITHIUM3AES_AVX2_aes256ctr_prf(uint8_t *out,
-        size_t outlen,
-        const uint8_t seed[32],
-        uint64_t nonce);
-
 #endif

--- a/crypto_sign/dilithium3aes/avx2/poly.c
+++ b/crypto_sign/dilithium3aes/avx2/poly.c
@@ -72,25 +72,6 @@ void PQCLEAN_DILITHIUM3AES_AVX2_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM3AES_AVX2_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              positive standard representatives. Assumes input
-*              coefficients to be at most 2^31 - 2^22 + 1 in
-*              absolute value.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM3AES_AVX2_poly_freeze(poly *a) {
-    DBENCH_START();
-
-    PQCLEAN_DILITHIUM3AES_AVX2_poly_reduce(a);
-    PQCLEAN_DILITHIUM3AES_AVX2_poly_caddq(a);
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM3AES_AVX2_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.
@@ -794,7 +775,7 @@ void PQCLEAN_DILITHIUM3AES_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const p
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *a: byte array with bit-packed polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM3AES_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[POLYZ_PACKEDBYTES + 12]) {
+void PQCLEAN_DILITHIUM3AES_AVX2_polyz_unpack(poly *restrict r, const uint8_t *a) {
     unsigned int i;
     __m256i f;
     const __m256i shufbidx = _mm256_set_epi8(-1, 11, 10, 9, -1, 9, 8, 7, -1, 6, 5, 4, -1, 4, 3, 2,
@@ -827,7 +808,7 @@ void PQCLEAN_DILITHIUM3AES_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[P
 *                            POLYW1_PACKEDBYTES bytes
 *              - const poly *a: pointer to input polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM3AES_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES], const poly *restrict a) {
+void PQCLEAN_DILITHIUM3AES_AVX2_polyw1_pack(uint8_t *r, const poly *restrict a) {
     unsigned int i;
     __m256i f0, f1, f2, f3, f4, f5, f6, f7;
     const __m256i shift = _mm256_set1_epi16((16 << 8) + 1);

--- a/crypto_sign/dilithium3aes/avx2/poly.h
+++ b/crypto_sign/dilithium3aes/avx2/poly.h
@@ -9,7 +9,6 @@ typedef ALIGNED_INT32(N) poly;
 
 void PQCLEAN_DILITHIUM3AES_AVX2_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM3AES_AVX2_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM3AES_AVX2_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM3AES_AVX2_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM3AES_AVX2_poly_sub(poly *c, const poly *a, const poly *b);
@@ -45,8 +44,8 @@ void PQCLEAN_DILITHIUM3AES_AVX2_polyt0_pack(uint8_t r[POLYT0_PACKEDBYTES], const
 void PQCLEAN_DILITHIUM3AES_AVX2_polyt0_unpack(poly *r, const uint8_t a[POLYT0_PACKEDBYTES]);
 
 void PQCLEAN_DILITHIUM3AES_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly *a);
-void PQCLEAN_DILITHIUM3AES_AVX2_polyz_unpack(poly *r, const uint8_t a[POLYZ_PACKEDBYTES + 14]);
+void PQCLEAN_DILITHIUM3AES_AVX2_polyz_unpack(poly *r, const uint8_t *a);
 
-void PQCLEAN_DILITHIUM3AES_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES + 8], const poly *a);
+void PQCLEAN_DILITHIUM3AES_AVX2_polyw1_pack(uint8_t *r, const poly *a);
 
 #endif

--- a/crypto_sign/dilithium3aes/avx2/polyvec.c
+++ b/crypto_sign/dilithium3aes/avx2/polyvec.c
@@ -74,22 +74,6 @@ void PQCLEAN_DILITHIUM3AES_AVX2_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM3AES_AVX2_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM3AES_AVX2_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM3AES_AVX2_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM3AES_AVX2_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -219,22 +203,6 @@ void PQCLEAN_DILITHIUM3AES_AVX2_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM3AES_AVX2_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM3AES_AVX2_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM3AES_AVX2_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM3AES_AVX2_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium3aes/avx2/polyvec.h
+++ b/crypto_sign/dilithium3aes/avx2/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM3AES_AVX2_polyvecl_uniform_gamma1(polyvecl *v, const uint8
 
 void PQCLEAN_DILITHIUM3AES_AVX2_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM3AES_AVX2_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM3AES_AVX2_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM3AES_AVX2_polyvecl_ntt(polyvecl *v);
@@ -37,7 +35,6 @@ void PQCLEAN_DILITHIUM3AES_AVX2_polyveck_uniform_eta(polyveck *v, const uint8_t 
 
 void PQCLEAN_DILITHIUM3AES_AVX2_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM3AES_AVX2_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM3AES_AVX2_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM3AES_AVX2_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM3AES_AVX2_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium3aes/avx2/rejsample.h
+++ b/crypto_sign/dilithium3aes/avx2/rejsample.h
@@ -14,6 +14,6 @@ extern const uint8_t PQCLEAN_DILITHIUM3AES_AVX2_idxlut[256][8];
 
 unsigned int PQCLEAN_DILITHIUM3AES_AVX2_rej_uniform_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN + 8]);
 
-unsigned int PQCLEAN_DILITHIUM3AES_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN]);
+unsigned int PQCLEAN_DILITHIUM3AES_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_ETA_BUFLEN]);
 
 #endif

--- a/crypto_sign/dilithium3aes/clean/aes256ctr.c
+++ b/crypto_sign/dilithium3aes/clean/aes256ctr.c
@@ -466,7 +466,7 @@ static void inc4_be(uint32_t *x) {
     *x = br_swap32(*x);
 }
 
-static void aes_ctr4x(uint8_t out[64], uint32_t ivw[16], uint64_t sk_exp[64]) {
+static void aes_ctr4x(uint8_t out[64], uint32_t ivw[16], uint64_t sk_exp[120]) {
     uint32_t w[16];
     uint64_t q[8];
     int i;
@@ -508,41 +508,7 @@ static void br_aes_ct64_ctr_init(uint64_t sk_exp[120], const uint8_t *key) {
     br_aes_ct64_skey_expand(sk_exp, skey);
 }
 
-static void br_aes_ct64_ctr_run(uint64_t sk_exp[120], const uint8_t *iv, uint32_t cc, uint8_t *data, size_t len) {
-    uint32_t ivw[16];
-    size_t i;
-
-    br_range_dec32le(ivw, 3, iv);
-    memcpy(ivw +  4, ivw, 3 * sizeof(uint32_t));
-    memcpy(ivw +  8, ivw, 3 * sizeof(uint32_t));
-    memcpy(ivw + 12, ivw, 3 * sizeof(uint32_t));
-    ivw[ 3] = br_swap32(cc);
-    ivw[ 7] = br_swap32(cc + 1);
-    ivw[11] = br_swap32(cc + 2);
-    ivw[15] = br_swap32(cc + 3);
-
-    while (len > 64) {
-        aes_ctr4x(data, ivw, sk_exp);
-        data += 64;
-        len -= 64;
-    }
-    if (len > 0) {
-        uint8_t tmp[64];
-        aes_ctr4x(tmp, ivw, sk_exp);
-        for (i = 0; i < len; i++) {
-            data[i] = tmp[i];
-        }
-    }
-}
-
-void PQCLEAN_DILITHIUM3AES_CLEAN_aes256ctr_prf(uint8_t *out, size_t outlen, const uint8_t *key, const uint8_t *nonce) {
-    uint64_t sk_exp[120];
-
-    br_aes_ct64_ctr_init(sk_exp, key);
-    br_aes_ct64_ctr_run(sk_exp, nonce, 0, out, outlen);
-}
-
-void PQCLEAN_DILITHIUM3AES_CLEAN_aes256ctr_init(aes256ctr_ctx *s, const uint8_t *key, const uint8_t *nonce) {
+void PQCLEAN_DILITHIUM3AES_CLEAN_aes256ctr_init(aes256ctr_ctx *s, const uint8_t key[32], const uint8_t nonce[12]) {
     br_aes_ct64_ctr_init(s->sk_exp, key);
 
     br_range_dec32le(s->ivw, 3, nonce);

--- a/crypto_sign/dilithium3aes/clean/aes256ctr.h
+++ b/crypto_sign/dilithium3aes/clean/aes256ctr.h
@@ -12,11 +12,6 @@ typedef struct {
     uint32_t ivw[16];
 } aes256ctr_ctx;
 
-void PQCLEAN_DILITHIUM3AES_CLEAN_aes256ctr_prf(uint8_t *out,
-        size_t outlen,
-        const uint8_t key[32],
-        const uint8_t nonce[12]);
-
 void PQCLEAN_DILITHIUM3AES_CLEAN_aes256ctr_init(aes256ctr_ctx *state,
         const uint8_t key[32],
         const uint8_t nonce[12]);

--- a/crypto_sign/dilithium3aes/clean/poly.c
+++ b/crypto_sign/dilithium3aes/clean/poly.c
@@ -48,25 +48,6 @@ void PQCLEAN_DILITHIUM3AES_CLEAN_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM3AES_CLEAN_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              standard representatives.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM3AES_CLEAN_poly_freeze(poly *a) {
-    unsigned int i;
-    DBENCH_START();
-
-    for (i = 0; i < N; ++i) {
-        a->coeffs[i] = PQCLEAN_DILITHIUM3AES_CLEAN_freeze(a->coeffs[i]);
-    }
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM3AES_CLEAN_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.

--- a/crypto_sign/dilithium3aes/clean/poly.h
+++ b/crypto_sign/dilithium3aes/clean/poly.h
@@ -9,7 +9,6 @@ typedef struct {
 
 void PQCLEAN_DILITHIUM3AES_CLEAN_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM3AES_CLEAN_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM3AES_CLEAN_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM3AES_CLEAN_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM3AES_CLEAN_poly_sub(poly *c, const poly *a, const poly *b);

--- a/crypto_sign/dilithium3aes/clean/polyvec.c
+++ b/crypto_sign/dilithium3aes/clean/polyvec.c
@@ -61,22 +61,6 @@ void PQCLEAN_DILITHIUM3AES_CLEAN_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM3AES_CLEAN_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM3AES_CLEAN_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM3AES_CLEAN_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM3AES_CLEAN_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -215,22 +199,6 @@ void PQCLEAN_DILITHIUM3AES_CLEAN_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM3AES_CLEAN_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM3AES_CLEAN_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM3AES_CLEAN_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM3AES_CLEAN_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium3aes/clean/polyvec.h
+++ b/crypto_sign/dilithium3aes/clean/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM3AES_CLEAN_polyvecl_uniform_gamma1(polyvecl *v, const uint
 
 void PQCLEAN_DILITHIUM3AES_CLEAN_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM3AES_CLEAN_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM3AES_CLEAN_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM3AES_CLEAN_polyvecl_ntt(polyvecl *v);
@@ -40,7 +38,6 @@ void PQCLEAN_DILITHIUM3AES_CLEAN_polyveck_uniform_eta(polyveck *v, const uint8_t
 
 void PQCLEAN_DILITHIUM3AES_CLEAN_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM3AES_CLEAN_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM3AES_CLEAN_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM3AES_CLEAN_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM3AES_CLEAN_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium5/META.yml
+++ b/crypto_sign/dilithium5/META.yml
@@ -17,9 +17,9 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
     - name: clean
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
     - name: avx2
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
       supported_platforms:
         - architecture: x86_64
           operating_systems:
@@ -29,6 +29,7 @@ implementations:
               - aes
               - avx2
               - popcnt
+
     - name: aarch64
       version: https://github.com/neon-ntt/neon-ntt/tree/014d2a0c21d705a523b3bfd2a740f8f0a2ba7a27
       supported_platforms:

--- a/crypto_sign/dilithium5/avx2/fips202x4.c
+++ b/crypto_sign/dilithium5/avx2/fips202x4.c
@@ -100,13 +100,13 @@ static void keccakx4_squeezeblocks(uint8_t *out0,
             t = _mm_castsi128_pd(_mm256_castsi256_si128(s[i]));
             _mm_storel_pd(&temp0, t);
             _mm_storeh_pd(&temp1, t);
-            memmove(&out0[8 * i], &temp0, sizeof(double));
-            memmove(&out1[8 * i], &temp1, sizeof(double));
+            memcpy(&out0[8 * i], &temp0, sizeof(double));
+            memcpy(&out1[8 * i], &temp1, sizeof(double));
             t = _mm_castsi128_pd(_mm256_extracti128_si256(s[i], 1));
             _mm_storel_pd(&temp0, t);
             _mm_storeh_pd(&temp1, t);
-            memmove(&out2[8 * i], &temp0, sizeof(double));
-            memmove(&out3[8 * i], &temp1, sizeof(double));
+            memcpy(&out2[8 * i], &temp0, sizeof(double));
+            memcpy(&out3[8 * i], &temp1, sizeof(double));
         }
 
         out0 += r;

--- a/crypto_sign/dilithium5/avx2/poly.c
+++ b/crypto_sign/dilithium5/avx2/poly.c
@@ -73,25 +73,6 @@ void PQCLEAN_DILITHIUM5_AVX2_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM5_AVX2_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              positive standard representatives. Assumes input
-*              coefficients to be at most 2^31 - 2^22 + 1 in
-*              absolute value.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM5_AVX2_poly_freeze(poly *a) {
-    DBENCH_START();
-
-    PQCLEAN_DILITHIUM5_AVX2_poly_reduce(a);
-    PQCLEAN_DILITHIUM5_AVX2_poly_caddq(a);
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM5_AVX2_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.
@@ -958,7 +939,7 @@ void PQCLEAN_DILITHIUM5_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *a: byte array with bit-packed polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM5_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[POLYZ_PACKEDBYTES + 12]) {
+void PQCLEAN_DILITHIUM5_AVX2_polyz_unpack(poly *restrict r, const uint8_t *a) {
     unsigned int i;
     __m256i f;
     const __m256i shufbidx = _mm256_set_epi8(-1, 11, 10, 9, -1, 9, 8, 7, -1, 6, 5, 4, -1, 4, 3, 2,
@@ -991,7 +972,7 @@ void PQCLEAN_DILITHIUM5_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[POLY
 *                            POLYW1_PACKEDBYTES bytes
 *              - const poly *a: pointer to input polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM5_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES], const poly *restrict a) {
+void PQCLEAN_DILITHIUM5_AVX2_polyw1_pack(uint8_t *r, const poly *restrict a) {
     unsigned int i;
     __m256i f0, f1, f2, f3, f4, f5, f6, f7;
     const __m256i shift = _mm256_set1_epi16((16 << 8) + 1);

--- a/crypto_sign/dilithium5/avx2/poly.h
+++ b/crypto_sign/dilithium5/avx2/poly.h
@@ -9,7 +9,6 @@ typedef ALIGNED_INT32(N) poly;
 
 void PQCLEAN_DILITHIUM5_AVX2_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM5_AVX2_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM5_AVX2_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM5_AVX2_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM5_AVX2_poly_sub(poly *c, const poly *a, const poly *b);
@@ -72,8 +71,8 @@ void PQCLEAN_DILITHIUM5_AVX2_polyt0_pack(uint8_t r[POLYT0_PACKEDBYTES], const po
 void PQCLEAN_DILITHIUM5_AVX2_polyt0_unpack(poly *r, const uint8_t a[POLYT0_PACKEDBYTES]);
 
 void PQCLEAN_DILITHIUM5_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly *a);
-void PQCLEAN_DILITHIUM5_AVX2_polyz_unpack(poly *r, const uint8_t a[POLYZ_PACKEDBYTES + 14]);
+void PQCLEAN_DILITHIUM5_AVX2_polyz_unpack(poly *r, const uint8_t *a);
 
-void PQCLEAN_DILITHIUM5_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES + 8], const poly *a);
+void PQCLEAN_DILITHIUM5_AVX2_polyw1_pack(uint8_t *r, const poly *a);
 
 #endif

--- a/crypto_sign/dilithium5/avx2/polyvec.c
+++ b/crypto_sign/dilithium5/avx2/polyvec.c
@@ -163,22 +163,6 @@ void PQCLEAN_DILITHIUM5_AVX2_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM5_AVX2_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM5_AVX2_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM5_AVX2_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM5_AVX2_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -308,22 +292,6 @@ void PQCLEAN_DILITHIUM5_AVX2_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM5_AVX2_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM5_AVX2_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM5_AVX2_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM5_AVX2_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium5/avx2/polyvec.h
+++ b/crypto_sign/dilithium5/avx2/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM5_AVX2_polyvecl_uniform_gamma1(polyvecl *v, const uint8_t 
 
 void PQCLEAN_DILITHIUM5_AVX2_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM5_AVX2_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM5_AVX2_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM5_AVX2_polyvecl_ntt(polyvecl *v);
@@ -37,7 +35,6 @@ void PQCLEAN_DILITHIUM5_AVX2_polyveck_uniform_eta(polyveck *v, const uint8_t see
 
 void PQCLEAN_DILITHIUM5_AVX2_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM5_AVX2_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM5_AVX2_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM5_AVX2_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM5_AVX2_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium5/avx2/rejsample.h
+++ b/crypto_sign/dilithium5/avx2/rejsample.h
@@ -14,6 +14,6 @@ extern const uint8_t PQCLEAN_DILITHIUM5_AVX2_idxlut[256][8];
 
 unsigned int PQCLEAN_DILITHIUM5_AVX2_rej_uniform_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN + 8]);
 
-unsigned int PQCLEAN_DILITHIUM5_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN]);
+unsigned int PQCLEAN_DILITHIUM5_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_ETA_BUFLEN]);
 
 #endif

--- a/crypto_sign/dilithium5/clean/poly.c
+++ b/crypto_sign/dilithium5/clean/poly.c
@@ -48,25 +48,6 @@ void PQCLEAN_DILITHIUM5_CLEAN_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM5_CLEAN_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              standard representatives.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM5_CLEAN_poly_freeze(poly *a) {
-    unsigned int i;
-    DBENCH_START();
-
-    for (i = 0; i < N; ++i) {
-        a->coeffs[i] = PQCLEAN_DILITHIUM5_CLEAN_freeze(a->coeffs[i]);
-    }
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM5_CLEAN_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.

--- a/crypto_sign/dilithium5/clean/poly.h
+++ b/crypto_sign/dilithium5/clean/poly.h
@@ -9,7 +9,6 @@ typedef struct {
 
 void PQCLEAN_DILITHIUM5_CLEAN_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM5_CLEAN_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM5_CLEAN_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM5_CLEAN_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM5_CLEAN_poly_sub(poly *c, const poly *a, const poly *b);

--- a/crypto_sign/dilithium5/clean/polyvec.c
+++ b/crypto_sign/dilithium5/clean/polyvec.c
@@ -61,22 +61,6 @@ void PQCLEAN_DILITHIUM5_CLEAN_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM5_CLEAN_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM5_CLEAN_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM5_CLEAN_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM5_CLEAN_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -215,22 +199,6 @@ void PQCLEAN_DILITHIUM5_CLEAN_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM5_CLEAN_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM5_CLEAN_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM5_CLEAN_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM5_CLEAN_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium5/clean/polyvec.h
+++ b/crypto_sign/dilithium5/clean/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM5_CLEAN_polyvecl_uniform_gamma1(polyvecl *v, const uint8_t
 
 void PQCLEAN_DILITHIUM5_CLEAN_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM5_CLEAN_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM5_CLEAN_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM5_CLEAN_polyvecl_ntt(polyvecl *v);
@@ -40,7 +38,6 @@ void PQCLEAN_DILITHIUM5_CLEAN_polyveck_uniform_eta(polyveck *v, const uint8_t se
 
 void PQCLEAN_DILITHIUM5_CLEAN_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM5_CLEAN_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM5_CLEAN_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM5_CLEAN_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM5_CLEAN_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium5aes/META.yml
+++ b/crypto_sign/dilithium5aes/META.yml
@@ -17,9 +17,9 @@ auxiliary-submitters:
   - Damien Stehlé
 implementations:
     - name: clean
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
     - name: avx2
-      version: https://github.com/pq-crystals/dilithium/commit/adf7476d645fb808b5c5d2dd1ef1aaeefdc0c897 via https://github.com/jschanck/package-pqclean/tree/80749c85/dilithium
+      version: https://github.com/pq-crystals/dilithium/commit/61b51a71701b8ae9f546a1e5d220e1950ed20d06 via https://github.com/jschanck/package-pqclean/tree/98146649/dilithium
       supported_platforms:
         - architecture: x86_64
           operating_systems:

--- a/crypto_sign/dilithium5aes/avx2/aes256ctr.c
+++ b/crypto_sign/dilithium5aes/avx2/aes256ctr.c
@@ -116,27 +116,3 @@ void PQCLEAN_DILITHIUM5AES_AVX2_aes256ctr_squeezeblocks(uint8_t *out,
         out += 64;
     }
 }
-
-void PQCLEAN_DILITHIUM5AES_AVX2_aes256ctr_prf(uint8_t *out,
-        size_t outlen,
-        const uint8_t seed[32],
-        uint64_t nonce) {
-    unsigned int i;
-    uint8_t buf[64];
-    aes256ctr_ctx state;
-
-    PQCLEAN_DILITHIUM5AES_AVX2_aes256ctr_init(&state, seed, nonce);
-
-    while (outlen >= 64) {
-        aesni_encrypt4(out, &state.n, state.rkeys);
-        outlen -= 64;
-        out += 64;
-    }
-
-    if (outlen) {
-        aesni_encrypt4(buf, &state.n, state.rkeys);
-        for (i = 0; i < outlen; i++) {
-            out[i] = buf[i];
-        }
-    }
-}

--- a/crypto_sign/dilithium5aes/avx2/aes256ctr.h
+++ b/crypto_sign/dilithium5aes/avx2/aes256ctr.h
@@ -21,9 +21,4 @@ void PQCLEAN_DILITHIUM5AES_AVX2_aes256ctr_squeezeblocks(uint8_t *out,
         size_t nblocks,
         aes256ctr_ctx *state);
 
-void PQCLEAN_DILITHIUM5AES_AVX2_aes256ctr_prf(uint8_t *out,
-        size_t outlen,
-        const uint8_t seed[32],
-        uint64_t nonce);
-
 #endif

--- a/crypto_sign/dilithium5aes/avx2/poly.c
+++ b/crypto_sign/dilithium5aes/avx2/poly.c
@@ -72,25 +72,6 @@ void PQCLEAN_DILITHIUM5AES_AVX2_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM5AES_AVX2_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              positive standard representatives. Assumes input
-*              coefficients to be at most 2^31 - 2^22 + 1 in
-*              absolute value.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM5AES_AVX2_poly_freeze(poly *a) {
-    DBENCH_START();
-
-    PQCLEAN_DILITHIUM5AES_AVX2_poly_reduce(a);
-    PQCLEAN_DILITHIUM5AES_AVX2_poly_caddq(a);
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM5AES_AVX2_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.
@@ -818,7 +799,7 @@ void PQCLEAN_DILITHIUM5AES_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const p
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *a: byte array with bit-packed polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM5AES_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[POLYZ_PACKEDBYTES + 12]) {
+void PQCLEAN_DILITHIUM5AES_AVX2_polyz_unpack(poly *restrict r, const uint8_t *a) {
     unsigned int i;
     __m256i f;
     const __m256i shufbidx = _mm256_set_epi8(-1, 11, 10, 9, -1, 9, 8, 7, -1, 6, 5, 4, -1, 4, 3, 2,
@@ -851,7 +832,7 @@ void PQCLEAN_DILITHIUM5AES_AVX2_polyz_unpack(poly *restrict r, const uint8_t a[P
 *                            POLYW1_PACKEDBYTES bytes
 *              - const poly *a: pointer to input polynomial
 **************************************************/
-void PQCLEAN_DILITHIUM5AES_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES], const poly *restrict a) {
+void PQCLEAN_DILITHIUM5AES_AVX2_polyw1_pack(uint8_t *r, const poly *restrict a) {
     unsigned int i;
     __m256i f0, f1, f2, f3, f4, f5, f6, f7;
     const __m256i shift = _mm256_set1_epi16((16 << 8) + 1);

--- a/crypto_sign/dilithium5aes/avx2/poly.h
+++ b/crypto_sign/dilithium5aes/avx2/poly.h
@@ -9,7 +9,6 @@ typedef ALIGNED_INT32(N) poly;
 
 void PQCLEAN_DILITHIUM5AES_AVX2_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM5AES_AVX2_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM5AES_AVX2_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM5AES_AVX2_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM5AES_AVX2_poly_sub(poly *c, const poly *a, const poly *b);
@@ -45,8 +44,8 @@ void PQCLEAN_DILITHIUM5AES_AVX2_polyt0_pack(uint8_t r[POLYT0_PACKEDBYTES], const
 void PQCLEAN_DILITHIUM5AES_AVX2_polyt0_unpack(poly *r, const uint8_t a[POLYT0_PACKEDBYTES]);
 
 void PQCLEAN_DILITHIUM5AES_AVX2_polyz_pack(uint8_t r[POLYZ_PACKEDBYTES], const poly *a);
-void PQCLEAN_DILITHIUM5AES_AVX2_polyz_unpack(poly *r, const uint8_t a[POLYZ_PACKEDBYTES + 14]);
+void PQCLEAN_DILITHIUM5AES_AVX2_polyz_unpack(poly *r, const uint8_t *a);
 
-void PQCLEAN_DILITHIUM5AES_AVX2_polyw1_pack(uint8_t r[POLYW1_PACKEDBYTES + 8], const poly *a);
+void PQCLEAN_DILITHIUM5AES_AVX2_polyw1_pack(uint8_t *r, const poly *a);
 
 #endif

--- a/crypto_sign/dilithium5aes/avx2/polyvec.c
+++ b/crypto_sign/dilithium5aes/avx2/polyvec.c
@@ -74,22 +74,6 @@ void PQCLEAN_DILITHIUM5AES_AVX2_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM5AES_AVX2_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM5AES_AVX2_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM5AES_AVX2_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM5AES_AVX2_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -219,22 +203,6 @@ void PQCLEAN_DILITHIUM5AES_AVX2_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM5AES_AVX2_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM5AES_AVX2_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM5AES_AVX2_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM5AES_AVX2_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium5aes/avx2/polyvec.h
+++ b/crypto_sign/dilithium5aes/avx2/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM5AES_AVX2_polyvecl_uniform_gamma1(polyvecl *v, const uint8
 
 void PQCLEAN_DILITHIUM5AES_AVX2_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM5AES_AVX2_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM5AES_AVX2_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM5AES_AVX2_polyvecl_ntt(polyvecl *v);
@@ -37,7 +35,6 @@ void PQCLEAN_DILITHIUM5AES_AVX2_polyveck_uniform_eta(polyveck *v, const uint8_t 
 
 void PQCLEAN_DILITHIUM5AES_AVX2_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM5AES_AVX2_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM5AES_AVX2_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM5AES_AVX2_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM5AES_AVX2_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);

--- a/crypto_sign/dilithium5aes/avx2/rejsample.h
+++ b/crypto_sign/dilithium5aes/avx2/rejsample.h
@@ -14,6 +14,6 @@ extern const uint8_t PQCLEAN_DILITHIUM5AES_AVX2_idxlut[256][8];
 
 unsigned int PQCLEAN_DILITHIUM5AES_AVX2_rej_uniform_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN + 8]);
 
-unsigned int PQCLEAN_DILITHIUM5AES_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_BUFLEN]);
+unsigned int PQCLEAN_DILITHIUM5AES_AVX2_rej_eta_avx(int32_t *r, const uint8_t buf[REJ_UNIFORM_ETA_BUFLEN]);
 
 #endif

--- a/crypto_sign/dilithium5aes/clean/aes256ctr.c
+++ b/crypto_sign/dilithium5aes/clean/aes256ctr.c
@@ -466,7 +466,7 @@ static void inc4_be(uint32_t *x) {
     *x = br_swap32(*x);
 }
 
-static void aes_ctr4x(uint8_t out[64], uint32_t ivw[16], uint64_t sk_exp[64]) {
+static void aes_ctr4x(uint8_t out[64], uint32_t ivw[16], uint64_t sk_exp[120]) {
     uint32_t w[16];
     uint64_t q[8];
     int i;
@@ -508,41 +508,7 @@ static void br_aes_ct64_ctr_init(uint64_t sk_exp[120], const uint8_t *key) {
     br_aes_ct64_skey_expand(sk_exp, skey);
 }
 
-static void br_aes_ct64_ctr_run(uint64_t sk_exp[120], const uint8_t *iv, uint32_t cc, uint8_t *data, size_t len) {
-    uint32_t ivw[16];
-    size_t i;
-
-    br_range_dec32le(ivw, 3, iv);
-    memcpy(ivw +  4, ivw, 3 * sizeof(uint32_t));
-    memcpy(ivw +  8, ivw, 3 * sizeof(uint32_t));
-    memcpy(ivw + 12, ivw, 3 * sizeof(uint32_t));
-    ivw[ 3] = br_swap32(cc);
-    ivw[ 7] = br_swap32(cc + 1);
-    ivw[11] = br_swap32(cc + 2);
-    ivw[15] = br_swap32(cc + 3);
-
-    while (len > 64) {
-        aes_ctr4x(data, ivw, sk_exp);
-        data += 64;
-        len -= 64;
-    }
-    if (len > 0) {
-        uint8_t tmp[64];
-        aes_ctr4x(tmp, ivw, sk_exp);
-        for (i = 0; i < len; i++) {
-            data[i] = tmp[i];
-        }
-    }
-}
-
-void PQCLEAN_DILITHIUM5AES_CLEAN_aes256ctr_prf(uint8_t *out, size_t outlen, const uint8_t *key, const uint8_t *nonce) {
-    uint64_t sk_exp[120];
-
-    br_aes_ct64_ctr_init(sk_exp, key);
-    br_aes_ct64_ctr_run(sk_exp, nonce, 0, out, outlen);
-}
-
-void PQCLEAN_DILITHIUM5AES_CLEAN_aes256ctr_init(aes256ctr_ctx *s, const uint8_t *key, const uint8_t *nonce) {
+void PQCLEAN_DILITHIUM5AES_CLEAN_aes256ctr_init(aes256ctr_ctx *s, const uint8_t key[32], const uint8_t nonce[12]) {
     br_aes_ct64_ctr_init(s->sk_exp, key);
 
     br_range_dec32le(s->ivw, 3, nonce);

--- a/crypto_sign/dilithium5aes/clean/aes256ctr.h
+++ b/crypto_sign/dilithium5aes/clean/aes256ctr.h
@@ -12,11 +12,6 @@ typedef struct {
     uint32_t ivw[16];
 } aes256ctr_ctx;
 
-void PQCLEAN_DILITHIUM5AES_CLEAN_aes256ctr_prf(uint8_t *out,
-        size_t outlen,
-        const uint8_t key[32],
-        const uint8_t nonce[12]);
-
 void PQCLEAN_DILITHIUM5AES_CLEAN_aes256ctr_init(aes256ctr_ctx *state,
         const uint8_t key[32],
         const uint8_t nonce[12]);

--- a/crypto_sign/dilithium5aes/clean/poly.c
+++ b/crypto_sign/dilithium5aes/clean/poly.c
@@ -48,25 +48,6 @@ void PQCLEAN_DILITHIUM5AES_CLEAN_poly_caddq(poly *a) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM5AES_CLEAN_poly_freeze
-*
-* Description: Inplace reduction of all coefficients of polynomial to
-*              standard representatives.
-*
-* Arguments:   - poly *a: pointer to input/output polynomial
-**************************************************/
-void PQCLEAN_DILITHIUM5AES_CLEAN_poly_freeze(poly *a) {
-    unsigned int i;
-    DBENCH_START();
-
-    for (i = 0; i < N; ++i) {
-        a->coeffs[i] = PQCLEAN_DILITHIUM5AES_CLEAN_freeze(a->coeffs[i]);
-    }
-
-    DBENCH_STOP(*tred);
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM5AES_CLEAN_poly_add
 *
 * Description: Add polynomials. No modular reduction is performed.

--- a/crypto_sign/dilithium5aes/clean/poly.h
+++ b/crypto_sign/dilithium5aes/clean/poly.h
@@ -9,7 +9,6 @@ typedef struct {
 
 void PQCLEAN_DILITHIUM5AES_CLEAN_poly_reduce(poly *a);
 void PQCLEAN_DILITHIUM5AES_CLEAN_poly_caddq(poly *a);
-void PQCLEAN_DILITHIUM5AES_CLEAN_poly_freeze(poly *a);
 
 void PQCLEAN_DILITHIUM5AES_CLEAN_poly_add(poly *c, const poly *a, const poly *b);
 void PQCLEAN_DILITHIUM5AES_CLEAN_poly_sub(poly *c, const poly *a, const poly *b);

--- a/crypto_sign/dilithium5aes/clean/polyvec.c
+++ b/crypto_sign/dilithium5aes/clean/polyvec.c
@@ -61,22 +61,6 @@ void PQCLEAN_DILITHIUM5AES_CLEAN_polyvecl_reduce(polyvecl *v) {
 }
 
 /*************************************************
-* Name:        PQCLEAN_DILITHIUM5AES_CLEAN_polyvecl_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length L
-*              to standard representatives.
-*
-* Arguments:   - polyvecl *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM5AES_CLEAN_polyvecl_freeze(polyvecl *v) {
-    unsigned int i;
-
-    for (i = 0; i < L; ++i) {
-        PQCLEAN_DILITHIUM5AES_CLEAN_poly_freeze(&v->vec[i]);
-    }
-}
-
-/*************************************************
 * Name:        PQCLEAN_DILITHIUM5AES_CLEAN_polyvecl_add
 *
 * Description: Add vectors of polynomials of length L.
@@ -215,22 +199,6 @@ void PQCLEAN_DILITHIUM5AES_CLEAN_polyveck_caddq(polyveck *v) {
 
     for (i = 0; i < K; ++i) {
         PQCLEAN_DILITHIUM5AES_CLEAN_poly_caddq(&v->vec[i]);
-    }
-}
-
-/*************************************************
-* Name:        PQCLEAN_DILITHIUM5AES_CLEAN_polyveck_freeze
-*
-* Description: Reduce coefficients of polynomials in vector of length K
-*              to standard representatives.
-*
-* Arguments:   - polyveck *v: pointer to input/output vector
-**************************************************/
-void PQCLEAN_DILITHIUM5AES_CLEAN_polyveck_freeze(polyveck *v)  {
-    unsigned int i;
-
-    for (i = 0; i < K; ++i) {
-        PQCLEAN_DILITHIUM5AES_CLEAN_poly_freeze(&v->vec[i]);
     }
 }
 

--- a/crypto_sign/dilithium5aes/clean/polyvec.h
+++ b/crypto_sign/dilithium5aes/clean/polyvec.h
@@ -15,8 +15,6 @@ void PQCLEAN_DILITHIUM5AES_CLEAN_polyvecl_uniform_gamma1(polyvecl *v, const uint
 
 void PQCLEAN_DILITHIUM5AES_CLEAN_polyvecl_reduce(polyvecl *v);
 
-void PQCLEAN_DILITHIUM5AES_CLEAN_polyvecl_freeze(polyvecl *v);
-
 void PQCLEAN_DILITHIUM5AES_CLEAN_polyvecl_add(polyvecl *w, const polyvecl *u, const polyvecl *v);
 
 void PQCLEAN_DILITHIUM5AES_CLEAN_polyvecl_ntt(polyvecl *v);
@@ -40,7 +38,6 @@ void PQCLEAN_DILITHIUM5AES_CLEAN_polyveck_uniform_eta(polyveck *v, const uint8_t
 
 void PQCLEAN_DILITHIUM5AES_CLEAN_polyveck_reduce(polyveck *v);
 void PQCLEAN_DILITHIUM5AES_CLEAN_polyveck_caddq(polyveck *v);
-void PQCLEAN_DILITHIUM5AES_CLEAN_polyveck_freeze(polyveck *v);
 
 void PQCLEAN_DILITHIUM5AES_CLEAN_polyveck_add(polyveck *w, const polyveck *u, const polyveck *v);
 void PQCLEAN_DILITHIUM5AES_CLEAN_polyveck_sub(polyveck *w, const polyveck *u, const polyveck *v);


### PR DESCRIPTION
Update Dilithium to pull in GCC 11 fixes.

Also note that I originally applied 52851284 directly in the PQClean tree instead of in my packaging scripts. I had hoped upstream would take it, but they fixed the UB with a `__may_alias__` extension instead. So now I've backported the fix to my packaging scripts. I changed the memmove to a memcpy because of https://github.com/open-quantum-safe/profiling/issues/47.