### PR TITLE
Add prevent branching __asm__ macro trick

### DIFF
--- a/common/compat.h
+++ b/common/compat.h
@@ -54,4 +54,20 @@ UNALIGNED_VECTOR_POLYFILL_GCC
 # define PQCLEAN_VLA(__t,__x,__s) __t __x[__s]
 #endif
 
+/*********************************
+ * Prevent branching on variable *
+ *********************************/
+
+#if defined(__GNUC__) || defined(__clang__)
+  // Prevent the compiler from
+  //    1) inferring that b is 0/1-valued, and
+  //    2) handling the two cases with a branch.
+  // This is not necessary when verify.c and kem.c are separate translation
+  // units, but we expect that downstream consumers will copy this code and/or
+  // change how it is built.
+# define PQCLEAN_PREVENT_BRANCH_HACK(b)  __asm__("" : "+r"(b) : /* no inputs */);
+#else
+# define PQCLEAN_PREVENT_BRANCH_HACK(b)
+#endif
+
 #endif // PQCLEAN_COMMON_COMPAT_H

--- a/test/common/compat.h
+++ b/test/common/compat.h
@@ -1,3 +1,4 @@
 /** Empty on purpose so preprocessor / compiler-specific stuff does not choke test_char.py **/
 
 #define PQCLEAN_VLA(__t,__x,__s) __t __x[__s]
+#define PQCLEAN_PREVENT_BRANCH_HACK(b)


### PR DESCRIPTION
This macro can be used to prevent branching in CMOVs and such, to prevent attacks like [Clangover](https://pqshield.com/pqshield-plugs-timing-leaks-in-kyber-ml-kem-to-improve-pqc-implementation-maturity/). Unfortunately, I don't know how to do this on MSVC or in other compilers. 