### PR TITLE
Avoid -Wstrict-prototypes warning

### DIFF
--- a/test/crypto_kem/nistkat.c
+++ b/test/crypto_kem/nistkat.c
@@ -38,8 +38,7 @@ static void fprintBstr(FILE *fp, const char *S, const uint8_t *A, size_t L) {
     fprintf(fp, "\n");
 }
 
-int main() {
-
+int main(void) {
     uint8_t entropy_input[48];
     uint8_t seed[48];
     FILE *fh = stdout;

--- a/test/crypto_kem/printparams.c
+++ b/test/crypto_kem/printparams.c
@@ -5,7 +5,7 @@
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(PQCLEAN_NAMESPACE, fun)
 
-int main() {
+int main(void) {
     printf("{\n");
     printf("\t\"CRYPTO_SECRETKEYBYTES\": %u,\n",  NAMESPACE(CRYPTO_SECRETKEYBYTES));
     printf("\t\"CRYPTO_PUBLICKEYBYTES\": %u,\n",  NAMESPACE(CRYPTO_PUBLICKEYBYTES));

--- a/test/crypto_sign/nistkat.c
+++ b/test/crypto_sign/nistkat.c
@@ -37,8 +37,7 @@ static void fprintBstr(FILE *fp, const char *S, const uint8_t *A, size_t L) {
     fprintf(fp, "\n");
 }
 
-int main() {
-
+int main(void) {
     uint8_t entropy_input[48];
     uint8_t seed[48];
     FILE *fh = stdout;

--- a/test/crypto_sign/printparams.c
+++ b/test/crypto_sign/printparams.c
@@ -5,7 +5,7 @@
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(PQCLEAN_NAMESPACE, fun)
 
-int main() {
+int main(void) {
     printf("{\n");
     printf("\t\"CRYPTO_SECRETKEYBYTES\": %u,\n",  NAMESPACE(CRYPTO_SECRETKEYBYTES));
     printf("\t\"CRYPTO_PUBLICKEYBYTES\": %u,\n",  NAMESPACE(CRYPTO_PUBLICKEYBYTES));


### PR DESCRIPTION
Avoid e.g.:

```
crypto_sign/printparams.c:8:9: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
int main() {
        ^
         void
1 error generated.
```