### PR TITLE
Fix type of steps buffer in sphincs merkle.c

### DIFF
--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx8[8 * 8] = { 0 };
     int j;
     struct leaf_info_x8 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx8[8 * 8] = { 0 };
     int j;
     struct leaf_info_x8 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx8[8 * 8] = { 0 };
     int j;
     struct leaf_info_x8 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx8[8 * 8] = { 0 };
     int j;
     struct leaf_info_x8 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx8[8 * 8] = { 0 };
     int j;
     struct leaf_info_x8 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx8[8 * 8] = { 0 };
     int j;
     struct leaf_info_x8 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx2[2 * 8] = { 0 };
     int j;
     struct leaf_info_x2 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx4[4 * 8] = { 0 };
     int j;
     struct leaf_info_x4 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-128f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx2[2 * 8] = { 0 };
     int j;
     struct leaf_info_x2 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx4[4 * 8] = { 0 };
     int j;
     struct leaf_info_x4 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-128s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx2[2 * 8] = { 0 };
     int j;
     struct leaf_info_x2 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx4[4 * 8] = { 0 };
     int j;
     struct leaf_info_x4 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-192f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx2[2 * 8] = { 0 };
     int j;
     struct leaf_info_x2 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx4[4 * 8] = { 0 };
     int j;
     struct leaf_info_x4 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-192s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx2[2 * 8] = { 0 };
     int j;
     struct leaf_info_x2 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx4[4 * 8] = { 0 };
     int j;
     struct leaf_info_x4 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-256f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx2[2 * 8] = { 0 };
     int j;
     struct leaf_info_x2 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/merkle.c
@@ -22,7 +22,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
     uint32_t tree_addrx4[4 * 8] = { 0 };
     int j;
     struct leaf_info_x4 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);

--- a/crypto_sign/sphincs-shake-256s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/merkle.c
@@ -21,7 +21,7 @@ void merkle_sign(uint8_t *sig, unsigned char *root,
                  uint32_t idx_leaf) {
     unsigned char *auth_path = sig + SPX_WOTS_BYTES;
     struct leaf_info_x1 info = { 0 };
-    unsigned steps[ SPX_WOTS_LEN ];
+    uint32_t steps[ SPX_WOTS_LEN ];
 
     info.wots_sig = sig;
     chain_lengths(steps, root);


### PR DESCRIPTION
<!-- This template will help you get your code into PQClean. -->

<!-- Type some lines about your submission -->

The `leaf_info_*` structs specify a `uint32_t` pointer, but the `merkle_sign` methods allocate a `unsigned` buffer. On most platforms this is effectively the same thing (i.e., a 4-byte unsigned integer), but at least on ARMv7 `uint32_t` is defined as `unsigned long`, which is also 4 bytes but the compiler will complain.