### PR TITLE
Attempt to manually report flags for Apple M chips

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -281,5 +281,15 @@ def get_cpu_info():
     while the_info is None or 'flags' not in the_info:
         import cpuinfo
         the_info = cpuinfo.get_cpu_info()
+        if 'Apple M' in the_info.get('brand_raw', ''):
+            the_info['flags'] = [
+                'sha3',
+                'sha256',
+                'sha1',
+                'aes',
+                'crc32',
+                'neon',
+                'asimd',
+            ]
 
     return the_info


### PR DESCRIPTION
This hopefully resolves #483. I'm manually setting the `flags` field for Apple M-series chips. It's not exhaustive, but hopefully enough.

@mouse07410, could you please test if this works?