### PR TITLE
CryptGenRandom expects DWORD

### DIFF
--- a/common/randombytes.c
+++ b/common/randombytes.c
@@ -100,7 +100,7 @@ static int randombytes_win32_randombytes(void *buf, const size_t n) {
         return -1;
     }
 
-    tmp = CryptGenRandom(ctx, n, (BYTE *) buf);
+    tmp = CryptGenRandom(ctx, (unsigned long)n, (BYTE *) buf);
     if (tmp == FALSE) {
         return -1;
     }


### PR DESCRIPTION
I accidentally missed this Windows 64-bit build failure.

cc @dsprenkels