### PR TITLE
Add tests for variable-length signatures

### DIFF
--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -338,7 +338,6 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign(
     sm[0] = (uint8_t)(sigbuflen >> 8);
     sm[1] = (uint8_t)sigbuflen;
     *smlen = mlen + 2 + NONCELEN + sigbuflen;
-    if (sm[*smlen] == 0) sm[0] = 0;
     return 0;
 }
 

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -296,7 +296,6 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_signature(
     }
     sig[0] = 0x30 + 9;
     *siglen = 1 + NONCELEN + vlen;
-    if (sig[*siglen+1] == 0) sig[0] = 0;
     return 0;
 }
 

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -296,6 +296,7 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_signature(
     }
     sig[0] = 0x30 + 9;
     *siglen = 1 + NONCELEN + vlen;
+    sig[*siglen] = 0;
     return 0;
 }
 
@@ -338,6 +339,7 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign(
     sm[0] = (uint8_t)(sigbuflen >> 8);
     sm[1] = (uint8_t)sigbuflen;
     *smlen = mlen + 2 + NONCELEN + sigbuflen;
+    sm[*smlen] = 0;
     return 0;
 }
 

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -338,6 +338,7 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign(
     sm[0] = (uint8_t)(sigbuflen >> 8);
     sm[1] = (uint8_t)sigbuflen;
     *smlen = mlen + 2 + NONCELEN + sigbuflen;
+    if (sm[*smlen] == 0) sm[0] = 0;
     return 0;
 }
 

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -296,6 +296,7 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_signature(
     }
     sig[0] = 0x30 + 9;
     *siglen = 1 + NONCELEN + vlen;
+    if (sig[*siglen+1] == 0) sig[0] = 0;
     return 0;
 }
 

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -296,7 +296,6 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_signature(
     }
     sig[0] = 0x30 + 9;
     *siglen = 1 + NONCELEN + vlen;
-    sig[*siglen] = 0;
     return 0;
 }
 
@@ -339,7 +338,6 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign(
     sm[0] = (uint8_t)(sigbuflen >> 8);
     sm[1] = (uint8_t)sigbuflen;
     *smlen = mlen + 2 + NONCELEN + sigbuflen;
-    sm[*smlen] = 0;
     return 0;
 }
 

--- a/test/crypto_sign/functest.c
+++ b/test/crypto_sign/functest.c
@@ -79,6 +79,15 @@ inline static void *malloc_s(size_t size) {
 
 static int test_sign(void) {
     /*
+     * In order to properly test variable-length signatures, we need to check
+     * that the implementation does not modify the provided buffer beyond the
+     * reported signature length. We do this by filling the buffer with random
+     * bytes before the call to sign and checking afterward that the tail has
+     * not been modified.
+    */
+    uint8_t sm_random_cmp[MLEN + CRYPTO_BYTES];
+
+    /*
      * This is most likely going to be aligned by the compiler.
      * 16 extra bytes for canary
      * 1 extra byte for unalignment
@@ -124,7 +133,14 @@ static int test_sign(void) {
         RETURNS_ZERO(crypto_sign_keypair(pk + 8, sk + 8));
 
         randombytes(m + 8, MLEN);
+        // Fill the sm buffer with random bytes
+        randombytes(sm_random_cmp, MLEN + CRYPTO_BYTES);
+        memcpy(sm + 8, sm_random_cmp, MLEN + CRYPTO_BYTES);
+
         RETURNS_ZERO(crypto_sign(sm + 8, &smlen, m + 8, MLEN, sk + 8));
+
+        // check that the tail has not been modified
+        RETURNS_ZERO(memcmp(sm + 8 + smlen, sm_random_cmp + smlen, MLEN + CRYPTO_BYTES - smlen));
 
         // By relying on m == sm we prevent having to allocate CRYPTO_BYTES
         // twice
@@ -157,6 +173,15 @@ end:
 }
 
 static int test_sign_detached(void) {
+    /*
+     * In order to properly test variable-length signatures, we need to check
+     * that the implementation does not modify the provided buffer beyond the
+     * reported signature length. We do this by filling the buffer with random
+     * bytes before the call to sign and checking afterward that the tail has
+     * not been modified.
+    */
+    uint8_t sig_random_cmp[CRYPTO_BYTES];
+
     /*
      * This is most likely going to be aligned by the compiler.
      * 16 extra bytes for canary
@@ -202,7 +227,15 @@ static int test_sign_detached(void) {
         RETURNS_ZERO(crypto_sign_keypair(pk + 8, sk + 8));
 
         randombytes(m + 8, MLEN);
+
+        // Fill the sig buffer with random bytes
+        randombytes(sig_random_cmp, CRYPTO_BYTES);
+        memcpy(sig + 8, sig_random_cmp, CRYPTO_BYTES);
+
         RETURNS_ZERO(crypto_sign_signature(sig + 8, &siglen, m + 8, MLEN, sk + 8));
+
+        // check that the tail has not been modified
+        RETURNS_ZERO(memcmp(sig + 8 + siglen, sig_random_cmp + siglen, CRYPTO_BYTES - siglen));
 
         if ((returncode =
                     crypto_sign_verify(sig + 8, siglen, m + 8, MLEN, pk + 8)) != 0) {

--- a/test/crypto_sign/functest.c
+++ b/test/crypto_sign/functest.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <valgrind/memcheck.h>
 
 #ifndef NTESTS
 #define NTESTS 5
@@ -137,7 +138,17 @@ static int test_sign(void) {
         randombytes(sm_random_cmp, MLEN + CRYPTO_BYTES);
         memcpy(sm + 8, sm_random_cmp, MLEN + CRYPTO_BYTES);
 
+        /*
+         * With this buffer marked as undefined, valgrind will detect
+         * cases where the signing code depends on the value of the tail
+         * of the buffer.
+         */
+        VALGRIND_MAKE_MEM_UNDEFINED(sm + 8, MLEN + CRYPTO_BYTES);
+
         RETURNS_ZERO(crypto_sign(sm + 8, &smlen, m + 8, MLEN, sk + 8));
+
+        // We have to mark the tail as defined before doing the memcmp.
+        VALGRIND_MAKE_MEM_DEFINED(sm + 8 + smlen, MLEN + CRYPTO_BYTES - smlen);
 
         // check that the tail has not been modified
         RETURNS_ZERO(memcmp(sm + 8 + smlen, sm_random_cmp + smlen, MLEN + CRYPTO_BYTES - smlen));
@@ -232,7 +243,17 @@ static int test_sign_detached(void) {
         randombytes(sig_random_cmp, CRYPTO_BYTES);
         memcpy(sig + 8, sig_random_cmp, CRYPTO_BYTES);
 
+        /*
+         * With this buffer marked as undefined, valgrind will detect
+         * cases where the signing code depends on the value of the tail
+         * of the buffer.
+         */
+        VALGRIND_MAKE_MEM_UNDEFINED(sig + 8, CRYPTO_BYTES);
+
         RETURNS_ZERO(crypto_sign_signature(sig + 8, &siglen, m + 8, MLEN, sk + 8));
+
+        // We have to mark the tail as defined before doing the memcmp.
+        VALGRIND_MAKE_MEM_DEFINED(sig + 8 + siglen, CRYPTO_BYTES - siglen);
 
         // check that the tail has not been modified
         RETURNS_ZERO(memcmp(sig + 8 + siglen, sig_random_cmp + siglen, CRYPTO_BYTES - siglen));

--- a/test/test_valgrind.py
+++ b/test/test_valgrind.py
@@ -45,7 +45,7 @@ def test_valgrind(implementation: pqclean.Implementation, impl_path, test_dir,
                  SCHEME_DIR=os.path.abspath(impl_path),
                  IMPLEMENTATION=implementation.name,
                  DEST_DIR=dest_dir,
-                 EXTRAFLAGS="-gdwarf-4",
+                 EXTRAFLAGS="-gdwarf-4 -DPQCLEAN_USE_VALGRIND",
                  NTESTS=1,
                  working_dir=os.path.join(test_dir, 'test'))
     functest_name = './functest_{}_{}'.format(implementation.scheme.name,


### PR DESCRIPTION
<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->
This PR adds tests for variable-length signatures, as discussed in #530.

There are two tests:
1. Fill the signature buffer with random bytes before calling the signing operation. Check to see that the "tail" of the buffer (beyond the returned `siglen` is unmodified.
2. Mark the signature buffer as "undefined" and use Valgrind to check that the signing operation does not depend on the value of this buffer. This, combined with the previous test, ensures that the signing operation does not read past the end of the buffer in any meaningful way.

The commit history contains a number of reverted commits which deliberately trigger test failures. This is to demonstrate that the new tests do indeed catch undesired behaviour. If you want to double-check this, just checkout one of the "TO BE REVERTED" commits and run either
`pytest -v -n=auto -k "falcon-512 and clean" test_functest.py::test_functest` or `pytest -v -n=auto -k "falcon-512 and clean" test_valgrind.py`. I'll squash these commits at merge.

Will mark as ready for review once I see that CI has passed.

<!-- !! If you are not submitting a new scheme, we suggest removing the following lines!!  -->