### PR TITLE
Disable asan on armv7l/clang builds

### DIFF
--- a/test/test_functest.py
+++ b/test/test_functest.py
@@ -54,13 +54,10 @@ def test_functest_sanitizers(implementation, impl_path, test_dir,
                              init, destr):
     dest_dir = os.path.join(test_dir, 'bin')
     env = None
-    if (implementation.scheme.name == "sphincs-sha256-192s-robust"
-            and 'CI' in os.environ
-            and implementation.name == "clean"
-            and 'clang' in os.environ.get('CC', '')):
-        raise unittest.SkipTest("Clang makes this test use too much RAM")
     if platform.machine() == 'ppc' and 'clang' in os.environ.get('CC', 'gcc'):
         raise unittest.SkipTest("Clang does not support ASAN on ppc")
+    elif platform.machine() == 'armv7l' and 'clang' in os.environ.get('CC', 'gcc'):
+            raise unittest.SkipTest("A bug with asan on armv7l, see #471")
     elif platform.machine() in ['armv7l', 'aarch64']:
         env = {'ASAN_OPTIONS': 'detect_leaks=0'}
     elif platform.system() == 'Darwin':


### PR DESCRIPTION
cf. #469 and https://github.com/llvm/llvm-project/issues/59826, disable asan on Clang/armv7l.

I'm also removing the skip of a specific SPHINCS+ parameterset, as I don't think it's relevant anymore.