### PR TITLE
Add SPDX headers and copyright notices at the beginning of files.

### DIFF
--- a/crypto_sign/falcon-1024/aarch64/Makefile
+++ b/crypto_sign/falcon-1024/aarch64/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-1024_aarch64.a

--- a/crypto_sign/falcon-1024/aarch64/api.h
+++ b/crypto_sign/falcon-1024/aarch64/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCON1024_AARCH64_API_H
 #define PQCLEAN_FALCON1024_AARCH64_API_H
 

--- a/crypto_sign/falcon-1024/aarch64/ntt_consts.c
+++ b/crypto_sign/falcon-1024/aarch64/ntt_consts.c
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #include "ntt_consts.h"
 #include "params.h"
 

--- a/crypto_sign/falcon-1024/aarch64/ntt_consts.h
+++ b/crypto_sign/falcon-1024/aarch64/ntt_consts.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef NTT_CONSTS
 #define NTT_CONSTS
 

--- a/crypto_sign/falcon-1024/aarch64/params.h
+++ b/crypto_sign/falcon-1024/aarch64/params.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef PARAMS_H
 #define PARAMS_H
 

--- a/crypto_sign/falcon-1024/aarch64/poly.h
+++ b/crypto_sign/falcon-1024/aarch64/poly.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef POLY_H
 #define POLY_H
 

--- a/crypto_sign/falcon-1024/aarch64/pqclean.c
+++ b/crypto_sign/falcon-1024/aarch64/pqclean.c
@@ -1,4 +1,9 @@
 /*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ * Copyright: Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-1024/aarch64/util.h
+++ b/crypto_sign/falcon-1024/aarch64/util.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef UTIL_H
 #define UTIL_H
 

--- a/crypto_sign/falcon-1024/avx2/Makefile
+++ b/crypto_sign/falcon-1024/avx2/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-1024_avx2.a

--- a/crypto_sign/falcon-1024/avx2/api.h
+++ b/crypto_sign/falcon-1024/avx2/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCON1024_AVX2_API_H
 #define PQCLEAN_FALCON1024_AVX2_API_H
 

--- a/crypto_sign/falcon-1024/avx2/pqclean.c
+++ b/crypto_sign/falcon-1024/avx2/pqclean.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifer: MIT
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-1024/clean/Makefile
+++ b/crypto_sign/falcon-1024/clean/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-1024_clean.a

--- a/crypto_sign/falcon-1024/clean/api.h
+++ b/crypto_sign/falcon-1024/clean/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCON1024_CLEAN_API_H
 #define PQCLEAN_FALCON1024_CLEAN_API_H
 

--- a/crypto_sign/falcon-1024/clean/pqclean.c
+++ b/crypto_sign/falcon-1024/clean/pqclean.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifer: MIT
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-512/aarch64/Makefile
+++ b/crypto_sign/falcon-512/aarch64/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-512_aarch64.a

--- a/crypto_sign/falcon-512/aarch64/api.h
+++ b/crypto_sign/falcon-512/aarch64/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCON512_AARCH64_API_H
 #define PQCLEAN_FALCON512_AARCH64_API_H
 

--- a/crypto_sign/falcon-512/aarch64/ntt_consts.c
+++ b/crypto_sign/falcon-512/aarch64/ntt_consts.c
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #include "ntt_consts.h"
 #include "params.h"
 

--- a/crypto_sign/falcon-512/aarch64/ntt_consts.h
+++ b/crypto_sign/falcon-512/aarch64/ntt_consts.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef NTT_CONSTS
 #define NTT_CONSTS
 

--- a/crypto_sign/falcon-512/aarch64/params.h
+++ b/crypto_sign/falcon-512/aarch64/params.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef PARAMS_H
 #define PARAMS_H
 

--- a/crypto_sign/falcon-512/aarch64/poly.h
+++ b/crypto_sign/falcon-512/aarch64/poly.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef POLY_H
 #define POLY_H
 

--- a/crypto_sign/falcon-512/aarch64/pqclean.c
+++ b/crypto_sign/falcon-512/aarch64/pqclean.c
@@ -1,4 +1,9 @@
 /*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ * Copyright: Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-512/aarch64/util.h
+++ b/crypto_sign/falcon-512/aarch64/util.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef UTIL_H
 #define UTIL_H
 

--- a/crypto_sign/falcon-512/avx2/Makefile
+++ b/crypto_sign/falcon-512/avx2/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-512_avx2.a

--- a/crypto_sign/falcon-512/avx2/api.h
+++ b/crypto_sign/falcon-512/avx2/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCON512_AVX2_API_H
 #define PQCLEAN_FALCON512_AVX2_API_H
 

--- a/crypto_sign/falcon-512/avx2/pqclean.c
+++ b/crypto_sign/falcon-512/avx2/pqclean.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifer: MIT
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-512/clean/Makefile
+++ b/crypto_sign/falcon-512/clean/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-512_clean.a

--- a/crypto_sign/falcon-512/clean/api.h
+++ b/crypto_sign/falcon-512/clean/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCON512_CLEAN_API_H
 #define PQCLEAN_FALCON512_CLEAN_API_H
 

--- a/crypto_sign/falcon-512/clean/pqclean.c
+++ b/crypto_sign/falcon-512/clean/pqclean.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifer: MIT
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-padded-1024/aarch64/Makefile
+++ b/crypto_sign/falcon-padded-1024/aarch64/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-padded-1024_aarch64.a

--- a/crypto_sign/falcon-padded-1024/aarch64/api.h
+++ b/crypto_sign/falcon-padded-1024/aarch64/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCONPADDED1024_AARCH64_API_H
 #define PQCLEAN_FALCONPADDED1024_AARCH64_API_H
 

--- a/crypto_sign/falcon-padded-1024/aarch64/ntt_consts.c
+++ b/crypto_sign/falcon-padded-1024/aarch64/ntt_consts.c
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #include "ntt_consts.h"
 #include "params.h"
 

--- a/crypto_sign/falcon-padded-1024/aarch64/ntt_consts.h
+++ b/crypto_sign/falcon-padded-1024/aarch64/ntt_consts.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef NTT_CONSTS
 #define NTT_CONSTS
 

--- a/crypto_sign/falcon-padded-1024/aarch64/params.h
+++ b/crypto_sign/falcon-padded-1024/aarch64/params.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef PARAMS_H
 #define PARAMS_H
 

--- a/crypto_sign/falcon-padded-1024/aarch64/poly.h
+++ b/crypto_sign/falcon-padded-1024/aarch64/poly.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef POLY_H
 #define POLY_H
 

--- a/crypto_sign/falcon-padded-1024/aarch64/pqclean.c
+++ b/crypto_sign/falcon-padded-1024/aarch64/pqclean.c
@@ -1,4 +1,9 @@
 /*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ * Copyright: Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-padded-1024/aarch64/util.h
+++ b/crypto_sign/falcon-padded-1024/aarch64/util.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef UTIL_H
 #define UTIL_H
 

--- a/crypto_sign/falcon-padded-1024/avx2/Makefile
+++ b/crypto_sign/falcon-padded-1024/avx2/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-padded-1024_avx2.a

--- a/crypto_sign/falcon-padded-1024/avx2/api.h
+++ b/crypto_sign/falcon-padded-1024/avx2/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCONPADDED1024_AVX2_API_H
 #define PQCLEAN_FALCONPADDED1024_AVX2_API_H
 

--- a/crypto_sign/falcon-padded-1024/avx2/pqclean.c
+++ b/crypto_sign/falcon-padded-1024/avx2/pqclean.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifer: MIT
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-padded-1024/clean/Makefile
+++ b/crypto_sign/falcon-padded-1024/clean/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-padded-1024_clean.a

--- a/crypto_sign/falcon-padded-1024/clean/api.h
+++ b/crypto_sign/falcon-padded-1024/clean/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCONPADDED1024_CLEAN_API_H
 #define PQCLEAN_FALCONPADDED1024_CLEAN_API_H
 

--- a/crypto_sign/falcon-padded-1024/clean/pqclean.c
+++ b/crypto_sign/falcon-padded-1024/clean/pqclean.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifer: MIT
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-padded-512/aarch64/Makefile
+++ b/crypto_sign/falcon-padded-512/aarch64/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-padded-512_aarch64.a

--- a/crypto_sign/falcon-padded-512/aarch64/api.h
+++ b/crypto_sign/falcon-padded-512/aarch64/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCONPADDED512_AARCH64_API_H
 #define PQCLEAN_FALCONPADDED512_AARCH64_API_H
 

--- a/crypto_sign/falcon-padded-512/aarch64/ntt_consts.c
+++ b/crypto_sign/falcon-padded-512/aarch64/ntt_consts.c
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #include "ntt_consts.h"
 #include "params.h"
 

--- a/crypto_sign/falcon-padded-512/aarch64/ntt_consts.h
+++ b/crypto_sign/falcon-padded-512/aarch64/ntt_consts.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef NTT_CONSTS
 #define NTT_CONSTS
 

--- a/crypto_sign/falcon-padded-512/aarch64/params.h
+++ b/crypto_sign/falcon-padded-512/aarch64/params.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef PARAMS_H
 #define PARAMS_H
 

--- a/crypto_sign/falcon-padded-512/aarch64/poly.h
+++ b/crypto_sign/falcon-padded-512/aarch64/poly.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef POLY_H
 #define POLY_H
 

--- a/crypto_sign/falcon-padded-512/aarch64/pqclean.c
+++ b/crypto_sign/falcon-padded-512/aarch64/pqclean.c
@@ -1,4 +1,9 @@
 /*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ * Copyright: Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-padded-512/aarch64/util.h
+++ b/crypto_sign/falcon-padded-512/aarch64/util.h
@@ -1,3 +1,33 @@
+/*
+ * SPDX-License-Identifer: Apache-2.0
+ * Copyright (c) 2023 by Cryptographic Engineering Research Group (CERG) ECE Department, George Mason University Fairfax, VA, U.S.A.
+ * Author: Duc Tri Nguyen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author   Duc Tri Nguyen <dnguye69@gmu.edu>, <cothannguyen@gmail.com>
+ *
+ * Copyright Thomas Pornin <thomas.pornin@nccgroup.com>.
+ *
+ * It has been reported that patent US7308097B2 may be applicable to parts
+ * of Falcon. William Whyte, one of the designers of Falcon and also
+ * representative of OnBoard Security (current owner of the said patent),
+ * has pledged, as part of the IP statements submitted to the NIST for the
+ * PQC project, that in the event of Falcon being selected for
+ * standardization, a worldwide non-exclusive license to the patent will be
+ * granted for the purpose of implementing the standard "without
+ * compensation and under reasonable terms and conditions that are
+ * demonstrably free of any unfair discrimination".
+*/
+
 #ifndef UTIL_H
 #define UTIL_H
 

--- a/crypto_sign/falcon-padded-512/avx2/Makefile
+++ b/crypto_sign/falcon-padded-512/avx2/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-padded-512_avx2.a

--- a/crypto_sign/falcon-padded-512/avx2/api.h
+++ b/crypto_sign/falcon-padded-512/avx2/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCONPADDED512_AVX2_API_H
 #define PQCLEAN_FALCONPADDED512_AVX2_API_H
 

--- a/crypto_sign/falcon-padded-512/avx2/pqclean.c
+++ b/crypto_sign/falcon-padded-512/avx2/pqclean.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifer: MIT
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
  * Wrapper for implementing the PQClean API.
  */
 

--- a/crypto_sign/falcon-padded-512/clean/Makefile
+++ b/crypto_sign/falcon-padded-512/clean/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright: Falcon Project
+# Copyright: PQClean Project
+
 # This Makefile can be used with GNU Make or BSD Make
 
 LIB=libfalcon-padded-512_clean.a

--- a/crypto_sign/falcon-padded-512/clean/api.h
+++ b/crypto_sign/falcon-padded-512/clean/api.h
@@ -1,3 +1,16 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright: National Institute of Standards and Technology; The software developed by NIST employees is not subject to copyright protection within the United States.
+ * Copyright: 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
+ * NIST-developed software is provided by NIST as a public service. You may use, copy, and distribute copies of the software in any medium, provided that you keep intact this entire notice. You may improve, modify, and create derivative works of the software or any portion of the software, and you may copy and distribute such modifications or works. Modified works should carry a notice stating that you changed the software and should note the date and nature of any such change. Please explicitly acknowledge the National Institute of Standards and Technology as the source of the software.
+ *
+ * NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+ *
+ * You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
+*/
+
 #ifndef PQCLEAN_FALCONPADDED512_CLEAN_API_H
 #define PQCLEAN_FALCONPADDED512_CLEAN_API_H
 

--- a/crypto_sign/falcon-padded-512/clean/pqclean.c
+++ b/crypto_sign/falcon-padded-512/clean/pqclean.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifer: MIT
+ * Copyright: Copyright (c) 2017-2019  Falcon Project
+ * Copyright: PQClean Project
+ *
  * Wrapper for implementing the PQClean API.
  */
 


### PR DESCRIPTION
In downstream projects, files may be copied and moved around. This makes it difficult to track the copyrights and licenses without having them stored in each file.

I've tried my best to be correct but I had to retrace changes over time, find origins again and make assumptions.

I've limited myself to Falcon for two reasons. First, at the moment, my ultimate goal is Debian packaging for liboqs and it is one of the two relevant algorithms in pqclean for liboqs. Second, it's already quite a lot of changes and things to potentially discuss. Coverage can be improved later on.

BTW, sphincsplus in pqclean is also relevant for liboqs packaging but I've elected to first do changes in sphincs/sphincplus through sphincs/sphincsplus#64 (even if the two repositories have diverged).

FInally, I'm adding mentions of NIST in copyrights for the reasons I menetion in the sphincsplus PR: it's what NIST is now using in https://csrc.nist.gov/Projects/pqc-dig-sig/standardization/example-files and it's more sensible than the previous mention of a single person.