### PR TITLE
Fix Falcon signature computation

### DIFF
--- a/crypto_sign/falcon-1024/META.yml
+++ b/crypto_sign/falcon-1024/META.yml
@@ -22,9 +22,9 @@ auxiliary-submitters:
   - Zhenfei Zhang
 implementations:
   - name: clean
-    version: 20230207
+    version: 20211101 with PQClean patches
   - name: avx2
-    version: 20230207
+    version: 20211101 with PQClean patches
     supported_platforms:
       - architecture: x86_64
         required_flags:

--- a/crypto_sign/falcon-1024/avx2/pqclean.c
+++ b/crypto_sign/falcon-1024/avx2/pqclean.c
@@ -131,7 +131,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
         fpr dummy_fpr;
     } tmp;
     int8_t f[1024], g[1024], F[1024], G[1024];
-    union {
+    struct {
         int16_t sig[1024];
         uint16_t hm[1024];
     } r;

--- a/crypto_sign/falcon-1024/clean/pqclean.c
+++ b/crypto_sign/falcon-1024/clean/pqclean.c
@@ -131,7 +131,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
         fpr dummy_fpr;
     } tmp;
     int8_t f[1024], g[1024], F[1024], G[1024];
-    union {
+    struct {
         int16_t sig[1024];
         uint16_t hm[1024];
     } r;

--- a/crypto_sign/falcon-512/META.yml
+++ b/crypto_sign/falcon-512/META.yml
@@ -22,9 +22,9 @@ auxiliary-submitters:
   - Zhenfei Zhang
 implementations:
   - name: clean
-    version: 20230207
+    version: 20211101 with PQClean patches
   - name: avx2
-    version: 20230207
+    version: 20211101 with PQClean patches
     supported_platforms:
       - architecture: x86_64
         required_flags:

--- a/crypto_sign/falcon-512/avx2/pqclean.c
+++ b/crypto_sign/falcon-512/avx2/pqclean.c
@@ -131,7 +131,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
         fpr dummy_fpr;
     } tmp;
     int8_t f[512], g[512], F[512], G[512];
-    union {
+    struct {
         int16_t sig[512];
         uint16_t hm[512];
     } r;

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -131,7 +131,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
         fpr dummy_fpr;
     } tmp;
     int8_t f[512], g[512], F[512], G[512];
-    union {
+    struct {
         int16_t sig[512];
         uint16_t hm[512];
     } r;


### PR DESCRIPTION
Falcon computes the signature in a loop, retrying if the signature is
too long. The Falcon-1024 limit seems a bit stricter than the Falcon-512
limit, which seemingly hits the recomputation more often.

If it would try to try again for a signature, the implementation would
read from the `hm` buffer again. However, `hm` was specified as a union
with `sig` and the previously attempted signature would be in its place.

In a previous version of Falcon, this recomputation would never happen,
so the case was never hit. Additionally, with the larger signature
lengths present in the NIST reference code and previous PQClean versions
of Falcon, this case would also never be hit.

Thanks a lot to @pornin for finding out this problem.

Closes #477 