### PR TITLE
Removed additional comma in Bibtex cite

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Find the paper at https://eprint.iacr.org/2022/337
 Please cite this work when referring to PQClean:
 
 ```bibtex
-@inproceedings{SSR:KSSW22,,
+@inproceedings{SSR:KSSW22,
   author    = {Matthias J. Kannwischer and
                Peter Schwabe and
                Douglas Stebila and


### PR DESCRIPTION
<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->

Only removed additional comma in Bibtex cite which leads to compile errors when using in latex project.
