### PR TITLE
fix(tests): Fix duplicate consistency checks for SPHINCS+

### DIFF
--- a/test/duplicate_consistency/sphincs-shake-128f-simple_avx2.yml
+++ b/test/duplicate_consistency/sphincs-shake-128f-simple_avx2.yml
@@ -46,15 +46,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192s-simple
     implementation: avx2
@@ -74,15 +68,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192f-simple
     implementation: avx2
@@ -102,15 +90,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256s-simple
     implementation: avx2
@@ -130,15 +112,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256f-simple
     implementation: avx2
@@ -158,12 +134,6 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h

--- a/test/duplicate_consistency/sphincs-shake-128s-simple_avx2.yml
+++ b/test/duplicate_consistency/sphincs-shake-128s-simple_avx2.yml
@@ -46,15 +46,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192s-simple
     implementation: avx2
@@ -74,15 +68,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192f-simple
     implementation: avx2
@@ -102,15 +90,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256s-simple
     implementation: avx2
@@ -130,15 +112,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256f-simple
     implementation: avx2
@@ -158,12 +134,6 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-128s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h

--- a/test/duplicate_consistency/sphincs-shake-192f-simple_avx2.yml
+++ b/test/duplicate_consistency/sphincs-shake-192f-simple_avx2.yml
@@ -46,15 +46,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-128f-simple
     implementation: avx2
@@ -74,15 +68,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192s-simple
     implementation: avx2
@@ -102,15 +90,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256s-simple
     implementation: avx2
@@ -130,15 +112,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256f-simple
     implementation: avx2
@@ -158,12 +134,6 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h

--- a/test/duplicate_consistency/sphincs-shake-192s-simple_avx2.yml
+++ b/test/duplicate_consistency/sphincs-shake-192s-simple_avx2.yml
@@ -46,15 +46,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-128f-simple
     implementation: avx2
@@ -74,15 +68,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192f-simple
     implementation: avx2
@@ -102,15 +90,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256s-simple
     implementation: avx2
@@ -130,15 +112,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256f-simple
     implementation: avx2
@@ -158,12 +134,6 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-192s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h

--- a/test/duplicate_consistency/sphincs-shake-256f-simple_avx2.yml
+++ b/test/duplicate_consistency/sphincs-shake-256f-simple_avx2.yml
@@ -46,15 +46,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-128f-simple
     implementation: avx2
@@ -74,15 +68,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192s-simple
     implementation: avx2
@@ -102,15 +90,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192f-simple
     implementation: avx2
@@ -130,15 +112,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256s-simple
     implementation: avx2
@@ -158,12 +134,6 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256f-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h

--- a/test/duplicate_consistency/sphincs-shake-256s-simple_avx2.yml
+++ b/test/duplicate_consistency/sphincs-shake-256s-simple_avx2.yml
@@ -46,15 +46,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-128f-simple
     implementation: avx2
@@ -74,15 +68,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192s-simple
     implementation: avx2
@@ -102,15 +90,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-192f-simple
     implementation: avx2
@@ -130,15 +112,9 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h
 - source:
     scheme: sphincs-shake-256f-simple
     implementation: avx2
@@ -158,12 +134,6 @@ consistency_checks:
   - wotsx4.h
 - source:
     scheme: sphincs-sha2-256s-simple
-    implementation: aesni
+    implementation: avx2
   files:
-  - thashx4.h
-  - merkle.c
-  - hashx4.h
-  - utilsx4.c
-  - utilsx4.h
   - wots.h
-  - wotsx4.h

--- a/test/pqclean.py
+++ b/test/pqclean.py
@@ -26,7 +26,7 @@ class Scheme:
         for scheme in Scheme.all_schemes():
             if scheme.name == scheme_name:
                 return scheme
-        raise KeyError()
+        raise KeyError(f"No scheme for {scheme_name}")
 
     @staticmethod
     @lru_cache(maxsize=1)
@@ -118,7 +118,7 @@ class Implementation:
         for implementation in scheme.implementations:
             if implementation.name == implementation_name:
                 return implementation
-        raise KeyError()
+        raise KeyError(f"No implementation for {scheme_name} - {implementation_name}")
 
     @staticmethod
     @lru_cache(maxsize=None)


### PR DESCRIPTION
The generator that I used for the duplicate consistency files for SPHINCS+ still had some assumptions on robust and haraka variants existing. This updates those files.

I'm also sneaking in a small improvement to `pqclean.py` to add the file that was not found to the exception message.

