### PR TITLE
Fix a bunch of clang-tidy 12 errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-google-readability-casting,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-valist.*,-llvmlibc-*,-bugprone-reserved-identifier,-cert-dcl37-c,-cert-dcl51-cpp,-bugprone-signed-char-misuse,-cert-str34-c,-misc-no-recursion,-altera-*,-bugprone-easily-swappable-parameters'
+Checks:          '*,-llvm-header-guard,-hicpp-*,-readability-function-size,-google-readability-todo,-google-readability-casting,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-valist.*,-llvmlibc-*,-bugprone-reserved-identifier,-cert-dcl37-c,-cert-dcl51-cpp,-bugprone-signed-char-misuse,-cert-str34-c,-misc-no-recursion,-altera-*,-bugprone-easily-swappable-parameters,-concurrency-mt-unsafe,-bugprone-implicit-widening-of-multiplication-result,-cppcoreguidelines*,-bugprone-narrowing-conversions,-readability-function-cognitive-complexity,-performance-*,-readability-suspicious-call-argument'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
@@ -180,16 +180,12 @@ CheckOptions:
     value:           CamelCase
   - key:             modernize-make-shared.IgnoreMacros
     value:           '1'
-  - key:             modernize-make-shared.IncludeStyle
-    value:           '0'
   - key:             modernize-make-shared.MakeSmartPtrFunction
     value:           'std::make_shared'
   - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
     value:           memory
   - key:             modernize-make-unique.IgnoreMacros
     value:           '1'
-  - key:             modernize-make-unique.IncludeStyle
-    value:           '0'
   - key:             modernize-make-unique.MakeSmartPtrFunction
     value:           'std::make_unique'
   - key:             modernize-make-unique.MakeSmartPtrFunctionHeader

--- a/crypto_kem/mceliece348864f/clean/pk_gen.c
+++ b/crypto_kem/mceliece348864f/clean/pk_gen.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "controlbits.h"
 #include "benes.h"
+#include "controlbits.h"
 #include "params.h"
 #include "pk_gen.h"
 #include "root.h"

--- a/crypto_kem/mceliece460896f/clean/pk_gen.c
+++ b/crypto_kem/mceliece460896f/clean/pk_gen.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "controlbits.h"
 #include "benes.h"
+#include "controlbits.h"
 #include "params.h"
 #include "pk_gen.h"
 #include "root.h"

--- a/crypto_kem/mceliece6688128f/clean/pk_gen.c
+++ b/crypto_kem/mceliece6688128f/clean/pk_gen.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "controlbits.h"
 #include "benes.h"
+#include "controlbits.h"
 #include "params.h"
 #include "pk_gen.h"
 #include "root.h"

--- a/crypto_kem/mceliece6960119/clean/pk_gen.c
+++ b/crypto_kem/mceliece6960119/clean/pk_gen.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "controlbits.h"
 #include "benes.h"
+#include "controlbits.h"
 #include "params.h"
 #include "pk_gen.h"
 #include "root.h"

--- a/crypto_kem/mceliece6960119f/clean/pk_gen.c
+++ b/crypto_kem/mceliece6960119f/clean/pk_gen.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "controlbits.h"
 #include "benes.h"
+#include "controlbits.h"
 #include "params.h"
 #include "pk_gen.h"
 #include "root.h"

--- a/crypto_kem/mceliece8192128f/clean/pk_gen.c
+++ b/crypto_kem/mceliece8192128f/clean/pk_gen.c
@@ -7,8 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "controlbits.h"
 #include "benes.h"
+#include "controlbits.h"
 #include "params.h"
 #include "pk_gen.h"
 #include "root.h"

--- a/crypto_kem/ntruhps2048509/avx2/poly_r2_inv.c
+++ b/crypto_kem/ntruhps2048509/avx2/poly_r2_inv.c
@@ -1,7 +1,7 @@
 #include <immintrin.h>
 
-#include "poly_r2_inv.h"
 #include "poly.h"
+#include "poly_r2_inv.h"
 
 // Using pdep/pext for these two functions is faster but not a lot since they work on uint64_t which means
 // we can only do 4 coefficients at a time. Per byte (where we store 8 coefficients) we will thus need 2 pdeps/pexts

--- a/crypto_kem/ntruhps2048677/avx2/poly_r2_inv.c
+++ b/crypto_kem/ntruhps2048677/avx2/poly_r2_inv.c
@@ -1,5 +1,5 @@
-#include "poly_r2_inv.h"
 #include "poly.h"
+#include "poly_r2_inv.h"
 
 // TODO this costs 1764 cycles.. (implementing as S3_to_bytes results in 2108)
 // This can be implemented nicely in assembly using pdep / pext functions

--- a/crypto_kem/ntruhrss701/avx2/poly_r2_inv.c
+++ b/crypto_kem/ntruhrss701/avx2/poly_r2_inv.c
@@ -1,5 +1,5 @@
-#include "poly_r2_inv.h"
 #include "poly.h"
+#include "poly_r2_inv.h"
 
 // TODO this costs 1764 cycles.. (implementing as S3_to_bytes results in 2108)
 // This can be implemented nicely in assembly using pdep / pext functions

--- a/crypto_sign/sphincs-shake256-128f-robust/avx2/thash_shake256_robustx4.c
+++ b/crypto_sign/sphincs-shake256-128f-robust/avx2/thash_shake256_robustx4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "thashx4.h"
 #include "address.h"
 #include "params.h"
+#include "thashx4.h"
 
 #include "fips202x4.h"
 

--- a/crypto_sign/sphincs-shake256-128s-robust/avx2/thash_shake256_robustx4.c
+++ b/crypto_sign/sphincs-shake256-128s-robust/avx2/thash_shake256_robustx4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "thashx4.h"
 #include "address.h"
 #include "params.h"
+#include "thashx4.h"
 
 #include "fips202x4.h"
 

--- a/crypto_sign/sphincs-shake256-192f-robust/avx2/thash_shake256_robustx4.c
+++ b/crypto_sign/sphincs-shake256-192f-robust/avx2/thash_shake256_robustx4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "thashx4.h"
 #include "address.h"
 #include "params.h"
+#include "thashx4.h"
 
 #include "fips202x4.h"
 

--- a/crypto_sign/sphincs-shake256-192s-robust/avx2/thash_shake256_robustx4.c
+++ b/crypto_sign/sphincs-shake256-192s-robust/avx2/thash_shake256_robustx4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "thashx4.h"
 #include "address.h"
 #include "params.h"
+#include "thashx4.h"
 
 #include "fips202x4.h"
 

--- a/crypto_sign/sphincs-shake256-256f-robust/avx2/thash_shake256_robustx4.c
+++ b/crypto_sign/sphincs-shake256-256f-robust/avx2/thash_shake256_robustx4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "thashx4.h"
 #include "address.h"
 #include "params.h"
+#include "thashx4.h"
 
 #include "fips202x4.h"
 

--- a/crypto_sign/sphincs-shake256-256s-robust/avx2/thash_shake256_robustx4.c
+++ b/crypto_sign/sphincs-shake256-256s-robust/avx2/thash_shake256_robustx4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "thashx4.h"
 #include "address.h"
 #include "params.h"
+#include "thashx4.h"
 
 #include "fips202x4.h"
 


### PR DESCRIPTION
I've added some more lints to the ignore lists because they gave stupid warnings, and fixed some issues in a few schemes.