### PR TITLE
crypto_kem/sntrup761: replace bitwise operators with intrinsics

### DIFF
--- a/crypto_kem/sntrup761/avx2/crypto_core_inv3sntrup761.c
+++ b/crypto_kem/sntrup761/avx2/crypto_core_inv3sntrup761.c
@@ -51,23 +51,23 @@ static inline void vec256_frombits(vec256 *v, const small *b) {
         vec256 c6 = _mm256_unpacklo_epi32(b6, b7);
         vec256 c7 = _mm256_unpackhi_epi32(b6, b7);
 
-        vec256 d0 = c0 | _mm256_slli_epi32(c1, 2); /* 0 8, 1 9, 2 10, 3 11, 32 40, 33 41, ..., 55 63 */
-        vec256 d2 = c2 | _mm256_slli_epi32(c3, 2);
-        vec256 d4 = c4 | _mm256_slli_epi32(c5, 2);
-        vec256 d6 = c6 | _mm256_slli_epi32(c7, 2);
+        vec256 d0 = _mm256_or_si256(c0, _mm256_slli_epi32(c1, 2)); /* 0 8, 1 9, 2 10, 3 11, 32 40, 33 41, ..., 55 63 */
+        vec256 d2 = _mm256_or_si256(c2, _mm256_slli_epi32(c3, 2));
+        vec256 d4 = _mm256_or_si256(c4, _mm256_slli_epi32(c5, 2));
+        vec256 d6 = _mm256_or_si256(c6, _mm256_slli_epi32(c7, 2));
 
         vec256 e0 = _mm256_unpacklo_epi64(d0, d2);
         vec256 e2 = _mm256_unpackhi_epi64(d0, d2);
         vec256 e4 = _mm256_unpacklo_epi64(d4, d6);
         vec256 e6 = _mm256_unpackhi_epi64(d4, d6);
 
-        vec256 f0 = e0 | _mm256_slli_epi32(e2, 1);
-        vec256 f4 = e4 | _mm256_slli_epi32(e6, 1);
+        vec256 f0 = _mm256_or_si256(e0, _mm256_slli_epi32(e2, 1));
+        vec256 f4 = _mm256_or_si256(e4, _mm256_slli_epi32(e6, 1));
 
         vec256 g0 = _mm256_permute2x128_si256(f0, f4, 0x20);
         vec256 g4 = _mm256_permute2x128_si256(f0, f4, 0x31);
 
-        vec256 h = g0 | _mm256_slli_epi32(g4, 4);
+        vec256 h = _mm256_or_si256(g0, _mm256_slli_epi32(g4, 4));
 
 #define TRANSPOSE _mm256_set_epi8( 31,27,23,19, 30,26,22,18, 29,25,21,17, 28,24,20,16, 15,11,7,3, 14,10,6,2, 13,9,5,1, 12,8,4,0 )
         h = _mm256_shuffle_epi8(h, TRANSPOSE);
@@ -88,30 +88,30 @@ static inline void vec256_tobits(const vec256 *v, small *b) {
         h = _mm256_permute4x64_epi64(h, 0xd8);
         h = _mm256_shuffle_epi8(h, TRANSPOSE);
 
-        vec256 g0 = h & _mm256_set1_epi8(15);
-        vec256 g4 = _mm256_srli_epi32(h, 4) & _mm256_set1_epi8(15);
+        vec256 g0 = _mm256_and_si256(h, _mm256_set1_epi8(15));
+        vec256 g4 = _mm256_and_si256(_mm256_srli_epi32(h, 4), _mm256_set1_epi8(15));
 
         vec256 f0 = _mm256_permute2x128_si256(g0, g4, 0x20);
         vec256 f4 = _mm256_permute2x128_si256(g0, g4, 0x31);
 
-        vec256 e0 = f0 & _mm256_set1_epi8(5);
-        vec256 e2 = _mm256_srli_epi32(f0, 1) & _mm256_set1_epi8(5);
-        vec256 e4 = f4 & _mm256_set1_epi8(5);
-        vec256 e6 = _mm256_srli_epi32(f4, 1) & _mm256_set1_epi8(5);
+        vec256 e0 = _mm256_and_si256(f0, _mm256_set1_epi8(5));
+        vec256 e2 = _mm256_and_si256(_mm256_srli_epi32(f0, 1), _mm256_set1_epi8(5));
+        vec256 e4 = _mm256_and_si256(f4, _mm256_set1_epi8(5));
+        vec256 e6 = _mm256_and_si256(_mm256_srli_epi32(f4, 1), _mm256_set1_epi8(5));
 
         vec256 d0 = _mm256_unpacklo_epi32(e0, e2);
         vec256 d2 = _mm256_unpackhi_epi32(e0, e2);
         vec256 d4 = _mm256_unpacklo_epi32(e4, e6);
         vec256 d6 = _mm256_unpackhi_epi32(e4, e6);
 
-        vec256 c0 = d0 & _mm256_set1_epi8(1);
-        vec256 c1 = _mm256_srli_epi32(d0, 2) & _mm256_set1_epi8(1);
-        vec256 c2 = d2 & _mm256_set1_epi8(1);
-        vec256 c3 = _mm256_srli_epi32(d2, 2) & _mm256_set1_epi8(1);
-        vec256 c4 = d4 & _mm256_set1_epi8(1);
-        vec256 c5 = _mm256_srli_epi32(d4, 2) & _mm256_set1_epi8(1);
-        vec256 c6 = d6 & _mm256_set1_epi8(1);
-        vec256 c7 = _mm256_srli_epi32(d6, 2) & _mm256_set1_epi8(1);
+        vec256 c0 = _mm256_and_si256(d0, _mm256_set1_epi8(1));
+        vec256 c1 = _mm256_and_si256(_mm256_srli_epi32(d0, 2), _mm256_set1_epi8(1));
+        vec256 c2 = _mm256_and_si256(d2, _mm256_set1_epi8(1));
+        vec256 c3 = _mm256_and_si256(_mm256_srli_epi32(d2, 2), _mm256_set1_epi8(1));
+        vec256 c4 = _mm256_and_si256(d4, _mm256_set1_epi8(1));
+        vec256 c5 = _mm256_and_si256(_mm256_srli_epi32(d4, 2), _mm256_set1_epi8(1));
+        vec256 c6 = _mm256_and_si256(d6, _mm256_set1_epi8(1));
+        vec256 c7 = _mm256_and_si256(_mm256_srli_epi32(d6, 2), _mm256_set1_epi8(1));
 
         vec256 b0 = _mm256_unpacklo_epi64(c0, c1);
         vec256 b1 = _mm256_unpackhi_epi64(c0, c1);
@@ -203,9 +203,9 @@ static inline void vec256_swap(vec256 *f, vec256 *g, int len, vec256 mask) {
     int i;
 
     for (i = 0; i < len; ++i) {
-        flip = mask & (f[i] ^ g[i]);
-        f[i] ^= flip;
-        g[i] ^= flip;
+        flip = _mm256_and_si256(mask, _mm256_xor_si256(f[i], g[i]));
+        f[i] = _mm256_xor_si256(f[i], flip);
+        g[i] = _mm256_xor_si256(g[i], flip);
     }
 }
 
@@ -216,9 +216,9 @@ static inline void vec256_scale(vec256 *f0, vec256 *f1, const vec256 c0, const v
         vec256 f0i = f0[i];
         vec256 f1i = f1[i];
 
-        f0i &= c0;
-        f1i ^= c1;
-        f1i &= f0i;
+        f0i = _mm256_and_si256(f0i, c0);
+        f1i = _mm256_xor_si256(f1i, c1);
+        f1i = _mm256_and_si256(f1i, f0i);
 
         f0[i] = f0i;
         f1[i] = f1i;
@@ -235,13 +235,13 @@ static inline void vec256_eliminate(vec256 *f0, vec256 *f1, vec256 *g0, vec256 *
         vec256 g1i = g1[i];
         vec256 t;
 
-        f0i &= c0;
-        f1i ^= c1;
-        f1i &= f0i;
+        f0i = _mm256_and_si256(f0i, c0);
+        f1i = _mm256_xor_si256(f1i, c1);
+        f1i = _mm256_and_si256(f1i, f0i);
 
-        t = g0i ^ f0i;
-        g0[i] = t | (g1i ^ f1i);
-        g1[i] = (g1i ^ f0i) & (f1i ^ t);
+        t = _mm256_xor_si256(g0i, f0i);
+        g0[i] = _mm256_or_si256(t, _mm256_xor_si256(g1i, f1i));
+        g1[i] = _mm256_and_si256(_mm256_xor_si256(g1i, f0i), _mm256_xor_si256(f1i, t));
     }
 }
 

--- a/crypto_kem/sntrup761/avx2/crypto_core_mult3sntrup761.c
+++ b/crypto_kem/sntrup761/avx2/crypto_core_mult3sntrup761.c
@@ -61,9 +61,9 @@ static void good(int16 fpad[3][512], const int16 f[768]) {
     for (;;) {
         f0 = load_x16(f + j);
         f1 = load_x16(f + 512 + j);
-        store_x16(&fpad[0][j], (f0 & mask0) | (f1 & mask1));
-        store_x16(&fpad[1][j], (f0 & mask1) | (f1 & mask2));
-        store_x16(&fpad[2][j], (f0 & mask2) | (f1 & mask0));
+        store_x16(&fpad[0][j], _mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)));
+        store_x16(&fpad[1][j], _mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)));
+        store_x16(&fpad[2][j], _mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)));
         j += 16;
         if (j == 256) {
             break;
@@ -71,38 +71,38 @@ static void good(int16 fpad[3][512], const int16 f[768]) {
 
         f0 = load_x16(f + j);
         f1 = load_x16(f + 512 + j);
-        store_x16(&fpad[0][j], (f0 & mask2) | (f1 & mask0));
-        store_x16(&fpad[1][j], (f0 & mask0) | (f1 & mask1));
-        store_x16(&fpad[2][j], (f0 & mask1) | (f1 & mask2));
+        store_x16(&fpad[0][j], _mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)));
+        store_x16(&fpad[1][j], _mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)));
+        store_x16(&fpad[2][j], _mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)));
         j += 16;
 
         f0 = load_x16(f + j);
         f1 = load_x16(f + 512 + j);
-        store_x16(&fpad[0][j], (f0 & mask1) | (f1 & mask2));
-        store_x16(&fpad[1][j], (f0 & mask2) | (f1 & mask0));
-        store_x16(&fpad[2][j], (f0 & mask0) | (f1 & mask1));
+        store_x16(&fpad[0][j], _mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)));
+        store_x16(&fpad[1][j], _mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)));
+        store_x16(&fpad[2][j], _mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)));
         j += 16;
     }
     for (;;) {
         f0 = load_x16(f + j);
-        store_x16(&fpad[0][j], f0 & mask2);
-        store_x16(&fpad[1][j], f0 & mask0);
-        store_x16(&fpad[2][j], f0 & mask1);
+        store_x16(&fpad[0][j], _mm256_and_si256(f0, mask2));
+        store_x16(&fpad[1][j], _mm256_and_si256(f0, mask0));
+        store_x16(&fpad[2][j], _mm256_and_si256(f0, mask1));
         j += 16;
         if (j == 512) {
             break;
         }
 
         f0 = load_x16(f + j);
-        store_x16(&fpad[0][j], f0 & mask1);
-        store_x16(&fpad[1][j], f0 & mask2);
-        store_x16(&fpad[2][j], f0 & mask0);
+        store_x16(&fpad[0][j], _mm256_and_si256(f0, mask1));
+        store_x16(&fpad[1][j], _mm256_and_si256(f0, mask2));
+        store_x16(&fpad[2][j], _mm256_and_si256(f0, mask0));
         j += 16;
 
         f0 = load_x16(f + j);
-        store_x16(&fpad[0][j], f0 & mask0);
-        store_x16(&fpad[1][j], f0 & mask1);
-        store_x16(&fpad[2][j], f0 & mask2);
+        store_x16(&fpad[0][j], _mm256_and_si256(f0, mask0));
+        store_x16(&fpad[1][j], _mm256_and_si256(f0, mask1));
+        store_x16(&fpad[2][j], _mm256_and_si256(f0, mask2));
         j += 16;
     }
 }
@@ -117,9 +117,9 @@ static void ungood(int16 f[1536], const int16 fpad[3][512]) {
         f0 = load_x16(&fpad[0][j]);
         f1 = load_x16(&fpad[1][j]);
         f2 = load_x16(&fpad[2][j]);
-        g0 = (f0 & mask0) | (f1 & mask1) | (f2 & mask2);
-        g1 = (f0 & mask1) | (f1 & mask2) | (f2 & mask0);
-        g2 = f0 ^ f1 ^ f2 ^ g0 ^ g1; /* same as (f0&mask2)|(f1&mask0)|(f2&mask1) */
+        g0 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)), _mm256_and_si256(f2, mask2));
+        g1 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)), _mm256_and_si256(f2, mask0));
+		g2 = _mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(f0, f1), f2), g0), g1); /* same as (f0&mask1)|(f1&mask2)|(f2&mask0) */
         store_x16(f + 0 + j, g0);
         store_x16(f + 512 + j, g1);
         store_x16(f + 1024 + j, g2);
@@ -128,9 +128,9 @@ static void ungood(int16 f[1536], const int16 fpad[3][512]) {
         f0 = load_x16(&fpad[0][j]);
         f1 = load_x16(&fpad[1][j]);
         f2 = load_x16(&fpad[2][j]);
-        g0 = (f0 & mask2) | (f1 & mask0) | (f2 & mask1);
-        g1 = (f0 & mask0) | (f1 & mask1) | (f2 & mask2);
-        g2 = f0 ^ f1 ^ f2 ^ g0 ^ g1; /* same as (f0&mask1)|(f1&mask2)|(f2&mask0) */
+        g0 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)), _mm256_and_si256(f2, mask1));
+        g1 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)), _mm256_and_si256(f2, mask2));
+        g2 = _mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(f0, f1), f2), g0), g1); /* same as (f0&mask1)|(f1&mask2)|(f2&mask0) */
         store_x16(f + 0 + j, g0);
         store_x16(f + 512 + j, g1);
         store_x16(f + 1024 + j, g2);
@@ -142,9 +142,9 @@ static void ungood(int16 f[1536], const int16 fpad[3][512]) {
         f0 = load_x16(&fpad[0][j]);
         f1 = load_x16(&fpad[1][j]);
         f2 = load_x16(&fpad[2][j]);
-        g0 = (f0 & mask1) | (f1 & mask2) | (f2 & mask0);
-        g1 = (f0 & mask2) | (f1 & mask0) | (f2 & mask1);
-        g2 = f0 ^ f1 ^ f2 ^ g0 ^ g1; /* same as (f0&mask0)|(f1&mask1)|(f2&mask2) */
+        g0 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)), _mm256_and_si256(f2, mask0));
+        g1 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)), _mm256_and_si256(f2, mask1));
+		g2 = _mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(f0, f1), f2), g0), g1); /* same as (f0&mask1)|(f1&mask2)|(f2&mask0) */
         store_x16(f + 0 + j, g0);
         store_x16(f + 512 + j, g1);
         store_x16(f + 1024 + j, g2);
@@ -202,7 +202,7 @@ static void mult768(int16 h[1536], const int16 f[768], const int16 g[768]) {
 
 static inline int16x16 freeze_3_x16(int16x16 x) {
     int16x16 mask, x3;
-    x = add_x16(x, const_x16(3)&signmask_x16(x));
+    x = add_x16(x, _mm256_and_si256(const_x16(3), signmask_x16(x)));
     mask = signmask_x16(sub_x16(x, const_x16(2)));
     x3 = sub_x16(x, const_x16(3));
     x = _mm256_blendv_epi8(x3, x, mask);

--- a/crypto_kem/sntrup761/avx2/crypto_core_multsntrup761.c
+++ b/crypto_kem/sntrup761/avx2/crypto_core_multsntrup761.c
@@ -81,9 +81,9 @@ static void good(int16 fpad[3][512], const int16 f[768]) {
     for (;;) {
         f0 = load_x16(f + j);
         f1 = load_x16(f + 512 + j);
-        store_x16(&fpad[0][j], (f0 & mask0) | (f1 & mask1));
-        store_x16(&fpad[1][j], (f0 & mask1) | (f1 & mask2));
-        store_x16(&fpad[2][j], (f0 & mask2) | (f1 & mask0));
+        store_x16(&fpad[0][j], _mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)));
+        store_x16(&fpad[1][j], _mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)));
+        store_x16(&fpad[2][j], _mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)));
         j += 16;
         if (j == 256) {
             break;
@@ -91,38 +91,38 @@ static void good(int16 fpad[3][512], const int16 f[768]) {
 
         f0 = load_x16(f + j);
         f1 = load_x16(f + 512 + j);
-        store_x16(&fpad[0][j], (f0 & mask2) | (f1 & mask0));
-        store_x16(&fpad[1][j], (f0 & mask0) | (f1 & mask1));
-        store_x16(&fpad[2][j], (f0 & mask1) | (f1 & mask2));
+		store_x16(&fpad[0][j], _mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)));
+		store_x16(&fpad[1][j], _mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)));
+		store_x16(&fpad[2][j], _mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)));
         j += 16;
 
         f0 = load_x16(f + j);
         f1 = load_x16(f + 512 + j);
-        store_x16(&fpad[0][j], (f0 & mask1) | (f1 & mask2));
-        store_x16(&fpad[1][j], (f0 & mask2) | (f1 & mask0));
-        store_x16(&fpad[2][j], (f0 & mask0) | (f1 & mask1));
+        store_x16(&fpad[0][j], _mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)));
+        store_x16(&fpad[1][j], _mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)));
+        store_x16(&fpad[2][j], _mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)));
         j += 16;
     }
     for (;;) {
         f0 = load_x16(f + j);
-        store_x16(&fpad[0][j], f0 & mask2);
-        store_x16(&fpad[1][j], f0 & mask0);
-        store_x16(&fpad[2][j], f0 & mask1);
+        store_x16(&fpad[0][j], _mm256_and_si256(f0, mask2));
+        store_x16(&fpad[1][j], _mm256_and_si256(f0, mask0));
+        store_x16(&fpad[2][j], _mm256_and_si256(f0, mask1));
         j += 16;
         if (j == 512) {
             break;
         }
 
         f0 = load_x16(f + j);
-        store_x16(&fpad[0][j], f0 & mask1);
-        store_x16(&fpad[1][j], f0 & mask2);
-        store_x16(&fpad[2][j], f0 & mask0);
+        store_x16(&fpad[0][j], _mm256_and_si256(f0, mask1));
+        store_x16(&fpad[1][j], _mm256_and_si256(f0, mask2));
+        store_x16(&fpad[2][j], _mm256_and_si256(f0, mask0));
         j += 16;
 
         f0 = load_x16(f + j);
-        store_x16(&fpad[0][j], f0 & mask0);
-        store_x16(&fpad[1][j], f0 & mask1);
-        store_x16(&fpad[2][j], f0 & mask2);
+        store_x16(&fpad[0][j], _mm256_and_si256(f0, mask0));
+        store_x16(&fpad[1][j], _mm256_and_si256(f0, mask1));
+        store_x16(&fpad[2][j], _mm256_and_si256(f0, mask2));
         j += 16;
     }
 }
@@ -137,9 +137,9 @@ static void ungood(int16 f[1536], const int16 fpad[3][512]) {
         f0 = load_x16(&fpad[0][j]);
         f1 = load_x16(&fpad[1][j]);
         f2 = load_x16(&fpad[2][j]);
-        g0 = (f0 & mask0) | (f1 & mask1) | (f2 & mask2);
-        g1 = (f0 & mask1) | (f1 & mask2) | (f2 & mask0);
-        g2 = f0 ^ f1 ^ f2 ^ g0 ^ g1; /* same as (f0&mask2)|(f1&mask0)|(f2&mask1) */
+        g0 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)), _mm256_and_si256(f2, mask2));
+        g1 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)), _mm256_and_si256(f2, mask0));
+		g2 = _mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(f0, f1), f2), g0), g1); /* same as (f0&mask1)|(f1&mask2)|(f2&mask0) */
         store_x16(f + 0 + j, g0);
         store_x16(f + 512 + j, g1);
         store_x16(f + 1024 + j, g2);
@@ -148,9 +148,9 @@ static void ungood(int16 f[1536], const int16 fpad[3][512]) {
         f0 = load_x16(&fpad[0][j]);
         f1 = load_x16(&fpad[1][j]);
         f2 = load_x16(&fpad[2][j]);
-        g0 = (f0 & mask2) | (f1 & mask0) | (f2 & mask1);
-        g1 = (f0 & mask0) | (f1 & mask1) | (f2 & mask2);
-        g2 = f0 ^ f1 ^ f2 ^ g0 ^ g1; /* same as (f0&mask1)|(f1&mask2)|(f2&mask0) */
+        g0 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)), _mm256_and_si256(f2, mask1));
+        g1 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask0), _mm256_and_si256(f1, mask1)), _mm256_and_si256(f2, mask2));
+		g2 = _mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(f0, f1), f2), g0), g1); /* same as (f0&mask1)|(f1&mask2)|(f2&mask0) */
         store_x16(f + 0 + j, g0);
         store_x16(f + 512 + j, g1);
         store_x16(f + 1024 + j, g2);
@@ -162,9 +162,9 @@ static void ungood(int16 f[1536], const int16 fpad[3][512]) {
         f0 = load_x16(&fpad[0][j]);
         f1 = load_x16(&fpad[1][j]);
         f2 = load_x16(&fpad[2][j]);
-        g0 = (f0 & mask1) | (f1 & mask2) | (f2 & mask0);
-        g1 = (f0 & mask2) | (f1 & mask0) | (f2 & mask1);
-        g2 = f0 ^ f1 ^ f2 ^ g0 ^ g1; /* same as (f0&mask0)|(f1&mask1)|(f2&mask2) */
+        g0 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask1), _mm256_and_si256(f1, mask2)), _mm256_and_si256(f2, mask0));
+        g1 = _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(f0, mask2), _mm256_and_si256(f1, mask0)), _mm256_and_si256(f2, mask1));
+		g2 = _mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(_mm256_xor_si256(f0, f1), f2), g0), g1); /* same as (f0&mask1)|(f1&mask2)|(f2&mask0) */
         store_x16(f + 0 + j, g0);
         store_x16(f + 512 + j, g1);
         store_x16(f + 1024 + j, g2);
@@ -257,7 +257,7 @@ static void mult768(int16 h[1536], const int16 f[768], const int16 g[768]) {
 
 static inline int16x16 freeze_4591_x16(int16x16 x) {
     int16x16 mask, xq;
-    x = add_x16(x, const_x16(q)&signmask_x16(x));
+    x = add_x16(x, _mm256_and_si256(const_x16(q), signmask_x16(x)));
     mask = signmask_x16(sub_x16(x, const_x16((q + 1) / 2)));
     xq = sub_x16(x, const_x16(q));
     x = _mm256_blendv_epi8(xq, x, mask);

--- a/crypto_kem/sntrup761/avx2/crypto_core_scale3sntrup761.c
+++ b/crypto_kem/sntrup761/avx2/crypto_core_scale3sntrup761.c
@@ -25,9 +25,9 @@ int PQCLEAN_SNTRUP761_AVX2_crypto_core_scale3sntrup761(unsigned char *outbytes, 
             x = _mm256_mullo_epi16(x, _mm256_set1_epi16(3));
             x = _mm256_sub_epi16(x, _mm256_set1_epi16((q + 1) / 2));
             xneg = _mm256_srai_epi16(x, 15);
-            x = _mm256_add_epi16(x, _mm256_set1_epi16(q)&xneg);
+            x = _mm256_add_epi16(x, _mm256_and_si256(_mm256_set1_epi16(q), xneg));
             xneg = _mm256_srai_epi16(x, 15);
-            x = _mm256_add_epi16(x, _mm256_set1_epi16(q)&xneg);
+            x = _mm256_add_epi16(x, _mm256_and_si256(_mm256_set1_epi16(q), xneg));
             x = _mm256_sub_epi16(x, _mm256_set1_epi16((q - 1) / 2));
             _mm256_storeu_si256((__m256i *) outbytes, x);
 

--- a/crypto_kem/sntrup761/avx2/crypto_core_weightsntrup761.c
+++ b/crypto_kem/sntrup761/avx2/crypto_core_weightsntrup761.c
@@ -15,18 +15,18 @@ int PQCLEAN_SNTRUP761_AVX2_crypto_core_weightsntrup761(unsigned char *outbytes, 
     int16 weight;
 
     sum = _mm256_loadu_si256((__m256i *) (in + p - 32));
-    sum &= endingmask;
+    sum = _mm256_and_si256(sum, endingmask);
 
     for (i = p - 32; i >= 0; i -= 32) {
         __m256i bits = _mm256_loadu_si256((__m256i *) in);
-        bits &= _mm256_set1_epi8(1);
+        bits = _mm256_and_si256(bits, _mm256_set1_epi8(1));
         sum = _mm256_add_epi8(sum, bits);
         in += 32;
     }
 
     /* sum is 32xint8; want to add these int8 */
     sumhi = _mm256_srli_epi16(sum, 8);
-    sum &= _mm256_set1_epi16(0xff);
+    sum = _mm256_and_si256(sum, _mm256_set1_epi16(0xff));
     sum = _mm256_add_epi16(sum, sumhi);
 
     /* sum is 16xint16; want to add these int16 */

--- a/crypto_kem/sntrup761/avx2/crypto_core_wforcesntrup761.c
+++ b/crypto_kem/sntrup761/avx2/crypto_core_wforcesntrup761.c
@@ -25,9 +25,9 @@ int PQCLEAN_SNTRUP761_AVX2_crypto_core_wforcesntrup761(unsigned char *out, const
     for (;;) {
         do {
             __m256i x = _mm256_loadu_si256((__m256i *) in);
-            x ^= _mm256_set1_epi8(1);
-            x &= maskvec;
-            x ^= _mm256_set1_epi8(1);
+            x = _mm256_xor_si256(x, _mm256_set1_epi8(1));
+            x = _mm256_and_si256(x, maskvec);
+            x = _mm256_xor_si256(x, _mm256_set1_epi8(1));
             _mm256_storeu_si256((__m256i *) out, x);
             in += 32;
             out += 32;
@@ -44,7 +44,7 @@ int PQCLEAN_SNTRUP761_AVX2_crypto_core_wforcesntrup761(unsigned char *out, const
     for (;;) {
         do {
             __m256i x = _mm256_loadu_si256((__m256i *) in);
-            x &= maskvec;
+            x = _mm256_and_si256(x, maskvec);
             _mm256_storeu_si256((__m256i *) out, x);
             in += 32;
             out += 32;

--- a/crypto_kem/sntrup761/avx2/crypto_decode_761x1531.c
+++ b/crypto_kem/sntrup761/avx2/crypto_decode_761x1531.c
@@ -44,11 +44,11 @@ static inline __m256i mulhiconst(__m256i x, int16 y) {
 static inline __m256i ifgesubconst(__m256i x, int16 y) {
     __m256i y16 = _mm256_set1_epi16(y);
     __m256i top16 = _mm256_set1_epi16((int16)(y - 1));
-    return sub(x, _mm256_cmpgt_epi16(x, top16) & y16);
+    return sub(x, _mm256_and_si256(_mm256_cmpgt_epi16(x, top16), y16));
 }
 
 static inline __m256i ifnegaddconst(__m256i x, int16 y) {
-    return add(x, signedshiftrightconst(x, 15) & _mm256_set1_epi16(y));
+    return add(x, _mm256_and_si256(signedshiftrightconst(x, 15), _mm256_set1_epi16(y)));
 }
 
 void PQCLEAN_SNTRUP761_AVX2_crypto_decode_761x1531(void *v, const unsigned char *s) {
@@ -287,7 +287,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_decode_761x1531(void *v, const unsigned char 
         A2 = A0 = _mm256_loadu_si256((__m256i *) &R4[i]);
         S0 = _mm256_loadu_si256((__m256i *) (s + 2 * i));
         S1 = _mm256_srli_epi16(S0, 8);
-        S0 &= _mm256_set1_epi16(255);
+        S0 = _mm256_and_si256(S0, _mm256_set1_epi16(255));
         A0 = sub(mulhiconst(A0, 2816), mulhiconst(mulloconst(A0, -2621), 6400)); /* -3200...3904 */
         A0 = add(A0, S1); /* -3200...4159 */
         A0 = sub(mulhiconst(A0, 2816), mulhiconst(mulloconst(A0, -2621), 6400)); /* -3338...3378 */
@@ -361,7 +361,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_decode_761x1531(void *v, const unsigned char 
         A0 = _mm256_loadu_si256((__m256i *) &R2[i]);
         S0 = _mm256_loadu_si256((__m256i *) (s + 2 * i));
         S1 = _mm256_srli_epi16(S0, 8);
-        S0 &= _mm256_set1_epi16(255);
+        S0 = _mm256_and_si256(S0, _mm256_set1_epi16(255));
         A0 = sub(mulhiconst(A0, 1592), mulhiconst(mulloconst(A0, -1832), 9157)); /* -4579...4976 */
         A0 = add(A0, S1); /* -4579...5231 */
         A0 = sub(mulhiconst(A0, 1592), mulhiconst(mulloconst(A0, -1832), 9157)); /* -4690...4705 */

--- a/crypto_kem/sntrup761/avx2/crypto_decode_761x3.c
+++ b/crypto_kem/sntrup761/avx2/crypto_decode_761x3.c
@@ -17,8 +17,8 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_decode_761x3(void *v, const unsigned char *s)
         s = nexts;
         nexts += 32;
 
-        __m256i s1 = _mm256_srli_epi16(s0 & _mm256_set1_epi8(-16), 4);
-        s0 &= _mm256_set1_epi8(15);
+        __m256i s1 = _mm256_srli_epi16(_mm256_and_si256(s0, _mm256_set1_epi8(-16)), 4);
+        s0 = _mm256_and_si256(s0, _mm256_set1_epi8(15));
 
         __m256i a0 = _mm256_unpacklo_epi8(s0, s1);
         /* 0 0>>4 1 1>>4 2 2>>4 3 3>>4 4 4>>4 5 5>>4 6 6>>4 7 7>>4 */
@@ -27,10 +27,10 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_decode_761x3(void *v, const unsigned char *s)
         /* 8 8>>4 9 9>>4 10 10>>4 ... */
         /* 24 24>>4 ... */
 
-        __m256i a2 = _mm256_srli_epi16(a0 & _mm256_set1_epi8(12), 2);
-        __m256i a3 = _mm256_srli_epi16(a1 & _mm256_set1_epi8(12), 2);
-        a0 &= _mm256_set1_epi8(3);
-        a1 &= _mm256_set1_epi8(3);
+        __m256i a2 = _mm256_srli_epi16(_mm256_and_si256(a0, _mm256_set1_epi8(12)), 2);
+        __m256i a3 = _mm256_srli_epi16(_mm256_and_si256(a1, _mm256_set1_epi8(12)), 2);
+        a0 = _mm256_and_si256(a0, _mm256_set1_epi8(3));
+        a1 = _mm256_and_si256(a1, _mm256_set1_epi8(3));
 
         __m256i b0 = _mm256_unpacklo_epi8(a0, a2);
         /* 0 0>>2 0>>4 0>>6 1 1>>2 1>>4 1>>6 */

--- a/crypto_kem/sntrup761/avx2/crypto_decode_761x4591.c
+++ b/crypto_kem/sntrup761/avx2/crypto_decode_761x4591.c
@@ -44,11 +44,11 @@ static inline __m256i mulhiconst(__m256i x, int16 y) {
 static inline __m256i ifgesubconst(__m256i x, int16 y) {
     __m256i y16 = _mm256_set1_epi16(y);
     __m256i top16 = _mm256_set1_epi16((int16)(y - 1));
-    return sub(x, _mm256_cmpgt_epi16(x, top16) & y16);
+    return sub(x, _mm256_and_si256(_mm256_cmpgt_epi16(x, top16), y16));
 }
 
 static inline __m256i ifnegaddconst(__m256i x, int16 y) {
-    return add(x, signedshiftrightconst(x, 15) & _mm256_set1_epi16(y));
+    return add(x, _mm256_and_si256(signedshiftrightconst(x, 15), _mm256_set1_epi16(y)));
 }
 
 void PQCLEAN_SNTRUP761_AVX2_crypto_decode_761x4591(void *v, const unsigned char *s) {
@@ -398,7 +398,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_decode_761x4591(void *v, const unsigned char 
         A0 = _mm256_loadu_si256((__m256i *) &R1[i]);
         S0 = _mm256_loadu_si256((__m256i *) (s + 2 * i));
         S1 = _mm256_srli_epi16(S0, 8);
-        S0 &= _mm256_set1_epi16(255);
+        S0 = _mm256_and_si256(S0, _mm256_set1_epi16(255));
         A0 = sub(mulhiconst(A0, 1702), mulhiconst(mulloconst(A0, -3654), 4591)); /* -2296...2721 */
         A0 = add(A0, S1); /* -2296...2976 */
         A0 = sub(mulhiconst(A0, 1702), mulhiconst(mulloconst(A0, -3654), 4591)); /* -2356...2372 */

--- a/crypto_kem/sntrup761/avx2/crypto_encode_761x1531.c
+++ b/crypto_kem/sntrup761/avx2/crypto_encode_761x1531.c
@@ -30,9 +30,9 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531(unsigned char *out, const voi
         }
         x = _mm256_loadu_si256((__m256i *) reading);
         x = _mm256_add_epi16(x, _mm256_set1_epi16(2295));
-        x &= _mm256_set1_epi16(16383);
+        x = _mm256_and_si256(x, _mm256_set1_epi16(16383));
         x = _mm256_mulhi_epi16(x, _mm256_set1_epi16(21846));
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(1531));
         x = _mm256_add_epi32(y, x);
@@ -76,8 +76,8 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531(unsigned char *out, const voi
         }
         x = _mm256_loadu_si256((__m256i *) (reading + 0));
         x2 = _mm256_loadu_si256((__m256i *) (reading + 16));
-        y = x & _mm256_set1_epi32(65535);
-        y2 = x2 & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
+        y2 = _mm256_and_si256(x2, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x2 = _mm256_srli_epi32(x2, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(9157));
@@ -114,7 +114,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531(unsigned char *out, const voi
             out -= 1;
         }
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(1280));
         x = _mm256_add_epi32(y, x);
@@ -153,8 +153,8 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531(unsigned char *out, const voi
         --i;
         x = _mm256_loadu_si256((__m256i *) (reading + 0));
         x2 = _mm256_loadu_si256((__m256i *) (reading + 16));
-        y = x & _mm256_set1_epi32(65535);
-        y2 = x2 & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
+        y2 = _mm256_and_si256(x2, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x2 = _mm256_srli_epi32(x2, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(6400));
@@ -185,7 +185,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531(unsigned char *out, const voi
         __m256i x, y;
         --i;
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(625));
         x = _mm256_add_epi32(y, x);
@@ -227,7 +227,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531(unsigned char *out, const voi
             out -= 4;
         }
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(1526));
         x = _mm256_add_epi32(y, x);

--- a/crypto_kem/sntrup761/avx2/crypto_encode_761x1531round.c
+++ b/crypto_kem/sntrup761/avx2/crypto_encode_761x1531round.c
@@ -32,9 +32,9 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531round(unsigned char *out, cons
         x = _mm256_mulhrs_epi16(x, _mm256_set1_epi16(10923));
         x = _mm256_add_epi16(x, _mm256_add_epi16(x, x));
         x = _mm256_add_epi16(x, _mm256_set1_epi16(2295));
-        x &= _mm256_set1_epi16(16383);
+        x = _mm256_and_si256(x, _mm256_set1_epi16(16383));
         x = _mm256_mulhi_epi16(x, _mm256_set1_epi16(21846));
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(1531));
         x = _mm256_add_epi32(y, x);
@@ -78,8 +78,8 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531round(unsigned char *out, cons
         }
         x = _mm256_loadu_si256((__m256i *) (reading + 0));
         x2 = _mm256_loadu_si256((__m256i *) (reading + 16));
-        y = x & _mm256_set1_epi32(65535);
-        y2 = x2 & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
+        y2 = _mm256_and_si256(x2, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x2 = _mm256_srli_epi32(x2, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(9157));
@@ -116,7 +116,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531round(unsigned char *out, cons
             out -= 1;
         }
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(1280));
         x = _mm256_add_epi32(y, x);
@@ -155,8 +155,8 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531round(unsigned char *out, cons
         --i;
         x = _mm256_loadu_si256((__m256i *) (reading + 0));
         x2 = _mm256_loadu_si256((__m256i *) (reading + 16));
-        y = x & _mm256_set1_epi32(65535);
-        y2 = x2 & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
+        y2 = _mm256_and_si256(x2, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x2 = _mm256_srli_epi32(x2, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(6400));
@@ -187,7 +187,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531round(unsigned char *out, cons
         __m256i x, y;
         --i;
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(625));
         x = _mm256_add_epi32(y, x);
@@ -229,7 +229,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x1531round(unsigned char *out, cons
             out -= 4;
         }
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(1526));
         x = _mm256_add_epi32(y, x);

--- a/crypto_kem/sntrup761/avx2/crypto_encode_761x3.c
+++ b/crypto_kem/sntrup761/avx2/crypto_encode_761x3.c
@@ -32,24 +32,24 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x3(unsigned char *s, const void *v)
         f = nextf;
         nextf += 128;
 
-        __m256i a0 = _mm256_packus_epi16(f0 & lobytes, f1 & lobytes);
+        __m256i a0 = _mm256_packus_epi16(_mm256_and_si256(f0, lobytes), _mm256_and_si256(f1, lobytes));
         /* 0 2 4 6 8 10 12 14 32 34 36 38 40 42 44 46 */
         /* 16 18 20 22 24 26 28 30 48 50 52 54 56 58 60 62 */
         __m256i a1 = _mm256_packus_epi16(_mm256_srli_epi16(f0, 8), _mm256_srli_epi16(f1, 8));
         /* 1 3 ... */
-        __m256i a2 = _mm256_packus_epi16(f2 & lobytes, f3 & lobytes);
+        __m256i a2 = _mm256_packus_epi16(_mm256_and_si256(f2, lobytes), _mm256_and_si256(f3, lobytes));
         __m256i a3 = _mm256_packus_epi16(_mm256_srli_epi16(f2, 8), _mm256_srli_epi16(f3, 8));
 
-        a0 = _mm256_add_epi8(a0, _mm256_slli_epi16(a1 & _mm256_set1_epi8(63), 2));
-        a2 = _mm256_add_epi8(a2, _mm256_slli_epi16(a3 & _mm256_set1_epi8(63), 2));
+        a0 = _mm256_add_epi8(a0, _mm256_slli_epi16(_mm256_and_si256(a1, _mm256_set1_epi8(63)), 2));
+        a2 = _mm256_add_epi8(a2, _mm256_slli_epi16(_mm256_and_si256(a3, _mm256_set1_epi8(63)), 2));
 
-        __m256i b0 = _mm256_packus_epi16(a0 & lobytes, a2 & lobytes);
+        __m256i b0 = _mm256_packus_epi16(_mm256_and_si256(a0, lobytes), _mm256_and_si256(a2, lobytes));
         /* 0 4 8 12 32 36 40 44 64 68 72 76 96 100 104 108 */
         /* 16 20 24 28 48 52 56 60 80 84 88 92 112 116 120 124 */
         __m256i b2 = _mm256_packus_epi16(_mm256_srli_epi16(a0, 8), _mm256_srli_epi16(a2, 8));
         /* 2 6 ... */
 
-        b0 = _mm256_add_epi8(b0, _mm256_slli_epi16(b2 & _mm256_set1_epi8(15), 4));
+        b0 = _mm256_add_epi8(b0, _mm256_slli_epi16(_mm256_and_si256(b2, _mm256_set1_epi8(15)), 4));
 
         b0 = _mm256_permutevar8x32_epi32(b0, _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0));
 

--- a/crypto_kem/sntrup761/avx2/crypto_encode_761x4591.c
+++ b/crypto_kem/sntrup761/avx2/crypto_encode_761x4591.c
@@ -32,10 +32,10 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x4591(unsigned char *out, const voi
         x2 = _mm256_loadu_si256((__m256i *) (reading + 16));
         x = _mm256_add_epi16(x, _mm256_set1_epi16(2295));
         x2 = _mm256_add_epi16(x2, _mm256_set1_epi16(2295));
-        x &= _mm256_set1_epi16(16383);
-        x2 &= _mm256_set1_epi16(16383);
-        y = x & _mm256_set1_epi32(65535);
-        y2 = x2 & _mm256_set1_epi32(65535);
+        x = _mm256_and_si256(x, _mm256_set1_epi16(16383));
+        x2 = _mm256_and_si256(x2, _mm256_set1_epi16(16383));
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
+        y2 = _mm256_and_si256(x2, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x2 = _mm256_srli_epi32(x2, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(4591));
@@ -72,7 +72,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x4591(unsigned char *out, const voi
             out -= 2;
         }
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(322));
         x = _mm256_add_epi32(y, x);
@@ -115,7 +115,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x4591(unsigned char *out, const voi
             out -= 1;
         }
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(406));
         x = _mm256_add_epi32(y, x);
@@ -153,7 +153,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x4591(unsigned char *out, const voi
         __m256i x, y;
         --i;
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(644));
         x = _mm256_add_epi32(y, x);
@@ -195,7 +195,7 @@ void PQCLEAN_SNTRUP761_AVX2_crypto_encode_761x4591(unsigned char *out, const voi
             out -= 1;
         }
         x = _mm256_loadu_si256((__m256i *) reading);
-        y = x & _mm256_set1_epi32(65535);
+        y = _mm256_and_si256(x, _mm256_set1_epi32(65535));
         x = _mm256_srli_epi32(x, 16);
         x = _mm256_mullo_epi32(x, _mm256_set1_epi32(1621));
         x = _mm256_add_epi32(y, x);

--- a/crypto_kem/sntrup761/avx2/crypto_sort_int32.c
+++ b/crypto_kem/sntrup761/avx2/crypto_sort_int32.c
@@ -88,8 +88,8 @@ static void merge16_finish(int32 *x, int32x8 x0, int32x8 x1, int flagdown) {
 
     if (flagdown) {
         mask = _mm256_set1_epi32(-1);
-        x0 ^= mask;
-        x1 ^= mask;
+        x0 = _mm256_xor_si256(x0, mask);
+        x1 = _mm256_xor_si256(x1, mask);
     }
 
     int32x8_store(&x[0], x0);
@@ -225,8 +225,8 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
 
         mask = _mm256_set_epi32(0, 0, -1, -1, 0, 0, -1, -1);
 
-        x0 ^= mask; /* A01234567 */
-        x1 ^= mask; /* B01234567 */
+        x0 = _mm256_xor_si256(x0, mask); /* A01234567 */
+        x1 = _mm256_xor_si256(x1, mask); /* B01234567 */
 
         b0 = _mm256_unpacklo_epi32(x0, x1); /* AB0AB1AB4AB5 */
         b1 = _mm256_unpackhi_epi32(x0, x1); /* AB2AB3AB6AB7 */
@@ -237,8 +237,8 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
         int32x8_MINMAX(c0, c1);
 
         mask = _mm256_set_epi32(0, 0, -1, -1, -1, -1, 0, 0);
-        c0 ^= mask;
-        c1 ^= mask;
+        c0 = _mm256_xor_si256(c0, mask);
+        c1 = _mm256_xor_si256(c1, mask);
 
         b0 = _mm256_unpacklo_epi32(c0, c1); /* A01B01A45B45 */
         b1 = _mm256_unpackhi_epi32(c0, c1); /* A23B23A67B67 */
@@ -259,8 +259,8 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
         b0 = _mm256_unpacklo_epi32(c0, c1); /* A01B01A45B45 */
         b1 = _mm256_unpackhi_epi32(c0, c1); /* A23B23A67B67 */
 
-        b0 ^= mask;
-        b1 ^= mask;
+        b0 = _mm256_xor_si256(b0, mask);
+        b1 = _mm256_xor_si256(b1, mask);
 
         c0 = _mm256_permute2x128_si256(b0, b1, 0x20); /* A01B01A23B23 */
         c1 = _mm256_permute2x128_si256(b0, b1, 0x31); /* A45B45A67B67 */
@@ -291,9 +291,9 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
 
         mask = _mm256_set1_epi32(-1);
         if (flagdown) {
-            x1 ^= mask;
+            x1 = _mm256_xor_si256(x1, mask);
         } else {
-            x0 ^= mask;
+            x0 = _mm256_xor_si256(x0, mask);
         }
 
         merge16_finish(x, x0, x1, flagdown);
@@ -313,10 +313,10 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
 
         if (flagdown) {
             mask = _mm256_set1_epi32(-1);
-            x0 ^= mask;
-            x1 ^= mask;
-            x2 ^= mask;
-            x3 ^= mask;
+            x0 = _mm256_xor_si256(x0, mask);
+            x1 = _mm256_xor_si256(x1, mask);
+            x2 = _mm256_xor_si256(x2, mask);
+            x3 = _mm256_xor_si256(x3, mask);
         }
 
         int32x8_MINMAX(x0, x2);
@@ -372,8 +372,8 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
         for (j = 0; j < n; j += 32) {
             int32x8 x0 = int32x8_load(&x[j]);
             int32x8 x1 = int32x8_load(&x[j + 16]);
-            x0 ^= mask;
-            x1 ^= mask;
+            x0 = _mm256_xor_si256(x0, mask);
+            x1 = _mm256_xor_si256(x1, mask);
             int32x8_store(&x[j], x0);
             int32x8_store(&x[j + 16], x1);
         }
@@ -493,14 +493,14 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
                         int32x8_MINMAX(x3, x7);
 
                         if (flip) {
-                            x0 ^= mask;
-                            x1 ^= mask;
-                            x2 ^= mask;
-                            x3 ^= mask;
-                            x4 ^= mask;
-                            x5 ^= mask;
-                            x6 ^= mask;
-                            x7 ^= mask;
+                            x0 = _mm256_xor_si256(x0, mask);
+                            x1 = _mm256_xor_si256(x1, mask);
+                            x2 = _mm256_xor_si256(x2, mask);
+                            x3 = _mm256_xor_si256(x3, mask);
+                            x4 = _mm256_xor_si256(x4, mask);
+                            x5 = _mm256_xor_si256(x5, mask);
+                            x6 = _mm256_xor_si256(x6, mask);
+                            x7 = _mm256_xor_si256(x7, mask);
                         }
 
                         int32x8_store(&x[i], x0);
@@ -532,8 +532,8 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
             while (z != target) {
                 int32x8 x0 = int32x8_load(&z[0]);
                 int32x8 x1 = int32x8_load(&z[8]);
-                x0 ^= mask;
-                x1 ^= mask;
+                x0 = _mm256_xor_si256(x0, mask);
+                x1 = _mm256_xor_si256(x1, mask);
                 int32x8_store(&z[0], x0);
                 int32x8_store(&z[8], x1);
                 z += 16;
@@ -543,8 +543,8 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
             while (z != target) {
                 int32x8 x0 = int32x8_load(&z[0]);
                 int32x8 x1 = int32x8_load(&z[8]);
-                x0 ^= mask;
-                x1 ^= mask;
+                x0 = _mm256_xor_si256(x0, mask);
+                x1 = _mm256_xor_si256(x1, mask);
                 int32x8 b0 = _mm256_permute2x128_si256(x0, x1, 0x20);
                 int32x8 b1 = _mm256_permute2x128_si256(x0, x1, 0x31);
                 int32x8_MINMAX(b0, b1);
@@ -559,8 +559,8 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
             while (z != target) {
                 int32x8 x0 = int32x8_load(&z[0]);
                 int32x8 x1 = int32x8_load(&z[8]);
-                x0 ^= mask;
-                x1 ^= mask;
+                x0 = _mm256_xor_si256(x0, mask);
+                x1 = _mm256_xor_si256(x1, mask);
                 int32x8 b0 = _mm256_permute2x128_si256(x0, x1, 0x20); /* A0123B0123 */
                 int32x8 b1 = _mm256_permute2x128_si256(x0, x1, 0x31); /* A4567B4567 */
                 int32x8 c0 = _mm256_unpacklo_epi64(b0, b1); /* A0145B0145 */
@@ -683,15 +683,15 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
         int32x8 c7 = _mm256_unpackhi_epi64(b5, b7); /* EFGH3EFGH7 */
 
         if (flagdown) {
-            c2 ^= mask;
-            c3 ^= mask;
-            c6 ^= mask;
-            c7 ^= mask;
+            c2 = _mm256_xor_si256(c2, mask);
+            c3 = _mm256_xor_si256(c3, mask);
+            c6 = _mm256_xor_si256(c6, mask);
+            c7 = _mm256_xor_si256(c7, mask);
         } else {
-            c0 ^= mask;
-            c1 ^= mask;
-            c4 ^= mask;
-            c5 ^= mask;
+            c0 = _mm256_xor_si256(c0, mask);
+            c1 = _mm256_xor_si256(c1, mask);
+            c4 = _mm256_xor_si256(c4, mask);
+            c5 = _mm256_xor_si256(c5, mask);
         }
 
         int32x8 d0 = _mm256_permute2x128_si256(c0, c4, 0x20); /* ABCDEFGH0 */
@@ -872,14 +872,14 @@ static void int32_sort_2power(int32 *x, long long n, int flagdown) {
         int32x8 d7 = _mm256_permute2x128_si256(c3, c7, 0x31); /* AECGBFDH7 */
 
         if (flagdown) {
-            d0 ^= mask;
-            d1 ^= mask;
-            d2 ^= mask;
-            d3 ^= mask;
-            d4 ^= mask;
-            d5 ^= mask;
-            d6 ^= mask;
-            d7 ^= mask;
+            d0 = _mm256_xor_si256(d0, mask);
+            d1 = _mm256_xor_si256(d1, mask);
+            d2 = _mm256_xor_si256(d2, mask);
+            d3 = _mm256_xor_si256(d3, mask);
+            d4 = _mm256_xor_si256(d4, mask);
+            d5 = _mm256_xor_si256(d5, mask);
+            d6 = _mm256_xor_si256(d6, mask);
+            d7 = _mm256_xor_si256(d7, mask);
         }
 
         int32x8_store(&x[i], d0);

--- a/crypto_kem/sntrup761/avx2/crypto_verify_1039.c
+++ b/crypto_kem/sntrup761/avx2/crypto_verify_1039.c
@@ -11,7 +11,7 @@ int PQCLEAN_SNTRUP761_AVX2_crypto_verify_1039(const unsigned char *x, const unsi
         do {
             __m256i x0 = _mm256_loadu_si256((__m256i *) x);
             __m256i y0 = _mm256_loadu_si256((__m256i *) y);
-            diff |= x0 ^ y0;
+            diff = _mm256_or_si256(diff, _mm256_xor_si256(x0, y0));
             i -= 32;
             x += 32;
             y += 32;
@@ -23,9 +23,9 @@ int PQCLEAN_SNTRUP761_AVX2_crypto_verify_1039(const unsigned char *x, const unsi
         y += i;
     }
 
-    diff |= _mm256_srli_epi16(diff, 8);
-    diff |= _mm256_srli_epi32(diff, 16);
-    diff |= _mm256_srli_epi64(diff, 32);
+    diff = _mm256_or_si256(diff, _mm256_srli_epi16(diff, 8));
+    diff = _mm256_or_si256(diff, _mm256_srli_epi32(diff, 16));
+    diff = _mm256_or_si256(diff, _mm256_srli_epi64(diff, 32));
 
     differentbits = (unsigned int) _mm256_extract_epi8(diff, 0);
     differentbits |= (unsigned int) _mm256_extract_epi8(diff, 8);


### PR DESCRIPTION
MSVC does not support AVX bitwise operators.

This replaces all those operators with the following intrinsics:
_mm256_and_si256
_mm256_or_si256
_mm256_xor_si256