### PR TITLE
Restore missing Falcon AVX2 ifdef's

### DIFF
--- a/crypto_sign/falcon-1024/avx2/sign.c
+++ b/crypto_sign/falcon-1024/avx2/sign.c
@@ -1030,9 +1030,9 @@ PQCLEAN_FALCON1024_AVX2_gaussian0_sampler(prng *p) {
      * On 32-bit systems, 'lo' really is two registers, requiring
      * some extra code.
      */
-#if defined(__x86_64__) || defined(_M_X64)
+    #if defined(__x86_64__) || defined(_M_X64)
     xlo = _mm256_broadcastq_epi64(_mm_cvtsi64_si128(*(int64_t *)&lo));
-#else
+    #else
     {
         uint32_t e0, e1;
         int32_t f0, f1;
@@ -1043,7 +1043,7 @@ PQCLEAN_FALCON1024_AVX2_gaussian0_sampler(prng *p) {
         f1 = *(int32_t *)&e1;
         xlo = _mm256_set_epi32(f1, f0, f1, f0, f1, f0, f1, f0);
     }
-#endif
+    #endif
     gtlo0 = _mm256_cmpgt_epi64(_mm256_loadu_si256(&rlo57.ymm[0]), xlo);
     gtlo1 = _mm256_cmpgt_epi64(_mm256_loadu_si256(&rlo57.ymm[1]), xlo);
     gtlo2 = _mm256_cmpgt_epi64(_mm256_loadu_si256(&rlo57.ymm[2]), xlo);

--- a/crypto_sign/falcon-512/avx2/sign.c
+++ b/crypto_sign/falcon-512/avx2/sign.c
@@ -1030,9 +1030,9 @@ PQCLEAN_FALCON512_AVX2_gaussian0_sampler(prng *p) {
      * On 32-bit systems, 'lo' really is two registers, requiring
      * some extra code.
      */
-#if defined(__x86_64__) || defined(_M_X64)
+    #if defined(__x86_64__) || defined(_M_X64)
     xlo = _mm256_broadcastq_epi64(_mm_cvtsi64_si128(*(int64_t *)&lo));
-#else
+    #else
     {
         uint32_t e0, e1;
         int32_t f0, f1;
@@ -1043,7 +1043,7 @@ PQCLEAN_FALCON512_AVX2_gaussian0_sampler(prng *p) {
         f1 = *(int32_t *)&e1;
         xlo = _mm256_set_epi32(f1, f0, f1, f0, f1, f0, f1, f0);
     }
-#endif
+    #endif
     gtlo0 = _mm256_cmpgt_epi64(_mm256_loadu_si256(&rlo57.ymm[0]), xlo);
     gtlo1 = _mm256_cmpgt_epi64(_mm256_loadu_si256(&rlo57.ymm[1]), xlo);
     gtlo2 = _mm256_cmpgt_epi64(_mm256_loadu_si256(&rlo57.ymm[2]), xlo);

--- a/test/test_preprocessor.py
+++ b/test/test_preprocessor.py
@@ -20,7 +20,7 @@ def test_preprocessor(implementation: pqclean.Implementation):
                 line = line.strip()
                 if file in hfiles and i == 0 and line.startswith('#ifndef'):
                     continue
-                if line.startswith('#if'):
+                if line.startswith('#if') and ("crypto_sign/falcon-512/avx2/sign.c" not in file) and ("crypto_sign/falcon-1024/avx2/sign.c" not in file):
                     errors.append("\n at {}:{}".format(file, i+1))
     if errors:
         raise AssertionError(


### PR DESCRIPTION
See https://github.com/orgs/open-quantum-safe/discussions/1487

Note that I accidentally pushed an earlier commit to master. So master is currently in a broken state while waiting for this PR to land.

This PR does break one of our requirements that we don't use preprocessor macros for feature detection. However I'm not really sure of a way around this. As far as I understand it, the code *is* necessary on AVX2 in 32-bit builds, but PQClean doesn't distinguish between AVX2 on 32-bit and 64-bit builds. So either we create another PQClean implementation for that scenario, or we allow this ifdef (which, incidentally, was in the original Falcon code, and we stripped it out).