### PR TITLE
Add new NIST signature APIs (optionally)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,31 @@ int PQCLEAN_SCHEME_IMPL_crypto_sign_verify(
     const uint8_t *pk);
 ```
 
+As NIST has changed the signature APIs for the final [FIPS204](https://csrc.nist.gov/pubs/fips/204/final) and [FIPS205](https://csrc.nist.gov/pubs/fips/205/final), we additionally support the new APIs.
+Implementations may use the new APIs by defining `#define PQCLEAN_USE_SIGN_CTX` in `api.h`.
+The updated APIs are:
+```c
+int PQCLEAN_SCHEME_IMPL_crypto_sign_signature(uint8_t *sig, size_t *siglen,
+        const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
+        const uint8_t *sk);
+
+int PQCLEAN_SCHEME_IMPL_crypto_sign(uint8_t *sm, size_t *smlen,
+        const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
+        const uint8_t *sk);
+
+int PQCLEAN_SCHEME_IMPL_crypto_sign_verify(const uint8_t *sig, size_t siglen,
+        const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
+        const uint8_t *pk);
+
+int PQCLEAN_SCHEME_IMPL_crypto_sign_open(uint8_t *m, size_t *mlen,
+        const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
+        const uint8_t *pk);
+```
+
 ## Building PQClean
 
 As noted above, PQClean is **not** meant to be built as a single library: it is a collection of source code that can be easily integrated into other libraries.  The PQClean repository includes various test programs which do build various files, but you should not use the resulting binaries.

--- a/crypto_sign/dilithium2/aarch64/api.h
+++ b/crypto_sign/dilithium2/aarch64/api.h
@@ -25,13 +25,13 @@ int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(
     const uint8_t *sig, size_t siglen,
-    const uint8_t *m, size_t mlen, 
+    const uint8_t *m, size_t mlen,
     const uint8_t *ctx, size_t ctxlen,
     const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign(
     uint8_t *sm, size_t *smlen,
-    const uint8_t *m, size_t mlen, 
+    const uint8_t *m, size_t mlen,
     const uint8_t *ctx, size_t ctxlen,
     const uint8_t *sk);
 

--- a/crypto_sign/dilithium2/aarch64/api.h
+++ b/crypto_sign/dilithium2/aarch64/api.h
@@ -21,7 +21,9 @@ int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
-    const uint8_t *m, size_t mlen, const uint8_t *sk);
+    const uint8_t *m, size_t mlen,
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(
     const uint8_t *sig, size_t siglen,

--- a/crypto_sign/dilithium2/aarch64/api.h
+++ b/crypto_sign/dilithium2/aarch64/api.h
@@ -1,6 +1,8 @@
 #ifndef PQCLEAN_DILITHIUM2_AARCH64_API_H
 #define PQCLEAN_DILITHIUM2_AARCH64_API_H
 
+#define PQCLEAN_USE_SIGN_CTX
+
 /*
  * This file is dual licensed
  * under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.html)
@@ -23,14 +25,19 @@ int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(
     const uint8_t *sig, size_t siglen,
-    const uint8_t *m, size_t mlen, const uint8_t *pk);
+    const uint8_t *m, size_t mlen, 
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign(
     uint8_t *sm, size_t *smlen,
-    const uint8_t *m, size_t mlen, const uint8_t *sk);
+    const uint8_t *m, size_t mlen, 
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_open(
     uint8_t *m, size_t *mlen,
+    const uint8_t *ctx, size_t ctxlen,
     const uint8_t *sm, size_t smlen, const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium2/aarch64/sign.c
+++ b/crypto_sign/dilithium2/aarch64/sign.c
@@ -114,7 +114,11 @@ int crypto_sign_signature(uint8_t *sig,
                           size_t *siglen,
                           const uint8_t *m,
                           size_t mlen,
+                          const uint8_t *ctx,
+                          size_t ctxlen,
                           const uint8_t *sk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int n;
     uint8_t seedbuf[2 * SEEDBYTES + TRBYTES + RNDBYTES + 2 * CRHBYTES];
     uint8_t *rho, *tr, *key, *mu, *rhoprime, *rnd;
@@ -235,13 +239,15 @@ int crypto_sign(uint8_t *sm,
                 size_t *smlen,
                 const uint8_t *m,
                 size_t mlen,
+                const uint8_t *ctx,
+                size_t ctxlen,
                 const uint8_t *sk) {
     size_t i;
 
     for (i = 0; i < mlen; ++i) {
         sm[PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
     }
-    crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_BYTES, mlen, sk);
+    crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
     *smlen += mlen;
     return 0;
 }
@@ -263,7 +269,11 @@ int crypto_sign_verify(const uint8_t *sig,
                        size_t siglen,
                        const uint8_t *m,
                        size_t mlen,
+                       const uint8_t *ctx,
+                       size_t ctxlen,
                        const uint8_t *pk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i;
     uint8_t buf[K * POLYW1_PACKEDBYTES];
     uint8_t rho[SEEDBYTES];
@@ -351,6 +361,8 @@ int crypto_sign_open(uint8_t *m,
                      size_t *mlen,
                      const uint8_t *sm,
                      size_t smlen,
+                     const uint8_t *ctx,
+                     size_t ctxlen,
                      const uint8_t *pk) {
     size_t i;
 
@@ -359,7 +371,7 @@ int crypto_sign_open(uint8_t *m,
     }
 
     *mlen = smlen - PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_BYTES;
-    if (crypto_sign_verify(sm, PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_BYTES, *mlen, pk)) {
+    if (crypto_sign_verify(sm, PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM2_AARCH64_CRYPTO_BYTES, *mlen, ctx, ctxlen, pk)) {
         goto badsig;
     } else {
         /* All good, copy msg, return 0 */

--- a/crypto_sign/dilithium2/aarch64/sign.h
+++ b/crypto_sign/dilithium2/aarch64/sign.h
@@ -22,21 +22,25 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,
+                          const uint8_t *ctx, size_t ctxlen,
                           const uint8_t *sk);
 
 #define crypto_sign DILITHIUM_NAMESPACE(crypto_sign)
 int crypto_sign(uint8_t *sm, size_t *smlen,
                 const uint8_t *m, size_t mlen,
+                const uint8_t *ctx, size_t ctxlen,
                 const uint8_t *sk);
 
 #define crypto_sign_verify DILITHIUM_NAMESPACE(crypto_sign_verify)
 int crypto_sign_verify(const uint8_t *sig, size_t siglen,
                        const uint8_t *m, size_t mlen,
+                       const uint8_t *ctx, size_t ctxlen,
                        const uint8_t *pk);
 
 #define crypto_sign_open DILITHIUM_NAMESPACE(crypto_sign_open)
 int crypto_sign_open(uint8_t *m, size_t *mlen,
                      const uint8_t *sm, size_t smlen,
+                     const uint8_t *ctx, size_t ctxlen,
                      const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium2/avx2/api.h
+++ b/crypto_sign/dilithium2/avx2/api.h
@@ -1,6 +1,8 @@
 #ifndef PQCLEAN_DILITHIUM2_AVX2_API_H
 #define PQCLEAN_DILITHIUM2_AVX2_API_H
 
+#define PQCLEAN_USE_SIGN_CTX
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -13,18 +15,22 @@ int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign(uint8_t *sm, size_t *smlen,
                                         const uint8_t *m, size_t mlen,
+                                        const uint8_t *ctx, size_t ctxlen,
                                         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium2/avx2/sign.c
+++ b/crypto_sign/dilithium2/avx2/sign.c
@@ -116,7 +116,9 @@ int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk) {
+int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i, n, pos;
     uint8_t seedbuf[2 * SEEDBYTES + TRBYTES + RNDBYTES + 2 * CRHBYTES];
     uint8_t *rho, *tr, *key, *rnd, *mu, *rhoprime;
@@ -253,13 +255,13 @@ rej:
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_DILITHIUM2_AVX2_crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen, const uint8_t *sk) {
+int PQCLEAN_DILITHIUM2_AVX2_crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk) {
     size_t i;
 
     for (i = 0; i < mlen; ++i) {
         sm[PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
     }
-    PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES, mlen, sk);
+    PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
     *smlen += mlen;
     return 0;
 }
@@ -277,7 +279,9 @@ int PQCLEAN_DILITHIUM2_AVX2_crypto_sign(uint8_t *sm, size_t *smlen, const uint8_
 *
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
-int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk) {
+int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i, j, pos = 0;
     /* PQCLEAN_DILITHIUM2_AVX2_polyw1_pack writes additional 14 bytes */
     ALIGNED_UINT8(K * POLYW1_PACKEDBYTES + 14) buf;
@@ -385,7 +389,7 @@ int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen
 *
 * Returns 0 if signed message could be verified correctly and -1 otherwise
 **************************************************/
-int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen, const uint8_t *pk) {
+int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk) {
     size_t i;
 
     if (smlen < PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES) {
@@ -393,7 +397,7 @@ int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uin
     }
 
     *mlen = smlen - PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES;
-    if (PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(sm, PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES, *mlen, pk)) {
+    if (PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(sm, PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM2_AVX2_CRYPTO_BYTES, *mlen, ctx, ctxlen, pk)) {
         goto badsig;
     } else {
         /* All good, copy msg, return 0 */

--- a/crypto_sign/dilithium2/avx2/sign.h
+++ b/crypto_sign/dilithium2/avx2/sign.h
@@ -12,18 +12,22 @@ int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign(uint8_t *sm, size_t *smlen,
                                         const uint8_t *m, size_t mlen,
+                                        const uint8_t *ctx, size_t ctxlen,
                                         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM2_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium2/clean/api.h
+++ b/crypto_sign/dilithium2/clean/api.h
@@ -1,6 +1,8 @@
 #ifndef PQCLEAN_DILITHIUM2_CLEAN_API_H
 #define PQCLEAN_DILITHIUM2_CLEAN_API_H
 
+#define PQCLEAN_USE_SIGN_CTX
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -13,18 +15,22 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign(uint8_t *sm, size_t *smlen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium2/clean/sign.c
+++ b/crypto_sign/dilithium2/clean/sign.c
@@ -81,7 +81,11 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(uint8_t *sig,
         size_t *siglen,
         const uint8_t *m,
         size_t mlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *sk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int n;
     uint8_t seedbuf[2 * SEEDBYTES + TRBYTES + RNDBYTES + 2 * CRHBYTES];
     uint8_t *rho, *tr, *key, *mu, *rhoprime, *rnd;
@@ -202,13 +206,15 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign(uint8_t *sm,
         size_t *smlen,
         const uint8_t *m,
         size_t mlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *sk) {
     size_t i;
 
     for (i = 0; i < mlen; ++i) {
         sm[PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
     }
-    PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES, mlen, sk);
+    PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
     *smlen += mlen;
     return 0;
 }
@@ -230,7 +236,11 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(const uint8_t *sig,
         size_t siglen,
         const uint8_t *m,
         size_t mlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *pk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i;
     uint8_t buf[K * POLYW1_PACKEDBYTES];
     uint8_t rho[SEEDBYTES];
@@ -317,6 +327,8 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_open(uint8_t *m,
         size_t *mlen,
         const uint8_t *sm,
         size_t smlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *pk) {
     size_t i;
 
@@ -325,7 +337,7 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_open(uint8_t *m,
     }
 
     *mlen = smlen - PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES;
-    if (PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(sm, PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES, *mlen, pk)) {
+    if (PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(sm, PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM2_CLEAN_CRYPTO_BYTES, *mlen, ctx, ctxlen, pk)) {
         goto badsig;
     } else {
         /* All good, copy msg, return 0 */

--- a/crypto_sign/dilithium2/clean/sign.h
+++ b/crypto_sign/dilithium2/clean/sign.h
@@ -12,18 +12,22 @@ int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign(uint8_t *sm, size_t *smlen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM2_CLEAN_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium3/aarch64/api.h
+++ b/crypto_sign/dilithium3/aarch64/api.h
@@ -25,7 +25,7 @@ int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(
     const uint8_t *sig, size_t siglen,
-    const uint8_t *m, size_t mlen, 
+    const uint8_t *m, size_t mlen,
     const uint8_t *ctx, size_t ctxlen,
     const uint8_t *pk);
 
@@ -37,7 +37,7 @@ int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign(
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_open(
     uint8_t *m, size_t *mlen,
-    const uint8_t *sm, size_t smlen, 
+    const uint8_t *sm, size_t smlen,
     const uint8_t *ctx, size_t ctxlen,
     const uint8_t *pk);
 

--- a/crypto_sign/dilithium3/aarch64/api.h
+++ b/crypto_sign/dilithium3/aarch64/api.h
@@ -21,7 +21,9 @@ int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
-    const uint8_t *m, size_t mlen, const uint8_t *sk);
+    const uint8_t *m, size_t mlen,
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(
     const uint8_t *sig, size_t siglen,

--- a/crypto_sign/dilithium3/aarch64/api.h
+++ b/crypto_sign/dilithium3/aarch64/api.h
@@ -7,6 +7,8 @@
  * or public domain at https://github.com/pq-crystals/dilithium
  */
 
+#define PQCLEAN_USE_SIGN_CTX
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -23,14 +25,20 @@ int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(
     const uint8_t *sig, size_t siglen,
-    const uint8_t *m, size_t mlen, const uint8_t *pk);
+    const uint8_t *m, size_t mlen, 
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign(
     uint8_t *sm, size_t *smlen,
-    const uint8_t *m, size_t mlen, const uint8_t *sk);
+    const uint8_t *m, size_t mlen,
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_open(
     uint8_t *m, size_t *mlen,
-    const uint8_t *sm, size_t smlen, const uint8_t *pk);
+    const uint8_t *sm, size_t smlen, 
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium3/aarch64/sign.c
+++ b/crypto_sign/dilithium3/aarch64/sign.c
@@ -114,7 +114,11 @@ int crypto_sign_signature(uint8_t *sig,
                           size_t *siglen,
                           const uint8_t *m,
                           size_t mlen,
+                          const uint8_t *ctx,
+                          size_t ctxlen,
                           const uint8_t *sk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int n;
     uint8_t seedbuf[2 * SEEDBYTES + TRBYTES + RNDBYTES + 2 * CRHBYTES];
     uint8_t *rho, *tr, *key, *mu, *rhoprime, *rnd;
@@ -235,13 +239,15 @@ int crypto_sign(uint8_t *sm,
                 size_t *smlen,
                 const uint8_t *m,
                 size_t mlen,
+                const uint8_t *ctx,
+                size_t ctxlen,
                 const uint8_t *sk) {
     size_t i;
 
     for (i = 0; i < mlen; ++i) {
         sm[PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
     }
-    crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_BYTES, mlen, sk);
+    crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
     *smlen += mlen;
     return 0;
 }
@@ -263,7 +269,11 @@ int crypto_sign_verify(const uint8_t *sig,
                        size_t siglen,
                        const uint8_t *m,
                        size_t mlen,
+                       const uint8_t *ctx,
+                       size_t ctxlen,
                        const uint8_t *pk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i;
     uint8_t buf[K * POLYW1_PACKEDBYTES];
     uint8_t rho[SEEDBYTES];
@@ -351,6 +361,8 @@ int crypto_sign_open(uint8_t *m,
                      size_t *mlen,
                      const uint8_t *sm,
                      size_t smlen,
+                     const uint8_t *ctx,
+                     size_t ctxlen, 
                      const uint8_t *pk) {
     size_t i;
 
@@ -359,7 +371,7 @@ int crypto_sign_open(uint8_t *m,
     }
 
     *mlen = smlen - PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_BYTES;
-    if (crypto_sign_verify(sm, PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_BYTES, *mlen, pk)) {
+    if (crypto_sign_verify(sm, PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM3_AARCH64_CRYPTO_BYTES, *mlen, ctx, ctxlen, pk)) {
         goto badsig;
     } else {
         /* All good, copy msg, return 0 */

--- a/crypto_sign/dilithium3/aarch64/sign.c
+++ b/crypto_sign/dilithium3/aarch64/sign.c
@@ -362,7 +362,7 @@ int crypto_sign_open(uint8_t *m,
                      const uint8_t *sm,
                      size_t smlen,
                      const uint8_t *ctx,
-                     size_t ctxlen, 
+                     size_t ctxlen,
                      const uint8_t *pk) {
     size_t i;
 

--- a/crypto_sign/dilithium3/aarch64/sign.h
+++ b/crypto_sign/dilithium3/aarch64/sign.h
@@ -22,21 +22,25 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,
+                          const uint8_t *ctx, size_t ctxlen,
                           const uint8_t *sk);
 
 #define crypto_sign DILITHIUM_NAMESPACE(crypto_sign)
 int crypto_sign(uint8_t *sm, size_t *smlen,
                 const uint8_t *m, size_t mlen,
+                const uint8_t *ctx, size_t ctxlen,
                 const uint8_t *sk);
 
 #define crypto_sign_verify DILITHIUM_NAMESPACE(crypto_sign_verify)
 int crypto_sign_verify(const uint8_t *sig, size_t siglen,
                        const uint8_t *m, size_t mlen,
+                       const uint8_t *ctx, size_t ctxlen,
                        const uint8_t *pk);
 
 #define crypto_sign_open DILITHIUM_NAMESPACE(crypto_sign_open)
 int crypto_sign_open(uint8_t *m, size_t *mlen,
                      const uint8_t *sm, size_t smlen,
+                     const uint8_t *ctx, size_t ctxlen,
                      const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium3/avx2/api.h
+++ b/crypto_sign/dilithium3/avx2/api.h
@@ -1,6 +1,8 @@
 #ifndef PQCLEAN_DILITHIUM3_AVX2_API_H
 #define PQCLEAN_DILITHIUM3_AVX2_API_H
 
+#define PQCLEAN_USE_SIGN_CTX
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -13,18 +15,22 @@ int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign(uint8_t *sm, size_t *smlen,
                                         const uint8_t *m, size_t mlen,
+                                        const uint8_t *ctx, size_t ctxlen,
                                         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium3/avx2/sign.c
+++ b/crypto_sign/dilithium3/avx2/sign.c
@@ -125,7 +125,9 @@ int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk) {
+int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen,const uint8_t *ctx, size_t ctxlen, const uint8_t *sk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i, n, pos;
     uint8_t seedbuf[2 * SEEDBYTES + TRBYTES + RNDBYTES + 2 * CRHBYTES];
     uint8_t *rho, *tr, *key, *rnd, *mu, *rhoprime;
@@ -263,13 +265,13 @@ rej:
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_DILITHIUM3_AVX2_crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen, const uint8_t *sk) {
+int PQCLEAN_DILITHIUM3_AVX2_crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk) {
     size_t i;
 
     for (i = 0; i < mlen; ++i) {
         sm[PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
     }
-    PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES, mlen, sk);
+    PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
     *smlen += mlen;
     return 0;
 }
@@ -287,7 +289,9 @@ int PQCLEAN_DILITHIUM3_AVX2_crypto_sign(uint8_t *sm, size_t *smlen, const uint8_
 *
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
-int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk) {
+int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i, j, pos = 0;
     /* PQCLEAN_DILITHIUM3_AVX2_polyw1_pack writes additional 14 bytes */
     ALIGNED_UINT8(K * POLYW1_PACKEDBYTES + 14) buf;
@@ -395,7 +399,7 @@ int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen
 *
 * Returns 0 if signed message could be verified correctly and -1 otherwise
 **************************************************/
-int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen, const uint8_t *pk) {
+int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk) {
     size_t i;
 
     if (smlen < PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES) {
@@ -403,7 +407,7 @@ int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uin
     }
 
     *mlen = smlen - PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES;
-    if (PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(sm, PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES, *mlen, pk)) {
+    if (PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(sm, PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM3_AVX2_CRYPTO_BYTES, *mlen, ctx, ctxlen, pk)) {
         goto badsig;
     } else {
         /* All good, copy msg, return 0 */

--- a/crypto_sign/dilithium3/avx2/sign.c
+++ b/crypto_sign/dilithium3/avx2/sign.c
@@ -125,7 +125,7 @@ int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen,const uint8_t *ctx, size_t ctxlen, const uint8_t *sk) {
+int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk) {
     (void) ctx;
     (void) ctxlen;
     unsigned int i, n, pos;

--- a/crypto_sign/dilithium3/avx2/sign.h
+++ b/crypto_sign/dilithium3/avx2/sign.h
@@ -12,18 +12,22 @@ int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign(uint8_t *sm, size_t *smlen,
                                         const uint8_t *m, size_t mlen,
+                                        const uint8_t *ctx, size_t ctxlen,
                                         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM3_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium3/clean/api.h
+++ b/crypto_sign/dilithium3/clean/api.h
@@ -1,6 +1,8 @@
 #ifndef PQCLEAN_DILITHIUM3_CLEAN_API_H
 #define PQCLEAN_DILITHIUM3_CLEAN_API_H
 
+#define PQCLEAN_USE_SIGN_CTX
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -13,18 +15,22 @@ int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign(uint8_t *sm, size_t *smlen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium3/clean/sign.c
+++ b/crypto_sign/dilithium3/clean/sign.c
@@ -81,7 +81,11 @@ int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(uint8_t *sig,
         size_t *siglen,
         const uint8_t *m,
         size_t mlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *sk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int n;
     uint8_t seedbuf[2 * SEEDBYTES + TRBYTES + RNDBYTES + 2 * CRHBYTES];
     uint8_t *rho, *tr, *key, *mu, *rhoprime, *rnd;
@@ -202,13 +206,15 @@ int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign(uint8_t *sm,
         size_t *smlen,
         const uint8_t *m,
         size_t mlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *sk) {
     size_t i;
 
     for (i = 0; i < mlen; ++i) {
         sm[PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
     }
-    PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES, mlen, sk);
+    PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
     *smlen += mlen;
     return 0;
 }
@@ -230,7 +236,11 @@ int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(const uint8_t *sig,
         size_t siglen,
         const uint8_t *m,
         size_t mlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *pk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i;
     uint8_t buf[K * POLYW1_PACKEDBYTES];
     uint8_t rho[SEEDBYTES];
@@ -317,6 +327,8 @@ int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_open(uint8_t *m,
         size_t *mlen,
         const uint8_t *sm,
         size_t smlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *pk) {
     size_t i;
 
@@ -325,7 +337,7 @@ int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_open(uint8_t *m,
     }
 
     *mlen = smlen - PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES;
-    if (PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(sm, PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES, *mlen, pk)) {
+    if (PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(sm, PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM3_CLEAN_CRYPTO_BYTES, *mlen, ctx, ctxlen, pk)) {
         goto badsig;
     } else {
         /* All good, copy msg, return 0 */

--- a/crypto_sign/dilithium3/clean/sign.h
+++ b/crypto_sign/dilithium3/clean/sign.h
@@ -12,18 +12,22 @@ int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign(uint8_t *sm, size_t *smlen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM3_CLEAN_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium5/aarch64/api.h
+++ b/crypto_sign/dilithium5/aarch64/api.h
@@ -21,7 +21,7 @@ int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
-    const uint8_t *m, size_t mlen, 
+    const uint8_t *m, size_t mlen,
     const uint8_t *ctx, size_t ctxlen,
     const uint8_t *sk);
 

--- a/crypto_sign/dilithium5/aarch64/api.h
+++ b/crypto_sign/dilithium5/aarch64/api.h
@@ -1,6 +1,8 @@
 #ifndef PQCLEAN_DILITHIUM5_AARCH64_API_H
 #define PQCLEAN_DILITHIUM5_AARCH64_API_H
 
+#define PQCLEAN_USE_SIGN_CTX
+
 /*
  * This file is dual licensed
  * under Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0.html)
@@ -19,18 +21,26 @@ int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
-    const uint8_t *m, size_t mlen, const uint8_t *sk);
+    const uint8_t *m, size_t mlen, 
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_verify(
     const uint8_t *sig, size_t siglen,
-    const uint8_t *m, size_t mlen, const uint8_t *pk);
+    const uint8_t *m, size_t mlen,
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign(
     uint8_t *sm, size_t *smlen,
-    const uint8_t *m, size_t mlen, const uint8_t *sk);
+    const uint8_t *m, size_t mlen,
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_open(
     uint8_t *m, size_t *mlen,
-    const uint8_t *sm, size_t smlen, const uint8_t *pk);
+    const uint8_t *sm, size_t smlen,
+    const uint8_t *ctx, size_t ctxlen,
+    const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium5/aarch64/sign.c
+++ b/crypto_sign/dilithium5/aarch64/sign.c
@@ -114,7 +114,11 @@ int crypto_sign_signature(uint8_t *sig,
                           size_t *siglen,
                           const uint8_t *m,
                           size_t mlen,
+                          const uint8_t *ctx,
+                          size_t ctxlen,
                           const uint8_t *sk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int n;
     uint8_t seedbuf[2 * SEEDBYTES + TRBYTES + RNDBYTES + 2 * CRHBYTES];
     uint8_t *rho, *tr, *key, *mu, *rhoprime, *rnd;
@@ -235,13 +239,15 @@ int crypto_sign(uint8_t *sm,
                 size_t *smlen,
                 const uint8_t *m,
                 size_t mlen,
+                const uint8_t *ctx,
+                size_t ctxlen,
                 const uint8_t *sk) {
     size_t i;
 
     for (i = 0; i < mlen; ++i) {
         sm[PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
     }
-    crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_BYTES, mlen, sk);
+    crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
     *smlen += mlen;
     return 0;
 }
@@ -263,7 +269,11 @@ int crypto_sign_verify(const uint8_t *sig,
                        size_t siglen,
                        const uint8_t *m,
                        size_t mlen,
+                       const uint8_t *ctx,
+                       size_t ctxlen,
                        const uint8_t *pk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i;
     uint8_t buf[K * POLYW1_PACKEDBYTES];
     uint8_t rho[SEEDBYTES];
@@ -351,6 +361,8 @@ int crypto_sign_open(uint8_t *m,
                      size_t *mlen,
                      const uint8_t *sm,
                      size_t smlen,
+                     const uint8_t *ctx,
+                     size_t ctxlen,
                      const uint8_t *pk) {
     size_t i;
 
@@ -359,7 +371,7 @@ int crypto_sign_open(uint8_t *m,
     }
 
     *mlen = smlen - PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_BYTES;
-    if (crypto_sign_verify(sm, PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_BYTES, *mlen, pk)) {
+    if (crypto_sign_verify(sm, PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM5_AARCH64_CRYPTO_BYTES, *mlen, ctx, ctxlen, pk)) {
         goto badsig;
     } else {
         /* All good, copy msg, return 0 */

--- a/crypto_sign/dilithium5/aarch64/sign.h
+++ b/crypto_sign/dilithium5/aarch64/sign.h
@@ -22,21 +22,25 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,
+                          const uint8_t *ctx, size_t ctxlen,
                           const uint8_t *sk);
 
 #define crypto_sign DILITHIUM_NAMESPACE(crypto_sign)
 int crypto_sign(uint8_t *sm, size_t *smlen,
                 const uint8_t *m, size_t mlen,
+                const uint8_t *ctx, size_t ctxlen,
                 const uint8_t *sk);
 
 #define crypto_sign_verify DILITHIUM_NAMESPACE(crypto_sign_verify)
 int crypto_sign_verify(const uint8_t *sig, size_t siglen,
                        const uint8_t *m, size_t mlen,
+                       const uint8_t *ctx, size_t ctxlen,
                        const uint8_t *pk);
 
 #define crypto_sign_open DILITHIUM_NAMESPACE(crypto_sign_open)
 int crypto_sign_open(uint8_t *m, size_t *mlen,
                      const uint8_t *sm, size_t smlen,
+                     const uint8_t *ctx, size_t ctxlen,
                      const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium5/avx2/api.h
+++ b/crypto_sign/dilithium5/avx2/api.h
@@ -1,6 +1,8 @@
 #ifndef PQCLEAN_DILITHIUM5_AVX2_API_H
 #define PQCLEAN_DILITHIUM5_AVX2_API_H
 
+#define PQCLEAN_USE_SIGN_CTX
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -13,18 +15,22 @@ int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign(uint8_t *sm, size_t *smlen,
                                         const uint8_t *m, size_t mlen,
+                                        const uint8_t *ctx, size_t ctxlen,
                                         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium5/avx2/sign.c
+++ b/crypto_sign/dilithium5/avx2/sign.c
@@ -134,7 +134,9 @@ int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk) {
+int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i, n, pos;
     uint8_t seedbuf[2 * SEEDBYTES + TRBYTES + RNDBYTES + 2 * CRHBYTES];
     uint8_t *rho, *tr, *key, *rnd, *mu, *rhoprime;
@@ -273,13 +275,13 @@ rej:
 *
 * Returns 0 (success)
 **************************************************/
-int PQCLEAN_DILITHIUM5_AVX2_crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen, const uint8_t *sk) {
+int PQCLEAN_DILITHIUM5_AVX2_crypto_sign(uint8_t *sm, size_t *smlen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk) {
     size_t i;
 
     for (i = 0; i < mlen; ++i) {
         sm[PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
     }
-    PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES, mlen, sk);
+    PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
     *smlen += mlen;
     return 0;
 }
@@ -297,7 +299,9 @@ int PQCLEAN_DILITHIUM5_AVX2_crypto_sign(uint8_t *sm, size_t *smlen, const uint8_
 *
 * Returns 0 if signature could be verified correctly and -1 otherwise
 **************************************************/
-int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk) {
+int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i, j, pos = 0;
     /* PQCLEAN_DILITHIUM5_AVX2_polyw1_pack writes additional 14 bytes */
     ALIGNED_UINT8(K * POLYW1_PACKEDBYTES + 14) buf;
@@ -405,7 +409,7 @@ int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen
 *
 * Returns 0 if signed message could be verified correctly and -1 otherwise
 **************************************************/
-int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen, const uint8_t *pk) {
+int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen, const uint8_t *ctx, size_t ctxlen,const uint8_t *pk) {
     size_t i;
 
     if (smlen < PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES) {
@@ -413,7 +417,7 @@ int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uin
     }
 
     *mlen = smlen - PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES;
-    if (PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(sm, PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES, *mlen, pk)) {
+    if (PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(sm, PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES, *mlen, ctx, ctxlen, pk)) {
         goto badsig;
     } else {
         /* All good, copy msg, return 0 */

--- a/crypto_sign/dilithium5/avx2/sign.c
+++ b/crypto_sign/dilithium5/avx2/sign.c
@@ -409,7 +409,7 @@ int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen
 *
 * Returns 0 if signed message could be verified correctly and -1 otherwise
 **************************************************/
-int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen, const uint8_t *ctx, size_t ctxlen,const uint8_t *pk) {
+int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen, const uint8_t *sm, size_t smlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk) {
     size_t i;
 
     if (smlen < PQCLEAN_DILITHIUM5_AVX2_CRYPTO_BYTES) {

--- a/crypto_sign/dilithium5/avx2/sign.h
+++ b/crypto_sign/dilithium5/avx2/sign.h
@@ -12,18 +12,22 @@ int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign(uint8_t *sm, size_t *smlen,
                                         const uint8_t *m, size_t mlen,
+                                        const uint8_t *ctx, size_t ctxlen,
                                         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM5_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium5/clean/api.h
+++ b/crypto_sign/dilithium5/clean/api.h
@@ -1,6 +1,8 @@
 #ifndef PQCLEAN_DILITHIUM5_CLEAN_API_H
 #define PQCLEAN_DILITHIUM5_CLEAN_API_H
 
+#define PQCLEAN_USE_SIGN_CTX
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -13,18 +15,22 @@ int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign(uint8_t *sm, size_t *smlen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/crypto_sign/dilithium5/clean/sign.c
+++ b/crypto_sign/dilithium5/clean/sign.c
@@ -81,7 +81,11 @@ int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(uint8_t *sig,
         size_t *siglen,
         const uint8_t *m,
         size_t mlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *sk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int n;
     uint8_t seedbuf[2 * SEEDBYTES + TRBYTES + RNDBYTES + 2 * CRHBYTES];
     uint8_t *rho, *tr, *key, *mu, *rhoprime, *rnd;
@@ -202,13 +206,15 @@ int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign(uint8_t *sm,
         size_t *smlen,
         const uint8_t *m,
         size_t mlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *sk) {
     size_t i;
 
     for (i = 0; i < mlen; ++i) {
         sm[PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
     }
-    PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES, mlen, sk);
+    PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(sm, smlen, sm + PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES, mlen, ctx, ctxlen, sk);
     *smlen += mlen;
     return 0;
 }
@@ -230,7 +236,11 @@ int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(const uint8_t *sig,
         size_t siglen,
         const uint8_t *m,
         size_t mlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *pk) {
+    (void) ctx;
+    (void) ctxlen;
     unsigned int i;
     uint8_t buf[K * POLYW1_PACKEDBYTES];
     uint8_t rho[SEEDBYTES];
@@ -317,6 +327,8 @@ int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_open(uint8_t *m,
         size_t *mlen,
         const uint8_t *sm,
         size_t smlen,
+        const uint8_t *ctx,
+        size_t ctxlen,
         const uint8_t *pk) {
     size_t i;
 
@@ -325,7 +337,7 @@ int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_open(uint8_t *m,
     }
 
     *mlen = smlen - PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES;
-    if (PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(sm, PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES, *mlen, pk)) {
+    if (PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(sm, PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES, sm + PQCLEAN_DILITHIUM5_CLEAN_CRYPTO_BYTES, *mlen, ctx, ctxlen, pk)) {
         goto badsig;
     } else {
         /* All good, copy msg, return 0 */

--- a/crypto_sign/dilithium5/clean/sign.h
+++ b/crypto_sign/dilithium5/clean/sign.h
@@ -12,18 +12,22 @@ int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign(uint8_t *sm, size_t *smlen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen,
         const uint8_t *m, size_t mlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 int PQCLEAN_DILITHIUM5_CLEAN_crypto_sign_open(uint8_t *m, size_t *mlen,
         const uint8_t *sm, size_t smlen,
+        const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
 #endif

--- a/test/crypto_sign/functest.c
+++ b/test/crypto_sign/functest.c
@@ -160,7 +160,7 @@ static int test_sign(void) {
     #ifdef PQCLEAN_USE_SIGN_CTX
     uint8_t *ctx_aligned = malloc_s(PQCLEAN_CTXLEN + 16 + 1);
     uint8_t *ctx  = (uint8_t *) ((uintptr_t) ctx_aligned | (uintptr_t) 1);
-    memset(ctx, 0, PQCLEAN_CTXLEN);
+    memset(ctx + 8, 0, PQCLEAN_CTXLEN);
     write_canary(ctx);
     write_canary(ctx + PQCLEAN_CTXLEN + 8);
     #endif
@@ -296,7 +296,7 @@ static int test_sign_detached(void) {
     #ifdef PQCLEAN_USE_SIGN_CTX
     uint8_t *ctx_aligned = malloc_s(PQCLEAN_CTXLEN + 16 + 1);
     uint8_t *ctx  = (uint8_t *) ((uintptr_t) ctx_aligned | (uintptr_t) 1);
-    memset(ctx, 0, PQCLEAN_CTXLEN);
+    memset(ctx + 8, 0, PQCLEAN_CTXLEN);
     write_canary(ctx);
     write_canary(ctx + PQCLEAN_CTXLEN + 8);
     #endif

--- a/test/crypto_sign/nistkat.c
+++ b/test/crypto_sign/nistkat.c
@@ -74,7 +74,11 @@ int main(void) {
     fprintBstr(fh, "pk = ", public_key, CRYPTO_PUBLICKEYBYTES);
     fprintBstr(fh, "sk = ", secret_key, CRYPTO_SECRETKEYBYTES);
 
+    #ifdef PQCLEAN_USE_SIGN_CTX
+    rc = crypto_sign(sm, &smlen, m, mlen, NULL, 0, secret_key);
+    #else
     rc = crypto_sign(sm, &smlen, m, mlen, secret_key);
+    #endif
     if (rc != 0) {
         fprintf(stderr, "[kat_kem] %s ERROR: crypto_sign failed!\n", CRYPTO_ALGNAME);
         return -2;
@@ -82,7 +86,11 @@ int main(void) {
     fprintf(fh, "smlen = %zu\n", smlen);
     fprintBstr(fh, "sm = ", sm, smlen);
 
+    #ifdef PQCLEAN_USE_SIGN_CTX
+    rc = crypto_sign_open(sm, &mlen1, sm, smlen, NULL, 0, public_key);
+    #else
     rc = crypto_sign_open(sm, &mlen1, sm, smlen, public_key);
+    #endif
     if (rc != 0) {
         fprintf(stderr, "[kat_kem] %s ERROR: crypto_sign_open failed!\n", CRYPTO_ALGNAME);
         return -3;

--- a/test/crypto_sign/testvectors.c
+++ b/test/crypto_sign/testvectors.c
@@ -55,16 +55,26 @@ int main(void) {
         printbytes(pk, CRYPTO_PUBLICKEYBYTES);
         printbytes(sk, CRYPTO_SECRETKEYBYTES);
 
+        #ifdef PQCLEAN_USE_SIGN_CTX
+        crypto_sign(sm, &smlen, mi, i, NULL, 0, sk);
+        crypto_sign_signature(sig, &siglen, mi, i, NULL, 0, sk);
+        #else
         crypto_sign(sm, &smlen, mi, i, sk);
         crypto_sign_signature(sig, &siglen, mi, i, sk);
+        #endif
 
         printbytes(sm, smlen);
         printbytes(sig, siglen);
 
         // By relying on m == sm we prevent having to allocate CRYPTO_BYTES
         // twice
+        #ifdef PQCLEAN_USE_SIGN_CTX
+        r = crypto_sign_open(sm, &mlen, sm, smlen, NULL, 0, pk);
+        r |= crypto_sign_verify(sig, siglen, mi, i, NULL, 0, pk);
+        #else
         r = crypto_sign_open(sm, &mlen, sm, smlen, pk);
         r |= crypto_sign_verify(sig, siglen, mi, i, pk);
+        #endif
 
         if (r) {
             printf("ERROR: signature verification failed\n");


### PR DESCRIPTION
I'm currently trying to add ML-DSA (Dilithium, FIPS204) to PQClean. This is the first preparatory PR.

As NIST has changed the signature APIs for the final [FIPS204](https://csrc.nist.gov/pubs/fips/204/final) and [FIPS205](https://csrc.nist.gov/pubs/fips/205/final), we additionally need to support the new APIs. Implementations may use the new APIs by defining `#define PQCLEAN_USE_SIGN_CTX` in `api.h`. 


The updated APIs following https://github.com/pq-crystals/dilithium are:

```c
int PQCLEAN_SCHEME_IMPL_crypto_sign_signature(uint8_t *sig, size_t *siglen,
        const uint8_t *m, size_t mlen,
        const uint8_t *ctx, size_t ctxlen,
        const uint8_t *sk);

int PQCLEAN_SCHEME_IMPL_crypto_sign(uint8_t *sm, size_t *smlen,
        const uint8_t *m, size_t mlen,
        const uint8_t *ctx, size_t ctxlen,
        const uint8_t *sk);

int PQCLEAN_SCHEME_IMPL_crypto_sign_verify(const uint8_t *sig, size_t siglen,
        const uint8_t *m, size_t mlen,
        const uint8_t *ctx, size_t ctxlen,
        const uint8_t *pk);

int PQCLEAN_SCHEME_IMPL_crypto_sign_open(uint8_t *m, size_t *mlen,
        const uint8_t *sm, size_t smlen,
        const uint8_t *ctx, size_t ctxlen,
        const uint8_t *pk);
```


I've switched Diltihium to the new API, but have not updated it to the new version yet.