### PR TITLE
Kill bugprone-easily-swappable-parameters

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-google-readability-casting,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-valist.*,-llvmlibc-*,-bugprone-reserved-identifier,-cert-dcl37-c,-cert-dcl51-cpp,-bugprone-signed-char-misuse,-cert-str34-c,-misc-no-recursion,-altera-*'
+Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-google-readability-casting,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-valist.*,-llvmlibc-*,-bugprone-reserved-identifier,-cert-dcl37-c,-cert-dcl51-cpp,-bugprone-signed-char-misuse,-cert-str34-c,-misc-no-recursion,-altera-*,-bugprone-easily-swappable-parameters'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
e.g.:
```
dilithium5/clean/packing.c:120:41: error: 3 adjacent parameters of 'PQCLEAN_DILITHIUM5_CLEAN_unpack_sk' of similar type ('uint8_t *') are easily swapped by mistake [bugprone-easily-swappable-parameters,-warnings-as-errors]
```

This is kinda unavoidable, though I agree with the warning. Why don't
people use structs more :(