### PR TITLE
fix(tests): Fix function signature for hqc_kat_release(void)

### DIFF
--- a/test/common/hqckatrng.c
+++ b/test/common/hqckatrng.c
@@ -58,6 +58,6 @@ int randombytes(uint8_t *buf, size_t n) {
  * @brief Release the PRNG context
  * @param[in] state Internal state of the PRNG
  */
-void hqc_kat_release() {
+void hqc_kat_release(void) {
     shake256_inc_ctx_release(&shake_prng_state);
 }


### PR DESCRIPTION
This should shut up some warnings

See #528
