### PR TITLE
SPHINCS+ gcc14 errors: unsigned -> uint32_t

### DIFF
--- a/crypto_sign/sphincs-sha2-128f-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-128f-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-128f-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-128f-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/address.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/context.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/context.h
@@ -16,6 +16,7 @@ typedef struct {
     uint8_t sk_seed[SPX_N];
 } spx_ctx;
 
+
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)
 void initialize_hash_function(spx_ctx *ctx);
 

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/context_sha2.c
@@ -1,6 +1,12 @@
 #include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha256avx.h"
+#include "sha2_offsets.h"
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -31,6 +37,7 @@ static void seed_state(spx_ctx *ctx) {
     ctx->statex8_seeded.msglen = 512;
 
 }
+
 
 /* For SHA, we initialize the hash function at the start */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/fors.c
@@ -1,12 +1,13 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
+
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
@@ -71,40 +72,40 @@ static void fors_gen_leafx8(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 8; j++) {
-        set_tree_index(fors_leaf_addrx8 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx8 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx8(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
-                  leaf + 4 * SPX_N,
-                  leaf + 5 * SPX_N,
-                  leaf + 6 * SPX_N,
-                  leaf + 7 * SPX_N,
+    fors_gen_skx8(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
+                  leaf + (4 * SPX_N),
+                  leaf + (5 * SPX_N),
+                  leaf + (6 * SPX_N),
+                  leaf + (7 * SPX_N),
                   ctx, fors_leaf_addrx8);
 
     for (j = 0; j < 8; j++) {
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx8(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
+    fors_sk_to_leafx8(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
                       ctx, fors_leaf_addrx8);
 }
 
@@ -144,9 +145,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -166,7 +167,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx8(roots + i * SPX_N, sig, ctx,
+        treehashx8(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx8,
                    fors_tree_addr, &fors_info);
 
@@ -215,7 +216,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/hash_sha2.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/hash_sha2.c
@@ -1,11 +1,14 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
+#include "sha2_offsets.h"
 #include "utils.h"
+
+
 
 #define SPX_SHAX_OUTPUT_BYTES SPX_SHA256_OUTPUT_BYTES
 #define SPX_SHAX_BLOCK_BYTES SPX_SHA256_BLOCK_BYTES
@@ -40,7 +43,7 @@ void mgf1_256(unsigned char *out, unsigned long outlen,
     if (outlen > i * SPX_SHA256_OUTPUT_BYTES) {
         u32_to_bytes(inbuf + inlen, i);
         sha256(outbuf, inbuf, inlen + 4);
-        memcpy(out, outbuf, outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(out, outbuf, outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }
 
@@ -65,7 +68,7 @@ void mgf1_512(unsigned char *out, unsigned long outlen,
     if (outlen > i * SPX_SHA512_OUTPUT_BYTES) {
         u32_to_bytes(inbuf + inlen, i);
         sha512(outbuf, inbuf, inlen + 4);
-        memcpy(out, outbuf, outlen - i * SPX_SHA512_OUTPUT_BYTES);
+        memcpy(out, outbuf, outlen - (i * SPX_SHA512_OUTPUT_BYTES));
     }
 }
 
@@ -107,6 +110,7 @@ void gen_message_random(unsigned char *R, const unsigned char *sk_prf,
     unsigned char buf[SPX_SHAX_BLOCK_BYTES + SPX_SHAX_OUTPUT_BYTES];
     shaXstate state;
     int i;
+
 
     /* This implements HMAC-SHA */
     for (i = 0; i < SPX_N; i++) {
@@ -160,7 +164,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 #define SPX_LEAF_BYTES ((SPX_LEAF_BITS + 7) / 8)
 #define SPX_DGST_BYTES (SPX_FORS_MSG_BYTES + SPX_TREE_BYTES + SPX_LEAF_BYTES)
 
-    unsigned char seed[2 * SPX_N + SPX_SHAX_OUTPUT_BYTES];
+    unsigned char seed[(2 * SPX_N) + SPX_SHAX_OUTPUT_BYTES];
 
     /* Round to nearest multiple of SPX_SHAX_BLOCK_BYTES */
 #define SPX_INBLOCKS (((SPX_N + SPX_PK_BYTES + SPX_SHAX_BLOCK_BYTES - 1) & \
@@ -180,17 +184,17 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     /* If R + pk + message cannot fill up an entire block */
     if (SPX_N + SPX_PK_BYTES + mlen < SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m, mlen);
-        shaX_inc_finalize(seed + 2 * SPX_N, &state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
+        shaX_inc_finalize(seed + (2 * SPX_N), &state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
     }
     /* Otherwise first fill a block, so that finalize only uses the message */
     else {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m,
-               SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES);
+               (SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) - SPX_N - SPX_PK_BYTES);
         shaX_inc_blocks(&state, inbuf, SPX_INBLOCKS);
 
         m += SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
         mlen -= SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
-        shaX_inc_finalize(seed + 2 * SPX_N, &state, m, (size_t)mlen);
+        shaX_inc_finalize(seed + (2 * SPX_N), &state, m, mlen);
     }
 
     // H_msg: MGF1-SHA-X(R ‖ PK.seed ‖ seed)
@@ -199,10 +203,11 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */
-    mgf1_X(bufp, SPX_DGST_BYTES, seed, 2 * SPX_N + SPX_SHAX_OUTPUT_BYTES);
+    mgf1_X(bufp, SPX_DGST_BYTES, seed, (2 * SPX_N) + SPX_SHAX_OUTPUT_BYTES);
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
@@ -211,3 +216,5 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);
     *leaf_idx &= (~(uint32_t)0) >> (32 - SPX_LEAF_BITS);
 }
+
+

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/hash_sha2x8.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/hash_sha2x8.c
@@ -1,15 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
 
-#include "address.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
-#include "utils.h"
+#include "sha2_offsets.h"
 
 /*
  * 8-way parallel version of prf_addr; takes 8x as much input and output
@@ -29,10 +27,10 @@ void prf_addrx8(unsigned char *out0,
     unsigned int j;
 
     for (j = 0; j < 8; j++) {
-        memcpy(bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES),
-               addrx8 + j * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)),
+               addrx8 + (j * 8), SPX_SHA256_ADDR_BYTES);
         memcpy(
-            bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES) + SPX_SHA256_ADDR_BYTES,
+            bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)) + SPX_SHA256_ADDR_BYTES,
             ctx->sk_seed,
             SPX_N
         );
@@ -40,36 +38,36 @@ void prf_addrx8(unsigned char *out0,
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + SPX_N),
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
         SPX_SHA256_ADDR_BYTES + SPX_N /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx8.h"
 #include "wots.h"
 #include "wotsx8.h"
@@ -52,7 +51,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/params.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/sha256avx.c
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "sha256avx.h"
@@ -99,14 +98,14 @@ void sha256_ctx_clone8x(sha256x8ctx *out, const sha256x8ctx *in) {
 }
 
 void sha256_init8x(sha256x8ctx *ctx) {
-    ctx->s[0] = _mm256_set_epi32((int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667);
+    ctx->s[0] = _mm256_set_epi32(0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667);
     ctx->s[1] = _mm256_set_epi32((int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85);
-    ctx->s[2] = _mm256_set_epi32((int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372);
+    ctx->s[2] = _mm256_set_epi32(0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372);
     ctx->s[3] = _mm256_set_epi32((int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a);
-    ctx->s[4] = _mm256_set_epi32((int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f);
+    ctx->s[4] = _mm256_set_epi32(0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f);
     ctx->s[5] = _mm256_set_epi32((int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c);
-    ctx->s[6] = _mm256_set_epi32((int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab);
-    ctx->s[7] = _mm256_set_epi32((int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19);
+    ctx->s[6] = _mm256_set_epi32(0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab);
+    ctx->s[7] = _mm256_set_epi32(0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19);
 
     ctx->datalen = 0;
     ctx->msglen = 0;
@@ -127,17 +126,17 @@ void sha256_final8x(sha256x8ctx *ctx,
     if (ctx->datalen < 56) {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
         sha256_transform8x(ctx,
@@ -156,14 +155,14 @@ void sha256_final8x(sha256x8ctx *ctx,
     // Add length of the message to each block
     ctx->msglen += ctx->datalen * 8;
     for (i = 0; i < 8; i++) {
-        ctx->msgblocks[64 * i + 63] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[64 * i + 62] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[64 * i + 61] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[64 * i + 60] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[64 * i + 59] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[64 * i + 58] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[64 * i + 57] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[64 * i + 56] = (unsigned char)(ctx->msglen >> 56);
+        ctx->msgblocks[(64 * i) + 63] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(64 * i) + 62] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(64 * i) + 61] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(64 * i) + 60] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(64 * i) + 59] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(64 * i) + 58] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(64 * i) + 57] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(64 * i) + 56] = (unsigned char)(ctx->msglen >> 56);
     }
     sha256_transform8x(ctx,
                        &ctx->msgblocks[64 * 0],

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/sha256x8.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/sha256x8.c
@@ -1,7 +1,9 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "sha256avx.h"
 #include "sha256x8.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 // Performs sha256x8 on an initialized (and perhaps seeded) state.
@@ -123,63 +125,63 @@ void mgf1x8(unsigned char *outx8, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx8 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx8 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx8 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx8 + 3 * (inlen + 4), in3, inlen);
-    memcpy(inbufx8 + 4 * (inlen + 4), in4, inlen);
-    memcpy(inbufx8 + 5 * (inlen + 4), in5, inlen);
-    memcpy(inbufx8 + 6 * (inlen + 4), in6, inlen);
-    memcpy(inbufx8 + 7 * (inlen + 4), in7, inlen);
+    memcpy(inbufx8 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx8 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx8 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx8 + (3 * (inlen + 4)), in3, inlen);
+    memcpy(inbufx8 + (4 * (inlen + 4)), in4, inlen);
+    memcpy(inbufx8 + (5 * (inlen + 4)), in5, inlen);
+    memcpy(inbufx8 + (6 * (inlen + 4)), in6, inlen);
+    memcpy(inbufx8 + (7 * (inlen + 4)), in7, inlen);
 
     /* While we can fit in at least another full block of SHA256 output.. */
     for (i = 0; (i + 1) * SPX_SHA256_OUTPUT_BYTES <= outlen; i++) {
         for (j = 0; j < 8; j++) {
-            u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
         }
 
-        sha256x8(outx8 + 0 * outlen,
-                 outx8 + 1 * outlen,
-                 outx8 + 2 * outlen,
-                 outx8 + 3 * outlen,
-                 outx8 + 4 * outlen,
-                 outx8 + 5 * outlen,
-                 outx8 + 6 * outlen,
-                 outx8 + 7 * outlen,
-                 inbufx8 + 0 * (inlen + 4),
-                 inbufx8 + 1 * (inlen + 4),
-                 inbufx8 + 2 * (inlen + 4),
-                 inbufx8 + 3 * (inlen + 4),
-                 inbufx8 + 4 * (inlen + 4),
-                 inbufx8 + 5 * (inlen + 4),
-                 inbufx8 + 6 * (inlen + 4),
-                 inbufx8 + 7 * (inlen + 4), inlen + 4);
+        sha256x8(outx8 + (0 * outlen),
+                 outx8 + (1 * outlen),
+                 outx8 + (2 * outlen),
+                 outx8 + (3 * outlen),
+                 outx8 + (4 * outlen),
+                 outx8 + (5 * outlen),
+                 outx8 + (6 * outlen),
+                 outx8 + (7 * outlen),
+                 inbufx8 + (0 * (inlen + 4)),
+                 inbufx8 + (1 * (inlen + 4)),
+                 inbufx8 + (2 * (inlen + 4)),
+                 inbufx8 + (3 * (inlen + 4)),
+                 inbufx8 + (4 * (inlen + 4)),
+                 inbufx8 + (5 * (inlen + 4)),
+                 inbufx8 + (6 * (inlen + 4)),
+                 inbufx8 + (7 * (inlen + 4)), inlen + 4);
         outx8 += SPX_SHA256_OUTPUT_BYTES;
     }
     /* Until we cannot anymore, and we fill the remainder. */
     for (j = 0; j < 8; j++) {
-        u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+        u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
     }
-    sha256x8(outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
-             inbufx8 + 0 * (inlen + 4),
-             inbufx8 + 1 * (inlen + 4),
-             inbufx8 + 2 * (inlen + 4),
-             inbufx8 + 3 * (inlen + 4),
-             inbufx8 + 4 * (inlen + 4),
-             inbufx8 + 5 * (inlen + 4),
-             inbufx8 + 6 * (inlen + 4),
-             inbufx8 + 7 * (inlen + 4), inlen + 4);
+    sha256x8(outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
+             inbufx8 + (0 * (inlen + 4)),
+             inbufx8 + (1 * (inlen + 4)),
+             inbufx8 + (2 * (inlen + 4)),
+             inbufx8 + (3 * (inlen + 4)),
+             inbufx8 + (4 * (inlen + 4)),
+             inbufx8 + (5 * (inlen + 4)),
+             inbufx8 + (6 * (inlen + 4)),
+             inbufx8 + (7 * (inlen + 4)), inlen + 4);
 
     for (j = 0; j < 8; j++) {
-        memcpy(outx8 + j * outlen,
-               outbufx8 + j * SPX_SHA256_OUTPUT_BYTES,
-               outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(outx8 + (j * outlen),
+               outbufx8 + (j * SPX_SHA256_OUTPUT_BYTES),
+               outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/sha256x8.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/sha256x8.h
@@ -4,6 +4,8 @@
 #include "params.h"
 #include "sha256avx.h"
 
+
+
 #define sha256x8_seeded SPX_NAMESPACE(sha256x8_seeded)
 void sha256x8_seeded(
     unsigned char *out0,

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/thash_sha2_simple.c
@@ -1,13 +1,15 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
 #include "utils.h"
+
 
 /**
  * Takes an array of inblocks concatenated arrays of SPX_N bytes.
@@ -17,7 +19,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -25,6 +27,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
+

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/thash_sha2_simplex8.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/thash_sha2_simplex8.c
@@ -1,15 +1,15 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thashx8.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
 #include "utils.h"
+
 
 /**
  * 8-way parallel version of thash; takes 8x as much input and output
@@ -36,59 +36,60 @@ void thashx8(unsigned char *out0,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }
+

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/utilsx8.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/utilsx8.c
@@ -1,5 +1,7 @@
+#include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "utils.h"
 #include "utilsx8.h"
 
@@ -56,7 +58,7 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = ((uint32_t)1 << (tree_height - 3)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[8 * SPX_N]; /* Current logical node */
-        gen_leafx8( current, ctx, 8 * idx + idx_offset,
+        gen_leafx8( current, ctx, (8 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
             uint32_t j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 8; j++) {
-                set_tree_height(tree_addrx8 + j * 8, h + 1);
-                set_tree_index(tree_addrx8 + j * 8,
-                               (8 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx8 + (j * 8), h + 1);
+                set_tree_index(tree_addrx8 + (j * 8),
+                               ((8 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx8[h * 8 * SPX_N];
             thashx8( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx8.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
-#include "utilsx8.h"
 #include "wotsx8.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, ..., addr} */
     for (j = 0; j < 8; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 8) {
         for (j = 0; j < 8 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx8(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -206,8 +204,8 @@ void wots_gen_leafx8(unsigned char *dest,
     }
 
     for (j = 0; j < 8; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -216,22 +214,22 @@ void wots_gen_leafx8(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 8; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx8(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
-                   buffer + 4 * wots_offset,
-                   buffer + 5 * wots_offset,
-                   buffer + 6 * wots_offset,
-                   buffer + 7 * wots_offset,
+        prf_addrx8(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
+                   buffer + (4 * wots_offset),
+                   buffer + (5 * wots_offset),
+                   buffer + (6 * wots_offset),
+                   buffer + (7 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 8; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -239,8 +237,8 @@ void wots_gen_leafx8(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -250,42 +248,42 @@ void wots_gen_leafx8(unsigned char *dest,
 
             /* Iterate one step on all 8 chains */
             for (j = 0; j < 8; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx8(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset, 1, ctx, leaf_addr);
+            thashx8(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx8(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            dest + 4 * SPX_N,
-            dest + 5 * SPX_N,
-            dest + 6 * SPX_N,
-            dest + 7 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset,
-            pk_buffer + 4 * wots_offset,
-            pk_buffer + 5 * wots_offset,
-            pk_buffer + 6 * wots_offset,
-            pk_buffer + 7 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx8(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            dest + (4 * SPX_N),
+            dest + (5 * SPX_N),
+            dest + (6 * SPX_N),
+            dest + (7 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset),
+            pk_buffer + (4 * wots_offset),
+            pk_buffer + (5 * wots_offset),
+            pk_buffer + (6 * wots_offset),
+            pk_buffer + (7 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-sha2-128f-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/address.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/context.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/context.h
@@ -14,6 +14,7 @@ typedef struct {
     // sha256 state that absorbed pub_seed
     sha256ctx state_seeded;
 
+
 } spx_ctx;
 
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/context_sha2.c
@@ -1,4 +1,9 @@
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha2_offsets.h"
+#include <stddef.h>
+#include <stdint.h>
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -20,6 +25,7 @@ static void seed_state(spx_ctx *ctx) {
     sha256_inc_init(&ctx->state_seeded);
     sha256_inc_blocks(&ctx->state_seeded, block, 1);
 }
+
 
 /* We initialize the state for the hash functions */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/fors.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/hash_sha2.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/hash_sha2.c
@@ -1,11 +1,14 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
+#include "sha2_offsets.h"
 #include "utils.h"
+
+
 
 #define SPX_SHAX_OUTPUT_BYTES SPX_SHA256_OUTPUT_BYTES
 #define SPX_SHAX_BLOCK_BYTES SPX_SHA256_BLOCK_BYTES
@@ -40,7 +43,7 @@ void mgf1_256(unsigned char *out, unsigned long outlen,
     if (outlen > i * SPX_SHA256_OUTPUT_BYTES) {
         u32_to_bytes(inbuf + inlen, i);
         sha256(outbuf, inbuf, inlen + 4);
-        memcpy(out, outbuf, outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(out, outbuf, outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }
 
@@ -65,7 +68,7 @@ void mgf1_512(unsigned char *out, unsigned long outlen,
     if (outlen > i * SPX_SHA512_OUTPUT_BYTES) {
         u32_to_bytes(inbuf + inlen, i);
         sha512(outbuf, inbuf, inlen + 4);
-        memcpy(out, outbuf, outlen - i * SPX_SHA512_OUTPUT_BYTES);
+        memcpy(out, outbuf, outlen - (i * SPX_SHA512_OUTPUT_BYTES));
     }
 }
 
@@ -107,6 +110,7 @@ void gen_message_random(unsigned char *R, const unsigned char *sk_prf,
     unsigned char buf[SPX_SHAX_BLOCK_BYTES + SPX_SHAX_OUTPUT_BYTES];
     shaXstate state;
     int i;
+
 
     /* This implements HMAC-SHA */
     for (i = 0; i < SPX_N; i++) {
@@ -160,7 +164,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 #define SPX_LEAF_BYTES ((SPX_LEAF_BITS + 7) / 8)
 #define SPX_DGST_BYTES (SPX_FORS_MSG_BYTES + SPX_TREE_BYTES + SPX_LEAF_BYTES)
 
-    unsigned char seed[2 * SPX_N + SPX_SHAX_OUTPUT_BYTES];
+    unsigned char seed[(2 * SPX_N) + SPX_SHAX_OUTPUT_BYTES];
 
     /* Round to nearest multiple of SPX_SHAX_BLOCK_BYTES */
 #define SPX_INBLOCKS (((SPX_N + SPX_PK_BYTES + SPX_SHAX_BLOCK_BYTES - 1) & \
@@ -180,17 +184,17 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     /* If R + pk + message cannot fill up an entire block */
     if (SPX_N + SPX_PK_BYTES + mlen < SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m, mlen);
-        shaX_inc_finalize(seed + 2 * SPX_N, &state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
+        shaX_inc_finalize(seed + (2 * SPX_N), &state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
     }
     /* Otherwise first fill a block, so that finalize only uses the message */
     else {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m,
-               SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES);
+               (SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) - SPX_N - SPX_PK_BYTES);
         shaX_inc_blocks(&state, inbuf, SPX_INBLOCKS);
 
         m += SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
         mlen -= SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
-        shaX_inc_finalize(seed + 2 * SPX_N, &state, m, (size_t)mlen);
+        shaX_inc_finalize(seed + (2 * SPX_N), &state, m, mlen);
     }
 
     // H_msg: MGF1-SHA-X(R ‖ PK.seed ‖ seed)
@@ -199,10 +203,11 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */
-    mgf1_X(bufp, SPX_DGST_BYTES, seed, 2 * SPX_N + SPX_SHAX_OUTPUT_BYTES);
+    mgf1_X(bufp, SPX_DGST_BYTES, seed, (2 * SPX_N) + SPX_SHAX_OUTPUT_BYTES);
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
@@ -211,3 +216,5 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);
     *leaf_idx &= (~(uint32_t)0) >> (32 - SPX_LEAF_BITS);
 }
+
+

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/params.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/thash_sha2_simple.c
@@ -1,13 +1,15 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
 #include "utils.h"
+
 
 /**
  * Takes an array of inblocks concatenated arrays of SPX_N bytes.
@@ -17,7 +19,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -25,6 +27,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
+

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/utils.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/utils.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/wots.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/wots.h
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-128f-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-sha2-128f-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-sha2-128s-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-128s-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-128s-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-128s-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/address.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/context.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/context.h
@@ -16,6 +16,7 @@ typedef struct {
     uint8_t sk_seed[SPX_N];
 } spx_ctx;
 
+
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)
 void initialize_hash_function(spx_ctx *ctx);
 

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/context_sha2.c
@@ -1,6 +1,12 @@
 #include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha256avx.h"
+#include "sha2_offsets.h"
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -31,6 +37,7 @@ static void seed_state(spx_ctx *ctx) {
     ctx->statex8_seeded.msglen = 512;
 
 }
+
 
 /* For SHA, we initialize the hash function at the start */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/fors.c
@@ -1,12 +1,13 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
+
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
@@ -71,40 +72,40 @@ static void fors_gen_leafx8(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 8; j++) {
-        set_tree_index(fors_leaf_addrx8 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx8 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx8(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
-                  leaf + 4 * SPX_N,
-                  leaf + 5 * SPX_N,
-                  leaf + 6 * SPX_N,
-                  leaf + 7 * SPX_N,
+    fors_gen_skx8(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
+                  leaf + (4 * SPX_N),
+                  leaf + (5 * SPX_N),
+                  leaf + (6 * SPX_N),
+                  leaf + (7 * SPX_N),
                   ctx, fors_leaf_addrx8);
 
     for (j = 0; j < 8; j++) {
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx8(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
+    fors_sk_to_leafx8(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
                       ctx, fors_leaf_addrx8);
 }
 
@@ -144,9 +145,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -166,7 +167,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx8(roots + i * SPX_N, sig, ctx,
+        treehashx8(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx8,
                    fors_tree_addr, &fors_info);
 
@@ -215,7 +216,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/hash_sha2.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/hash_sha2.c
@@ -1,11 +1,14 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
+#include "sha2_offsets.h"
 #include "utils.h"
+
+
 
 #define SPX_SHAX_OUTPUT_BYTES SPX_SHA256_OUTPUT_BYTES
 #define SPX_SHAX_BLOCK_BYTES SPX_SHA256_BLOCK_BYTES
@@ -40,7 +43,7 @@ void mgf1_256(unsigned char *out, unsigned long outlen,
     if (outlen > i * SPX_SHA256_OUTPUT_BYTES) {
         u32_to_bytes(inbuf + inlen, i);
         sha256(outbuf, inbuf, inlen + 4);
-        memcpy(out, outbuf, outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(out, outbuf, outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }
 
@@ -65,7 +68,7 @@ void mgf1_512(unsigned char *out, unsigned long outlen,
     if (outlen > i * SPX_SHA512_OUTPUT_BYTES) {
         u32_to_bytes(inbuf + inlen, i);
         sha512(outbuf, inbuf, inlen + 4);
-        memcpy(out, outbuf, outlen - i * SPX_SHA512_OUTPUT_BYTES);
+        memcpy(out, outbuf, outlen - (i * SPX_SHA512_OUTPUT_BYTES));
     }
 }
 
@@ -107,6 +110,7 @@ void gen_message_random(unsigned char *R, const unsigned char *sk_prf,
     unsigned char buf[SPX_SHAX_BLOCK_BYTES + SPX_SHAX_OUTPUT_BYTES];
     shaXstate state;
     int i;
+
 
     /* This implements HMAC-SHA */
     for (i = 0; i < SPX_N; i++) {
@@ -160,7 +164,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 #define SPX_LEAF_BYTES ((SPX_LEAF_BITS + 7) / 8)
 #define SPX_DGST_BYTES (SPX_FORS_MSG_BYTES + SPX_TREE_BYTES + SPX_LEAF_BYTES)
 
-    unsigned char seed[2 * SPX_N + SPX_SHAX_OUTPUT_BYTES];
+    unsigned char seed[(2 * SPX_N) + SPX_SHAX_OUTPUT_BYTES];
 
     /* Round to nearest multiple of SPX_SHAX_BLOCK_BYTES */
 #define SPX_INBLOCKS (((SPX_N + SPX_PK_BYTES + SPX_SHAX_BLOCK_BYTES - 1) & \
@@ -180,17 +184,17 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     /* If R + pk + message cannot fill up an entire block */
     if (SPX_N + SPX_PK_BYTES + mlen < SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m, mlen);
-        shaX_inc_finalize(seed + 2 * SPX_N, &state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
+        shaX_inc_finalize(seed + (2 * SPX_N), &state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
     }
     /* Otherwise first fill a block, so that finalize only uses the message */
     else {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m,
-               SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES);
+               (SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) - SPX_N - SPX_PK_BYTES);
         shaX_inc_blocks(&state, inbuf, SPX_INBLOCKS);
 
         m += SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
         mlen -= SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
-        shaX_inc_finalize(seed + 2 * SPX_N, &state, m, (size_t)mlen);
+        shaX_inc_finalize(seed + (2 * SPX_N), &state, m, mlen);
     }
 
     // H_msg: MGF1-SHA-X(R ‖ PK.seed ‖ seed)
@@ -199,10 +203,11 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */
-    mgf1_X(bufp, SPX_DGST_BYTES, seed, 2 * SPX_N + SPX_SHAX_OUTPUT_BYTES);
+    mgf1_X(bufp, SPX_DGST_BYTES, seed, (2 * SPX_N) + SPX_SHAX_OUTPUT_BYTES);
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
@@ -211,3 +216,5 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);
     *leaf_idx &= (~(uint32_t)0) >> (32 - SPX_LEAF_BITS);
 }
+
+

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/hash_sha2x8.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/hash_sha2x8.c
@@ -1,15 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
 
-#include "address.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
-#include "utils.h"
+#include "sha2_offsets.h"
 
 /*
  * 8-way parallel version of prf_addr; takes 8x as much input and output
@@ -29,10 +27,10 @@ void prf_addrx8(unsigned char *out0,
     unsigned int j;
 
     for (j = 0; j < 8; j++) {
-        memcpy(bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES),
-               addrx8 + j * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)),
+               addrx8 + (j * 8), SPX_SHA256_ADDR_BYTES);
         memcpy(
-            bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES) + SPX_SHA256_ADDR_BYTES,
+            bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)) + SPX_SHA256_ADDR_BYTES,
             ctx->sk_seed,
             SPX_N
         );
@@ -40,36 +38,36 @@ void prf_addrx8(unsigned char *out0,
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + SPX_N),
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
         SPX_SHA256_ADDR_BYTES + SPX_N /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx8.h"
 #include "wots.h"
 #include "wotsx8.h"
@@ -52,7 +51,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/params.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/sha256avx.c
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "sha256avx.h"
@@ -99,14 +98,14 @@ void sha256_ctx_clone8x(sha256x8ctx *out, const sha256x8ctx *in) {
 }
 
 void sha256_init8x(sha256x8ctx *ctx) {
-    ctx->s[0] = _mm256_set_epi32((int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667);
+    ctx->s[0] = _mm256_set_epi32(0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667);
     ctx->s[1] = _mm256_set_epi32((int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85);
-    ctx->s[2] = _mm256_set_epi32((int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372);
+    ctx->s[2] = _mm256_set_epi32(0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372);
     ctx->s[3] = _mm256_set_epi32((int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a);
-    ctx->s[4] = _mm256_set_epi32((int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f);
+    ctx->s[4] = _mm256_set_epi32(0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f);
     ctx->s[5] = _mm256_set_epi32((int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c);
-    ctx->s[6] = _mm256_set_epi32((int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab);
-    ctx->s[7] = _mm256_set_epi32((int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19);
+    ctx->s[6] = _mm256_set_epi32(0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab);
+    ctx->s[7] = _mm256_set_epi32(0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19);
 
     ctx->datalen = 0;
     ctx->msglen = 0;
@@ -127,17 +126,17 @@ void sha256_final8x(sha256x8ctx *ctx,
     if (ctx->datalen < 56) {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
         sha256_transform8x(ctx,
@@ -156,14 +155,14 @@ void sha256_final8x(sha256x8ctx *ctx,
     // Add length of the message to each block
     ctx->msglen += ctx->datalen * 8;
     for (i = 0; i < 8; i++) {
-        ctx->msgblocks[64 * i + 63] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[64 * i + 62] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[64 * i + 61] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[64 * i + 60] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[64 * i + 59] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[64 * i + 58] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[64 * i + 57] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[64 * i + 56] = (unsigned char)(ctx->msglen >> 56);
+        ctx->msgblocks[(64 * i) + 63] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(64 * i) + 62] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(64 * i) + 61] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(64 * i) + 60] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(64 * i) + 59] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(64 * i) + 58] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(64 * i) + 57] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(64 * i) + 56] = (unsigned char)(ctx->msglen >> 56);
     }
     sha256_transform8x(ctx,
                        &ctx->msgblocks[64 * 0],

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/sha256x8.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/sha256x8.c
@@ -1,7 +1,9 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "sha256avx.h"
 #include "sha256x8.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 // Performs sha256x8 on an initialized (and perhaps seeded) state.
@@ -123,63 +125,63 @@ void mgf1x8(unsigned char *outx8, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx8 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx8 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx8 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx8 + 3 * (inlen + 4), in3, inlen);
-    memcpy(inbufx8 + 4 * (inlen + 4), in4, inlen);
-    memcpy(inbufx8 + 5 * (inlen + 4), in5, inlen);
-    memcpy(inbufx8 + 6 * (inlen + 4), in6, inlen);
-    memcpy(inbufx8 + 7 * (inlen + 4), in7, inlen);
+    memcpy(inbufx8 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx8 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx8 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx8 + (3 * (inlen + 4)), in3, inlen);
+    memcpy(inbufx8 + (4 * (inlen + 4)), in4, inlen);
+    memcpy(inbufx8 + (5 * (inlen + 4)), in5, inlen);
+    memcpy(inbufx8 + (6 * (inlen + 4)), in6, inlen);
+    memcpy(inbufx8 + (7 * (inlen + 4)), in7, inlen);
 
     /* While we can fit in at least another full block of SHA256 output.. */
     for (i = 0; (i + 1) * SPX_SHA256_OUTPUT_BYTES <= outlen; i++) {
         for (j = 0; j < 8; j++) {
-            u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
         }
 
-        sha256x8(outx8 + 0 * outlen,
-                 outx8 + 1 * outlen,
-                 outx8 + 2 * outlen,
-                 outx8 + 3 * outlen,
-                 outx8 + 4 * outlen,
-                 outx8 + 5 * outlen,
-                 outx8 + 6 * outlen,
-                 outx8 + 7 * outlen,
-                 inbufx8 + 0 * (inlen + 4),
-                 inbufx8 + 1 * (inlen + 4),
-                 inbufx8 + 2 * (inlen + 4),
-                 inbufx8 + 3 * (inlen + 4),
-                 inbufx8 + 4 * (inlen + 4),
-                 inbufx8 + 5 * (inlen + 4),
-                 inbufx8 + 6 * (inlen + 4),
-                 inbufx8 + 7 * (inlen + 4), inlen + 4);
+        sha256x8(outx8 + (0 * outlen),
+                 outx8 + (1 * outlen),
+                 outx8 + (2 * outlen),
+                 outx8 + (3 * outlen),
+                 outx8 + (4 * outlen),
+                 outx8 + (5 * outlen),
+                 outx8 + (6 * outlen),
+                 outx8 + (7 * outlen),
+                 inbufx8 + (0 * (inlen + 4)),
+                 inbufx8 + (1 * (inlen + 4)),
+                 inbufx8 + (2 * (inlen + 4)),
+                 inbufx8 + (3 * (inlen + 4)),
+                 inbufx8 + (4 * (inlen + 4)),
+                 inbufx8 + (5 * (inlen + 4)),
+                 inbufx8 + (6 * (inlen + 4)),
+                 inbufx8 + (7 * (inlen + 4)), inlen + 4);
         outx8 += SPX_SHA256_OUTPUT_BYTES;
     }
     /* Until we cannot anymore, and we fill the remainder. */
     for (j = 0; j < 8; j++) {
-        u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+        u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
     }
-    sha256x8(outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
-             inbufx8 + 0 * (inlen + 4),
-             inbufx8 + 1 * (inlen + 4),
-             inbufx8 + 2 * (inlen + 4),
-             inbufx8 + 3 * (inlen + 4),
-             inbufx8 + 4 * (inlen + 4),
-             inbufx8 + 5 * (inlen + 4),
-             inbufx8 + 6 * (inlen + 4),
-             inbufx8 + 7 * (inlen + 4), inlen + 4);
+    sha256x8(outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
+             inbufx8 + (0 * (inlen + 4)),
+             inbufx8 + (1 * (inlen + 4)),
+             inbufx8 + (2 * (inlen + 4)),
+             inbufx8 + (3 * (inlen + 4)),
+             inbufx8 + (4 * (inlen + 4)),
+             inbufx8 + (5 * (inlen + 4)),
+             inbufx8 + (6 * (inlen + 4)),
+             inbufx8 + (7 * (inlen + 4)), inlen + 4);
 
     for (j = 0; j < 8; j++) {
-        memcpy(outx8 + j * outlen,
-               outbufx8 + j * SPX_SHA256_OUTPUT_BYTES,
-               outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(outx8 + (j * outlen),
+               outbufx8 + (j * SPX_SHA256_OUTPUT_BYTES),
+               outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/sha256x8.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/sha256x8.h
@@ -4,6 +4,8 @@
 #include "params.h"
 #include "sha256avx.h"
 
+
+
 #define sha256x8_seeded SPX_NAMESPACE(sha256x8_seeded)
 void sha256x8_seeded(
     unsigned char *out0,

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/thash_sha2_simple.c
@@ -1,13 +1,15 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
 #include "utils.h"
+
 
 /**
  * Takes an array of inblocks concatenated arrays of SPX_N bytes.
@@ -17,7 +19,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -25,6 +27,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
+

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/thash_sha2_simplex8.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/thash_sha2_simplex8.c
@@ -1,15 +1,15 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thashx8.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
 #include "utils.h"
+
 
 /**
  * 8-way parallel version of thash; takes 8x as much input and output
@@ -36,59 +36,60 @@ void thashx8(unsigned char *out0,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }
+

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/utilsx8.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/utilsx8.c
@@ -1,5 +1,7 @@
+#include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "utils.h"
 #include "utilsx8.h"
 
@@ -56,7 +58,7 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = ((uint32_t)1 << (tree_height - 3)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[8 * SPX_N]; /* Current logical node */
-        gen_leafx8( current, ctx, 8 * idx + idx_offset,
+        gen_leafx8( current, ctx, (8 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
             uint32_t j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 8; j++) {
-                set_tree_height(tree_addrx8 + j * 8, h + 1);
-                set_tree_index(tree_addrx8 + j * 8,
-                               (8 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx8 + (j * 8), h + 1);
+                set_tree_index(tree_addrx8 + (j * 8),
+                               ((8 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx8[h * 8 * SPX_N];
             thashx8( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx8.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
-#include "utilsx8.h"
 #include "wotsx8.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, ..., addr} */
     for (j = 0; j < 8; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 8) {
         for (j = 0; j < 8 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx8(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -206,8 +204,8 @@ void wots_gen_leafx8(unsigned char *dest,
     }
 
     for (j = 0; j < 8; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -216,22 +214,22 @@ void wots_gen_leafx8(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 8; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx8(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
-                   buffer + 4 * wots_offset,
-                   buffer + 5 * wots_offset,
-                   buffer + 6 * wots_offset,
-                   buffer + 7 * wots_offset,
+        prf_addrx8(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
+                   buffer + (4 * wots_offset),
+                   buffer + (5 * wots_offset),
+                   buffer + (6 * wots_offset),
+                   buffer + (7 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 8; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -239,8 +237,8 @@ void wots_gen_leafx8(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -250,42 +248,42 @@ void wots_gen_leafx8(unsigned char *dest,
 
             /* Iterate one step on all 8 chains */
             for (j = 0; j < 8; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx8(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset, 1, ctx, leaf_addr);
+            thashx8(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx8(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            dest + 4 * SPX_N,
-            dest + 5 * SPX_N,
-            dest + 6 * SPX_N,
-            dest + 7 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset,
-            pk_buffer + 4 * wots_offset,
-            pk_buffer + 5 * wots_offset,
-            pk_buffer + 6 * wots_offset,
-            pk_buffer + 7 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx8(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            dest + (4 * SPX_N),
+            dest + (5 * SPX_N),
+            dest + (6 * SPX_N),
+            dest + (7 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset),
+            pk_buffer + (4 * wots_offset),
+            pk_buffer + (5 * wots_offset),
+            pk_buffer + (6 * wots_offset),
+            pk_buffer + (7 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-sha2-128s-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/address.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/context.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/context.h
@@ -14,6 +14,7 @@ typedef struct {
     // sha256 state that absorbed pub_seed
     sha256ctx state_seeded;
 
+
 } spx_ctx;
 
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/context_sha2.c
@@ -1,4 +1,9 @@
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha2_offsets.h"
+#include <stddef.h>
+#include <stdint.h>
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -20,6 +25,7 @@ static void seed_state(spx_ctx *ctx) {
     sha256_inc_init(&ctx->state_seeded);
     sha256_inc_blocks(&ctx->state_seeded, block, 1);
 }
+
 
 /* We initialize the state for the hash functions */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/fors.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/hash_sha2.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/hash_sha2.c
@@ -1,11 +1,14 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
+#include "sha2_offsets.h"
 #include "utils.h"
+
+
 
 #define SPX_SHAX_OUTPUT_BYTES SPX_SHA256_OUTPUT_BYTES
 #define SPX_SHAX_BLOCK_BYTES SPX_SHA256_BLOCK_BYTES
@@ -40,7 +43,7 @@ void mgf1_256(unsigned char *out, unsigned long outlen,
     if (outlen > i * SPX_SHA256_OUTPUT_BYTES) {
         u32_to_bytes(inbuf + inlen, i);
         sha256(outbuf, inbuf, inlen + 4);
-        memcpy(out, outbuf, outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(out, outbuf, outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }
 
@@ -65,7 +68,7 @@ void mgf1_512(unsigned char *out, unsigned long outlen,
     if (outlen > i * SPX_SHA512_OUTPUT_BYTES) {
         u32_to_bytes(inbuf + inlen, i);
         sha512(outbuf, inbuf, inlen + 4);
-        memcpy(out, outbuf, outlen - i * SPX_SHA512_OUTPUT_BYTES);
+        memcpy(out, outbuf, outlen - (i * SPX_SHA512_OUTPUT_BYTES));
     }
 }
 
@@ -107,6 +110,7 @@ void gen_message_random(unsigned char *R, const unsigned char *sk_prf,
     unsigned char buf[SPX_SHAX_BLOCK_BYTES + SPX_SHAX_OUTPUT_BYTES];
     shaXstate state;
     int i;
+
 
     /* This implements HMAC-SHA */
     for (i = 0; i < SPX_N; i++) {
@@ -160,7 +164,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 #define SPX_LEAF_BYTES ((SPX_LEAF_BITS + 7) / 8)
 #define SPX_DGST_BYTES (SPX_FORS_MSG_BYTES + SPX_TREE_BYTES + SPX_LEAF_BYTES)
 
-    unsigned char seed[2 * SPX_N + SPX_SHAX_OUTPUT_BYTES];
+    unsigned char seed[(2 * SPX_N) + SPX_SHAX_OUTPUT_BYTES];
 
     /* Round to nearest multiple of SPX_SHAX_BLOCK_BYTES */
 #define SPX_INBLOCKS (((SPX_N + SPX_PK_BYTES + SPX_SHAX_BLOCK_BYTES - 1) & \
@@ -180,17 +184,17 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     /* If R + pk + message cannot fill up an entire block */
     if (SPX_N + SPX_PK_BYTES + mlen < SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m, mlen);
-        shaX_inc_finalize(seed + 2 * SPX_N, &state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
+        shaX_inc_finalize(seed + (2 * SPX_N), &state, inbuf, SPX_N + SPX_PK_BYTES + mlen);
     }
     /* Otherwise first fill a block, so that finalize only uses the message */
     else {
         memcpy(inbuf + SPX_N + SPX_PK_BYTES, m,
-               SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES);
+               (SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES) - SPX_N - SPX_PK_BYTES);
         shaX_inc_blocks(&state, inbuf, SPX_INBLOCKS);
 
         m += SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
         mlen -= SPX_INBLOCKS * SPX_SHAX_BLOCK_BYTES - SPX_N - SPX_PK_BYTES;
-        shaX_inc_finalize(seed + 2 * SPX_N, &state, m, (size_t)mlen);
+        shaX_inc_finalize(seed + (2 * SPX_N), &state, m, mlen);
     }
 
     // H_msg: MGF1-SHA-X(R ‖ PK.seed ‖ seed)
@@ -199,10 +203,11 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     /* By doing this in two steps, we prevent hashing the message twice;
        otherwise each iteration in MGF1 would hash the message again. */
-    mgf1_X(bufp, SPX_DGST_BYTES, seed, 2 * SPX_N + SPX_SHAX_OUTPUT_BYTES);
+    mgf1_X(bufp, SPX_DGST_BYTES, seed, (2 * SPX_N) + SPX_SHAX_OUTPUT_BYTES);
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);
@@ -211,3 +216,5 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
     *leaf_idx = (uint32_t)bytes_to_ull(bufp, SPX_LEAF_BYTES);
     *leaf_idx &= (~(uint32_t)0) >> (32 - SPX_LEAF_BITS);
 }
+
+

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/params.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/thash_sha2_simple.c
@@ -1,13 +1,15 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
 #include "utils.h"
+
 
 /**
  * Takes an array of inblocks concatenated arrays of SPX_N bytes.
@@ -17,7 +19,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -25,6 +27,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
+

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/utils.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/utils.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/wots.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/wots.h
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-128s-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-sha2-128s-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-sha2-192f-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-192f-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-192f-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-192f-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/address.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/context.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/context.h
@@ -19,6 +19,7 @@ typedef struct {
     uint8_t sk_seed[SPX_N];
 } spx_ctx;
 
+
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)
 void initialize_hash_function(spx_ctx *ctx);
 

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/context_sha2.c
@@ -1,6 +1,13 @@
 #include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha256avx.h"
+#include "sha2_offsets.h"
+#include "sha512x4.h"
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -40,7 +47,9 @@ static void seed_state(spx_ctx *ctx) {
     ctx->statex4_seeded_512.datalen = 0;
     ctx->statex4_seeded_512.msglen = 1024;
 
+
 }
+
 
 /* For SHA, we initialize the hash function at the start */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/fors.c
@@ -1,12 +1,13 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
+
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
@@ -71,40 +72,40 @@ static void fors_gen_leafx8(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 8; j++) {
-        set_tree_index(fors_leaf_addrx8 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx8 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx8(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
-                  leaf + 4 * SPX_N,
-                  leaf + 5 * SPX_N,
-                  leaf + 6 * SPX_N,
-                  leaf + 7 * SPX_N,
+    fors_gen_skx8(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
+                  leaf + (4 * SPX_N),
+                  leaf + (5 * SPX_N),
+                  leaf + (6 * SPX_N),
+                  leaf + (7 * SPX_N),
                   ctx, fors_leaf_addrx8);
 
     for (j = 0; j < 8; j++) {
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx8(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
+    fors_sk_to_leafx8(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
                       ctx, fors_leaf_addrx8);
 }
 
@@ -144,9 +145,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -166,7 +167,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx8(roots + i * SPX_N, sig, ctx,
+        treehashx8(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx8,
                    fors_tree_addr, &fors_info);
 
@@ -215,7 +216,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/hash_sha2x8.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/hash_sha2x8.c
@@ -1,15 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
 
-#include "address.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
-#include "utils.h"
+#include "sha2_offsets.h"
 
 /*
  * 8-way parallel version of prf_addr; takes 8x as much input and output
@@ -29,10 +27,10 @@ void prf_addrx8(unsigned char *out0,
     unsigned int j;
 
     for (j = 0; j < 8; j++) {
-        memcpy(bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES),
-               addrx8 + j * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)),
+               addrx8 + (j * 8), SPX_SHA256_ADDR_BYTES);
         memcpy(
-            bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES) + SPX_SHA256_ADDR_BYTES,
+            bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)) + SPX_SHA256_ADDR_BYTES,
             ctx->sk_seed,
             SPX_N
         );
@@ -40,36 +38,36 @@ void prf_addrx8(unsigned char *out0,
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + SPX_N),
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
         SPX_SHA256_ADDR_BYTES + SPX_N /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx8.h"
 #include "wots.h"
 #include "wotsx8.h"
@@ -52,7 +51,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/params.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/sha256avx.c
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "sha256avx.h"
@@ -99,14 +98,14 @@ void sha256_ctx_clone8x(sha256x8ctx *out, const sha256x8ctx *in) {
 }
 
 void sha256_init8x(sha256x8ctx *ctx) {
-    ctx->s[0] = _mm256_set_epi32((int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667);
+    ctx->s[0] = _mm256_set_epi32(0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667);
     ctx->s[1] = _mm256_set_epi32((int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85);
-    ctx->s[2] = _mm256_set_epi32((int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372);
+    ctx->s[2] = _mm256_set_epi32(0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372);
     ctx->s[3] = _mm256_set_epi32((int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a);
-    ctx->s[4] = _mm256_set_epi32((int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f);
+    ctx->s[4] = _mm256_set_epi32(0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f);
     ctx->s[5] = _mm256_set_epi32((int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c);
-    ctx->s[6] = _mm256_set_epi32((int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab);
-    ctx->s[7] = _mm256_set_epi32((int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19);
+    ctx->s[6] = _mm256_set_epi32(0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab);
+    ctx->s[7] = _mm256_set_epi32(0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19);
 
     ctx->datalen = 0;
     ctx->msglen = 0;
@@ -127,17 +126,17 @@ void sha256_final8x(sha256x8ctx *ctx,
     if (ctx->datalen < 56) {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
         sha256_transform8x(ctx,
@@ -156,14 +155,14 @@ void sha256_final8x(sha256x8ctx *ctx,
     // Add length of the message to each block
     ctx->msglen += ctx->datalen * 8;
     for (i = 0; i < 8; i++) {
-        ctx->msgblocks[64 * i + 63] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[64 * i + 62] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[64 * i + 61] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[64 * i + 60] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[64 * i + 59] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[64 * i + 58] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[64 * i + 57] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[64 * i + 56] = (unsigned char)(ctx->msglen >> 56);
+        ctx->msgblocks[(64 * i) + 63] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(64 * i) + 62] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(64 * i) + 61] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(64 * i) + 60] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(64 * i) + 59] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(64 * i) + 58] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(64 * i) + 57] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(64 * i) + 56] = (unsigned char)(ctx->msglen >> 56);
     }
     sha256_transform8x(ctx,
                        &ctx->msgblocks[64 * 0],

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/sha256x8.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/sha256x8.c
@@ -1,7 +1,9 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "sha256avx.h"
 #include "sha256x8.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 // Performs sha256x8 on an initialized (and perhaps seeded) state.
@@ -123,63 +125,63 @@ void mgf1x8(unsigned char *outx8, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx8 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx8 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx8 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx8 + 3 * (inlen + 4), in3, inlen);
-    memcpy(inbufx8 + 4 * (inlen + 4), in4, inlen);
-    memcpy(inbufx8 + 5 * (inlen + 4), in5, inlen);
-    memcpy(inbufx8 + 6 * (inlen + 4), in6, inlen);
-    memcpy(inbufx8 + 7 * (inlen + 4), in7, inlen);
+    memcpy(inbufx8 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx8 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx8 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx8 + (3 * (inlen + 4)), in3, inlen);
+    memcpy(inbufx8 + (4 * (inlen + 4)), in4, inlen);
+    memcpy(inbufx8 + (5 * (inlen + 4)), in5, inlen);
+    memcpy(inbufx8 + (6 * (inlen + 4)), in6, inlen);
+    memcpy(inbufx8 + (7 * (inlen + 4)), in7, inlen);
 
     /* While we can fit in at least another full block of SHA256 output.. */
     for (i = 0; (i + 1) * SPX_SHA256_OUTPUT_BYTES <= outlen; i++) {
         for (j = 0; j < 8; j++) {
-            u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
         }
 
-        sha256x8(outx8 + 0 * outlen,
-                 outx8 + 1 * outlen,
-                 outx8 + 2 * outlen,
-                 outx8 + 3 * outlen,
-                 outx8 + 4 * outlen,
-                 outx8 + 5 * outlen,
-                 outx8 + 6 * outlen,
-                 outx8 + 7 * outlen,
-                 inbufx8 + 0 * (inlen + 4),
-                 inbufx8 + 1 * (inlen + 4),
-                 inbufx8 + 2 * (inlen + 4),
-                 inbufx8 + 3 * (inlen + 4),
-                 inbufx8 + 4 * (inlen + 4),
-                 inbufx8 + 5 * (inlen + 4),
-                 inbufx8 + 6 * (inlen + 4),
-                 inbufx8 + 7 * (inlen + 4), inlen + 4);
+        sha256x8(outx8 + (0 * outlen),
+                 outx8 + (1 * outlen),
+                 outx8 + (2 * outlen),
+                 outx8 + (3 * outlen),
+                 outx8 + (4 * outlen),
+                 outx8 + (5 * outlen),
+                 outx8 + (6 * outlen),
+                 outx8 + (7 * outlen),
+                 inbufx8 + (0 * (inlen + 4)),
+                 inbufx8 + (1 * (inlen + 4)),
+                 inbufx8 + (2 * (inlen + 4)),
+                 inbufx8 + (3 * (inlen + 4)),
+                 inbufx8 + (4 * (inlen + 4)),
+                 inbufx8 + (5 * (inlen + 4)),
+                 inbufx8 + (6 * (inlen + 4)),
+                 inbufx8 + (7 * (inlen + 4)), inlen + 4);
         outx8 += SPX_SHA256_OUTPUT_BYTES;
     }
     /* Until we cannot anymore, and we fill the remainder. */
     for (j = 0; j < 8; j++) {
-        u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+        u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
     }
-    sha256x8(outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
-             inbufx8 + 0 * (inlen + 4),
-             inbufx8 + 1 * (inlen + 4),
-             inbufx8 + 2 * (inlen + 4),
-             inbufx8 + 3 * (inlen + 4),
-             inbufx8 + 4 * (inlen + 4),
-             inbufx8 + 5 * (inlen + 4),
-             inbufx8 + 6 * (inlen + 4),
-             inbufx8 + 7 * (inlen + 4), inlen + 4);
+    sha256x8(outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
+             inbufx8 + (0 * (inlen + 4)),
+             inbufx8 + (1 * (inlen + 4)),
+             inbufx8 + (2 * (inlen + 4)),
+             inbufx8 + (3 * (inlen + 4)),
+             inbufx8 + (4 * (inlen + 4)),
+             inbufx8 + (5 * (inlen + 4)),
+             inbufx8 + (6 * (inlen + 4)),
+             inbufx8 + (7 * (inlen + 4)), inlen + 4);
 
     for (j = 0; j < 8; j++) {
-        memcpy(outx8 + j * outlen,
-               outbufx8 + j * SPX_SHA256_OUTPUT_BYTES,
-               outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(outx8 + (j * outlen),
+               outbufx8 + (j * SPX_SHA256_OUTPUT_BYTES),
+               outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/sha256x8.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/sha256x8.h
@@ -4,6 +4,8 @@
 #include "params.h"
 #include "sha256avx.h"
 
+
+
 #define sha256x8_seeded SPX_NAMESPACE(sha256x8_seeded)
 void sha256x8_seeded(
     unsigned char *out0,

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/sha512x4.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/sha512x4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 /* pull in the entire thing */
 #include "sha512x4.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 typedef uint64_t u64;
@@ -40,6 +40,7 @@ static void transpose(u256 s[4]) {
     s[2] = _mm256_permute2x128_si256(tmp[0], tmp[2], 0x31);
     s[3] = _mm256_permute2x128_si256(tmp[1], tmp[3], 0x31);
 }
+
 
 void sha512_init4x(sha512x4ctx *ctx) {
 #define SET4(x) _mm256_set_epi64x((long long)(x), (long long)(x), (long long)(x), (long long)(x))
@@ -294,17 +295,17 @@ static void _sha512x4(
     if (ctx->datalen < 112) {
         for (i = 0; i < 4; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[128 * i + curlen++] = 0x80;
+            ctx->msgblocks[(128 * i) + curlen++] = 0x80;
             while (curlen < 128) {
-                ctx->msgblocks[128 * i + curlen++] = 0x00;
+                ctx->msgblocks[(128 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 4; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[128 * i + curlen++] = 0x80;
+            ctx->msgblocks[(128 * i) + curlen++] = 0x80;
             while (curlen < 128) {
-                ctx->msgblocks[128 * i + curlen++] = 0x00;
+                ctx->msgblocks[(128 * i) + curlen++] = 0x00;
             }
         }
         sha512_transform4x(
@@ -320,15 +321,15 @@ static void _sha512x4(
     // Add length of the message to each block
     ctx->msglen += (unsigned long long)(ctx->datalen) * 8;
     for (i = 0; i < 4; i++) {
-        ctx->msgblocks[128 * i + 127] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[128 * i + 126] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[128 * i + 125] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[128 * i + 124] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[128 * i + 123] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[128 * i + 122] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[128 * i + 121] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[128 * i + 120] = (unsigned char)(ctx->msglen >> 56);
-        memset( &ctx->msgblocks[128 * i + 112], 0, 8 );
+        ctx->msgblocks[(128 * i) + 127] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(128 * i) + 126] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(128 * i) + 125] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(128 * i) + 124] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(128 * i) + 123] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(128 * i) + 122] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(128 * i) + 121] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(128 * i) + 120] = (unsigned char)(ctx->msglen >> 56);
+        memset( &ctx->msgblocks[(128 * i) + 112], 0, 8 );
     }
     sha512_transform4x(
         ctx,
@@ -361,6 +362,7 @@ static void _sha512x4(
     memcpy(out3, out, 64);
 }
 
+
 /**
  * Note that inlen should be sufficiently small that it still allows for
  * an array to be allocated on the stack. Typically 'in' is merely a seed.
@@ -377,10 +379,10 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx4 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx4 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx4 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx4 + 3 * (inlen + 4), in3, inlen);
+    memcpy(inbufx4 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx4 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx4 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx4 + (3 * (inlen + 4)), in3, inlen);
 
     /* While we can fit in at least another full block of SHA512 output.. */
     unsigned long remaining = outlen;
@@ -391,7 +393,7 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
         }
         remaining -= this_step;
         for (j = 0; j < 4; j++) {
-            u32_to_bytes(inbufx4 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx4 + inlen + (j * (inlen + 4)), i);
         }
 
         sha512x4ctx ctx;
@@ -399,21 +401,21 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
 
         _sha512x4(
             &ctx,
-            outbuf + 0 * 64,
-            outbuf + 1 * 64,
-            outbuf + 2 * 64,
-            outbuf + 3 * 64,
-            inbufx4 + 0 * (inlen + 4),
-            inbufx4 + 1 * (inlen + 4),
-            inbufx4 + 2 * (inlen + 4),
-            inbufx4 + 3 * (inlen + 4),
+            outbuf + (0 * 64),
+            outbuf + (1 * 64),
+            outbuf + (2 * 64),
+            outbuf + (3 * 64),
+            inbufx4 + (0 * (inlen + 4)),
+            inbufx4 + (1 * (inlen + 4)),
+            inbufx4 + (2 * (inlen + 4)),
+            inbufx4 + (3 * (inlen + 4)),
             inlen + 4
         );
 
-        memcpy(outx4 + 0 * outlen, outbuf + 0 * 64, this_step);
-        memcpy(outx4 + 1 * outlen, outbuf + 1 * 64, this_step);
-        memcpy(outx4 + 2 * outlen, outbuf + 2 * 64, this_step);
-        memcpy(outx4 + 3 * outlen, outbuf + 3 * 64, this_step);
+        memcpy(outx4 + (0 * outlen), outbuf + (0 * 64), this_step);
+        memcpy(outx4 + (1 * outlen), outbuf + (1 * 64), this_step);
+        memcpy(outx4 + (2 * outlen), outbuf + (2 * 64), this_step);
+        memcpy(outx4 + (3 * outlen), outbuf + (3 * 64), this_step);
         outx4 += this_step;
     }
 }

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/sha512x4.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/sha512x4.h
@@ -4,6 +4,7 @@
 #include <immintrin.h>
 #include <stdint.h>
 
+
 #include "params.h"
 
 typedef struct SHA512state4x {
@@ -23,6 +24,7 @@ void sha512_transform4x(
     const unsigned char *d1,
     const unsigned char *d2,
     const unsigned char *d3);
+
 
 #define sha512x4_seeded SPX_NAMESPACE(sha512x4_seeded)
 void sha512x4_seeded(

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/thash_sha2_simple.c
@@ -1,9 +1,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
@@ -24,7 +25,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -32,7 +33,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
 
@@ -40,7 +41,7 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
                       const spx_ctx *ctx, uint32_t addr[8]) {
     unsigned char outbuf[SPX_SHA512_OUTPUT_BYTES];
     sha512ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha512_inc_ctx_clone(&sha2_state, &ctx->state_seeded_512);
@@ -48,6 +49,6 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/thash_sha2_simplex8.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/thash_sha2_simplex8.c
@@ -1,13 +1,12 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thashx8.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
 #include "utils.h"
 
@@ -67,61 +66,61 @@ void thashx8(unsigned char *out0,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }
 
 /**
@@ -153,60 +152,60 @@ static void thashx8_512(
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha512x4_seeded(
-        outbuf + 0 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 1 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 2 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 3 * SPX_SHA512_OUTPUT_BYTES,
+        outbuf + (0 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (1 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (2 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (3 * SPX_SHA512_OUTPUT_BYTES),
         &ctx->statex4_seeded_512, /* seed */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), /* in */
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), /* in */
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbuf + 0 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbuf + 1 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbuf + 2 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbuf + 3 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbuf + (0 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbuf + (1 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbuf + (2 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbuf + (3 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
 
     sha512x4_seeded(
-        outbuf + 0 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 1 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 2 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 3 * SPX_SHA512_OUTPUT_BYTES,
+        outbuf + (0 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (1 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (2 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (3 * SPX_SHA512_OUTPUT_BYTES),
         &ctx->statex4_seeded_512, /* seed */
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), /* in */
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), /* in */
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out4, outbuf + 0 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbuf + 1 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbuf + 2 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbuf + 3 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
+    memcpy(out4, outbuf + (0 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbuf + (1 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbuf + (2 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbuf + (3 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/utilsx8.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/utilsx8.c
@@ -1,5 +1,7 @@
+#include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "utils.h"
 #include "utilsx8.h"
 
@@ -56,7 +58,7 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = ((uint32_t)1 << (tree_height - 3)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[8 * SPX_N]; /* Current logical node */
-        gen_leafx8( current, ctx, 8 * idx + idx_offset,
+        gen_leafx8( current, ctx, (8 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
             uint32_t j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 8; j++) {
-                set_tree_height(tree_addrx8 + j * 8, h + 1);
-                set_tree_index(tree_addrx8 + j * 8,
-                               (8 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx8 + (j * 8), h + 1);
+                set_tree_index(tree_addrx8 + (j * 8),
+                               ((8 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx8[h * 8 * SPX_N];
             thashx8( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx8.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
-#include "utilsx8.h"
 #include "wotsx8.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, ..., addr} */
     for (j = 0; j < 8; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 8) {
         for (j = 0; j < 8 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx8(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -206,8 +204,8 @@ void wots_gen_leafx8(unsigned char *dest,
     }
 
     for (j = 0; j < 8; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -216,22 +214,22 @@ void wots_gen_leafx8(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 8; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx8(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
-                   buffer + 4 * wots_offset,
-                   buffer + 5 * wots_offset,
-                   buffer + 6 * wots_offset,
-                   buffer + 7 * wots_offset,
+        prf_addrx8(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
+                   buffer + (4 * wots_offset),
+                   buffer + (5 * wots_offset),
+                   buffer + (6 * wots_offset),
+                   buffer + (7 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 8; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -239,8 +237,8 @@ void wots_gen_leafx8(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -250,42 +248,42 @@ void wots_gen_leafx8(unsigned char *dest,
 
             /* Iterate one step on all 8 chains */
             for (j = 0; j < 8; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx8(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset, 1, ctx, leaf_addr);
+            thashx8(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx8(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            dest + 4 * SPX_N,
-            dest + 5 * SPX_N,
-            dest + 6 * SPX_N,
-            dest + 7 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset,
-            pk_buffer + 4 * wots_offset,
-            pk_buffer + 5 * wots_offset,
-            pk_buffer + 6 * wots_offset,
-            pk_buffer + 7 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx8(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            dest + (4 * SPX_N),
+            dest + (5 * SPX_N),
+            dest + (6 * SPX_N),
+            dest + (7 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset),
+            pk_buffer + (4 * wots_offset),
+            pk_buffer + (5 * wots_offset),
+            pk_buffer + (6 * wots_offset),
+            pk_buffer + (7 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-sha2-192f-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/address.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/context_sha2.c
@@ -1,4 +1,9 @@
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha2_offsets.h"
+#include <stddef.h>
+#include <stdint.h>
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -22,6 +27,7 @@ static void seed_state(spx_ctx *ctx) {
     sha512_inc_init(&ctx->state_seeded_512);
     sha512_inc_blocks(&ctx->state_seeded_512, block, 1);
 }
+
 
 /* We initialize the state for the hash functions */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/fors.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/params.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/thash_sha2_simple.c
@@ -1,9 +1,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
@@ -24,7 +25,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -32,7 +33,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
 
@@ -40,7 +41,7 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
                       const spx_ctx *ctx, uint32_t addr[8]) {
     unsigned char outbuf[SPX_SHA512_OUTPUT_BYTES];
     sha512ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha512_inc_ctx_clone(&sha2_state, &ctx->state_seeded_512);
@@ -48,6 +49,6 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/utils.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/utils.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/wots.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/wots.h
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-192f-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-sha2-192f-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-sha2-192s-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-192s-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-192s-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-192s-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/address.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/context.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/context.h
@@ -19,6 +19,7 @@ typedef struct {
     uint8_t sk_seed[SPX_N];
 } spx_ctx;
 
+
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)
 void initialize_hash_function(spx_ctx *ctx);
 

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/context_sha2.c
@@ -1,6 +1,13 @@
 #include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha256avx.h"
+#include "sha2_offsets.h"
+#include "sha512x4.h"
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -40,7 +47,9 @@ static void seed_state(spx_ctx *ctx) {
     ctx->statex4_seeded_512.datalen = 0;
     ctx->statex4_seeded_512.msglen = 1024;
 
+
 }
+
 
 /* For SHA, we initialize the hash function at the start */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/fors.c
@@ -1,12 +1,13 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
+
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
@@ -71,40 +72,40 @@ static void fors_gen_leafx8(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 8; j++) {
-        set_tree_index(fors_leaf_addrx8 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx8 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx8(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
-                  leaf + 4 * SPX_N,
-                  leaf + 5 * SPX_N,
-                  leaf + 6 * SPX_N,
-                  leaf + 7 * SPX_N,
+    fors_gen_skx8(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
+                  leaf + (4 * SPX_N),
+                  leaf + (5 * SPX_N),
+                  leaf + (6 * SPX_N),
+                  leaf + (7 * SPX_N),
                   ctx, fors_leaf_addrx8);
 
     for (j = 0; j < 8; j++) {
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx8(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
+    fors_sk_to_leafx8(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
                       ctx, fors_leaf_addrx8);
 }
 
@@ -144,9 +145,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -166,7 +167,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx8(roots + i * SPX_N, sig, ctx,
+        treehashx8(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx8,
                    fors_tree_addr, &fors_info);
 
@@ -215,7 +216,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/hash_sha2x8.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/hash_sha2x8.c
@@ -1,15 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
 
-#include "address.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
-#include "utils.h"
+#include "sha2_offsets.h"
 
 /*
  * 8-way parallel version of prf_addr; takes 8x as much input and output
@@ -29,10 +27,10 @@ void prf_addrx8(unsigned char *out0,
     unsigned int j;
 
     for (j = 0; j < 8; j++) {
-        memcpy(bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES),
-               addrx8 + j * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)),
+               addrx8 + (j * 8), SPX_SHA256_ADDR_BYTES);
         memcpy(
-            bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES) + SPX_SHA256_ADDR_BYTES,
+            bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)) + SPX_SHA256_ADDR_BYTES,
             ctx->sk_seed,
             SPX_N
         );
@@ -40,36 +38,36 @@ void prf_addrx8(unsigned char *out0,
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + SPX_N),
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
         SPX_SHA256_ADDR_BYTES + SPX_N /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx8.h"
 #include "wots.h"
 #include "wotsx8.h"
@@ -52,7 +51,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/params.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/sha256avx.c
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "sha256avx.h"
@@ -99,14 +98,14 @@ void sha256_ctx_clone8x(sha256x8ctx *out, const sha256x8ctx *in) {
 }
 
 void sha256_init8x(sha256x8ctx *ctx) {
-    ctx->s[0] = _mm256_set_epi32((int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667);
+    ctx->s[0] = _mm256_set_epi32(0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667);
     ctx->s[1] = _mm256_set_epi32((int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85);
-    ctx->s[2] = _mm256_set_epi32((int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372);
+    ctx->s[2] = _mm256_set_epi32(0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372);
     ctx->s[3] = _mm256_set_epi32((int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a);
-    ctx->s[4] = _mm256_set_epi32((int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f);
+    ctx->s[4] = _mm256_set_epi32(0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f);
     ctx->s[5] = _mm256_set_epi32((int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c);
-    ctx->s[6] = _mm256_set_epi32((int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab);
-    ctx->s[7] = _mm256_set_epi32((int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19);
+    ctx->s[6] = _mm256_set_epi32(0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab);
+    ctx->s[7] = _mm256_set_epi32(0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19);
 
     ctx->datalen = 0;
     ctx->msglen = 0;
@@ -127,17 +126,17 @@ void sha256_final8x(sha256x8ctx *ctx,
     if (ctx->datalen < 56) {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
         sha256_transform8x(ctx,
@@ -156,14 +155,14 @@ void sha256_final8x(sha256x8ctx *ctx,
     // Add length of the message to each block
     ctx->msglen += ctx->datalen * 8;
     for (i = 0; i < 8; i++) {
-        ctx->msgblocks[64 * i + 63] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[64 * i + 62] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[64 * i + 61] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[64 * i + 60] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[64 * i + 59] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[64 * i + 58] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[64 * i + 57] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[64 * i + 56] = (unsigned char)(ctx->msglen >> 56);
+        ctx->msgblocks[(64 * i) + 63] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(64 * i) + 62] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(64 * i) + 61] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(64 * i) + 60] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(64 * i) + 59] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(64 * i) + 58] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(64 * i) + 57] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(64 * i) + 56] = (unsigned char)(ctx->msglen >> 56);
     }
     sha256_transform8x(ctx,
                        &ctx->msgblocks[64 * 0],

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/sha256x8.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/sha256x8.c
@@ -1,7 +1,9 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "sha256avx.h"
 #include "sha256x8.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 // Performs sha256x8 on an initialized (and perhaps seeded) state.
@@ -123,63 +125,63 @@ void mgf1x8(unsigned char *outx8, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx8 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx8 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx8 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx8 + 3 * (inlen + 4), in3, inlen);
-    memcpy(inbufx8 + 4 * (inlen + 4), in4, inlen);
-    memcpy(inbufx8 + 5 * (inlen + 4), in5, inlen);
-    memcpy(inbufx8 + 6 * (inlen + 4), in6, inlen);
-    memcpy(inbufx8 + 7 * (inlen + 4), in7, inlen);
+    memcpy(inbufx8 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx8 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx8 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx8 + (3 * (inlen + 4)), in3, inlen);
+    memcpy(inbufx8 + (4 * (inlen + 4)), in4, inlen);
+    memcpy(inbufx8 + (5 * (inlen + 4)), in5, inlen);
+    memcpy(inbufx8 + (6 * (inlen + 4)), in6, inlen);
+    memcpy(inbufx8 + (7 * (inlen + 4)), in7, inlen);
 
     /* While we can fit in at least another full block of SHA256 output.. */
     for (i = 0; (i + 1) * SPX_SHA256_OUTPUT_BYTES <= outlen; i++) {
         for (j = 0; j < 8; j++) {
-            u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
         }
 
-        sha256x8(outx8 + 0 * outlen,
-                 outx8 + 1 * outlen,
-                 outx8 + 2 * outlen,
-                 outx8 + 3 * outlen,
-                 outx8 + 4 * outlen,
-                 outx8 + 5 * outlen,
-                 outx8 + 6 * outlen,
-                 outx8 + 7 * outlen,
-                 inbufx8 + 0 * (inlen + 4),
-                 inbufx8 + 1 * (inlen + 4),
-                 inbufx8 + 2 * (inlen + 4),
-                 inbufx8 + 3 * (inlen + 4),
-                 inbufx8 + 4 * (inlen + 4),
-                 inbufx8 + 5 * (inlen + 4),
-                 inbufx8 + 6 * (inlen + 4),
-                 inbufx8 + 7 * (inlen + 4), inlen + 4);
+        sha256x8(outx8 + (0 * outlen),
+                 outx8 + (1 * outlen),
+                 outx8 + (2 * outlen),
+                 outx8 + (3 * outlen),
+                 outx8 + (4 * outlen),
+                 outx8 + (5 * outlen),
+                 outx8 + (6 * outlen),
+                 outx8 + (7 * outlen),
+                 inbufx8 + (0 * (inlen + 4)),
+                 inbufx8 + (1 * (inlen + 4)),
+                 inbufx8 + (2 * (inlen + 4)),
+                 inbufx8 + (3 * (inlen + 4)),
+                 inbufx8 + (4 * (inlen + 4)),
+                 inbufx8 + (5 * (inlen + 4)),
+                 inbufx8 + (6 * (inlen + 4)),
+                 inbufx8 + (7 * (inlen + 4)), inlen + 4);
         outx8 += SPX_SHA256_OUTPUT_BYTES;
     }
     /* Until we cannot anymore, and we fill the remainder. */
     for (j = 0; j < 8; j++) {
-        u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+        u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
     }
-    sha256x8(outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
-             inbufx8 + 0 * (inlen + 4),
-             inbufx8 + 1 * (inlen + 4),
-             inbufx8 + 2 * (inlen + 4),
-             inbufx8 + 3 * (inlen + 4),
-             inbufx8 + 4 * (inlen + 4),
-             inbufx8 + 5 * (inlen + 4),
-             inbufx8 + 6 * (inlen + 4),
-             inbufx8 + 7 * (inlen + 4), inlen + 4);
+    sha256x8(outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
+             inbufx8 + (0 * (inlen + 4)),
+             inbufx8 + (1 * (inlen + 4)),
+             inbufx8 + (2 * (inlen + 4)),
+             inbufx8 + (3 * (inlen + 4)),
+             inbufx8 + (4 * (inlen + 4)),
+             inbufx8 + (5 * (inlen + 4)),
+             inbufx8 + (6 * (inlen + 4)),
+             inbufx8 + (7 * (inlen + 4)), inlen + 4);
 
     for (j = 0; j < 8; j++) {
-        memcpy(outx8 + j * outlen,
-               outbufx8 + j * SPX_SHA256_OUTPUT_BYTES,
-               outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(outx8 + (j * outlen),
+               outbufx8 + (j * SPX_SHA256_OUTPUT_BYTES),
+               outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/sha256x8.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/sha256x8.h
@@ -4,6 +4,8 @@
 #include "params.h"
 #include "sha256avx.h"
 
+
+
 #define sha256x8_seeded SPX_NAMESPACE(sha256x8_seeded)
 void sha256x8_seeded(
     unsigned char *out0,

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/sha512x4.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/sha512x4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 /* pull in the entire thing */
 #include "sha512x4.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 typedef uint64_t u64;
@@ -40,6 +40,7 @@ static void transpose(u256 s[4]) {
     s[2] = _mm256_permute2x128_si256(tmp[0], tmp[2], 0x31);
     s[3] = _mm256_permute2x128_si256(tmp[1], tmp[3], 0x31);
 }
+
 
 void sha512_init4x(sha512x4ctx *ctx) {
 #define SET4(x) _mm256_set_epi64x((long long)(x), (long long)(x), (long long)(x), (long long)(x))
@@ -294,17 +295,17 @@ static void _sha512x4(
     if (ctx->datalen < 112) {
         for (i = 0; i < 4; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[128 * i + curlen++] = 0x80;
+            ctx->msgblocks[(128 * i) + curlen++] = 0x80;
             while (curlen < 128) {
-                ctx->msgblocks[128 * i + curlen++] = 0x00;
+                ctx->msgblocks[(128 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 4; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[128 * i + curlen++] = 0x80;
+            ctx->msgblocks[(128 * i) + curlen++] = 0x80;
             while (curlen < 128) {
-                ctx->msgblocks[128 * i + curlen++] = 0x00;
+                ctx->msgblocks[(128 * i) + curlen++] = 0x00;
             }
         }
         sha512_transform4x(
@@ -320,15 +321,15 @@ static void _sha512x4(
     // Add length of the message to each block
     ctx->msglen += (unsigned long long)(ctx->datalen) * 8;
     for (i = 0; i < 4; i++) {
-        ctx->msgblocks[128 * i + 127] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[128 * i + 126] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[128 * i + 125] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[128 * i + 124] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[128 * i + 123] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[128 * i + 122] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[128 * i + 121] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[128 * i + 120] = (unsigned char)(ctx->msglen >> 56);
-        memset( &ctx->msgblocks[128 * i + 112], 0, 8 );
+        ctx->msgblocks[(128 * i) + 127] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(128 * i) + 126] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(128 * i) + 125] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(128 * i) + 124] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(128 * i) + 123] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(128 * i) + 122] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(128 * i) + 121] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(128 * i) + 120] = (unsigned char)(ctx->msglen >> 56);
+        memset( &ctx->msgblocks[(128 * i) + 112], 0, 8 );
     }
     sha512_transform4x(
         ctx,
@@ -361,6 +362,7 @@ static void _sha512x4(
     memcpy(out3, out, 64);
 }
 
+
 /**
  * Note that inlen should be sufficiently small that it still allows for
  * an array to be allocated on the stack. Typically 'in' is merely a seed.
@@ -377,10 +379,10 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx4 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx4 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx4 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx4 + 3 * (inlen + 4), in3, inlen);
+    memcpy(inbufx4 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx4 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx4 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx4 + (3 * (inlen + 4)), in3, inlen);
 
     /* While we can fit in at least another full block of SHA512 output.. */
     unsigned long remaining = outlen;
@@ -391,7 +393,7 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
         }
         remaining -= this_step;
         for (j = 0; j < 4; j++) {
-            u32_to_bytes(inbufx4 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx4 + inlen + (j * (inlen + 4)), i);
         }
 
         sha512x4ctx ctx;
@@ -399,21 +401,21 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
 
         _sha512x4(
             &ctx,
-            outbuf + 0 * 64,
-            outbuf + 1 * 64,
-            outbuf + 2 * 64,
-            outbuf + 3 * 64,
-            inbufx4 + 0 * (inlen + 4),
-            inbufx4 + 1 * (inlen + 4),
-            inbufx4 + 2 * (inlen + 4),
-            inbufx4 + 3 * (inlen + 4),
+            outbuf + (0 * 64),
+            outbuf + (1 * 64),
+            outbuf + (2 * 64),
+            outbuf + (3 * 64),
+            inbufx4 + (0 * (inlen + 4)),
+            inbufx4 + (1 * (inlen + 4)),
+            inbufx4 + (2 * (inlen + 4)),
+            inbufx4 + (3 * (inlen + 4)),
             inlen + 4
         );
 
-        memcpy(outx4 + 0 * outlen, outbuf + 0 * 64, this_step);
-        memcpy(outx4 + 1 * outlen, outbuf + 1 * 64, this_step);
-        memcpy(outx4 + 2 * outlen, outbuf + 2 * 64, this_step);
-        memcpy(outx4 + 3 * outlen, outbuf + 3 * 64, this_step);
+        memcpy(outx4 + (0 * outlen), outbuf + (0 * 64), this_step);
+        memcpy(outx4 + (1 * outlen), outbuf + (1 * 64), this_step);
+        memcpy(outx4 + (2 * outlen), outbuf + (2 * 64), this_step);
+        memcpy(outx4 + (3 * outlen), outbuf + (3 * 64), this_step);
         outx4 += this_step;
     }
 }

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/sha512x4.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/sha512x4.h
@@ -4,6 +4,7 @@
 #include <immintrin.h>
 #include <stdint.h>
 
+
 #include "params.h"
 
 typedef struct SHA512state4x {
@@ -23,6 +24,7 @@ void sha512_transform4x(
     const unsigned char *d1,
     const unsigned char *d2,
     const unsigned char *d3);
+
 
 #define sha512x4_seeded SPX_NAMESPACE(sha512x4_seeded)
 void sha512x4_seeded(

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/thash_sha2_simple.c
@@ -1,9 +1,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
@@ -24,7 +25,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -32,7 +33,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
 
@@ -40,7 +41,7 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
                       const spx_ctx *ctx, uint32_t addr[8]) {
     unsigned char outbuf[SPX_SHA512_OUTPUT_BYTES];
     sha512ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha512_inc_ctx_clone(&sha2_state, &ctx->state_seeded_512);
@@ -48,6 +49,6 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/thash_sha2_simplex8.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/thash_sha2_simplex8.c
@@ -1,13 +1,12 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thashx8.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
 #include "utils.h"
 
@@ -67,61 +66,61 @@ void thashx8(unsigned char *out0,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }
 
 /**
@@ -153,60 +152,60 @@ static void thashx8_512(
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha512x4_seeded(
-        outbuf + 0 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 1 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 2 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 3 * SPX_SHA512_OUTPUT_BYTES,
+        outbuf + (0 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (1 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (2 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (3 * SPX_SHA512_OUTPUT_BYTES),
         &ctx->statex4_seeded_512, /* seed */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), /* in */
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), /* in */
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbuf + 0 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbuf + 1 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbuf + 2 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbuf + 3 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbuf + (0 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbuf + (1 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbuf + (2 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbuf + (3 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
 
     sha512x4_seeded(
-        outbuf + 0 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 1 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 2 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 3 * SPX_SHA512_OUTPUT_BYTES,
+        outbuf + (0 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (1 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (2 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (3 * SPX_SHA512_OUTPUT_BYTES),
         &ctx->statex4_seeded_512, /* seed */
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), /* in */
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), /* in */
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out4, outbuf + 0 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbuf + 1 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbuf + 2 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbuf + 3 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
+    memcpy(out4, outbuf + (0 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbuf + (1 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbuf + (2 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbuf + (3 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/utilsx8.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/utilsx8.c
@@ -1,5 +1,7 @@
+#include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "utils.h"
 #include "utilsx8.h"
 
@@ -56,7 +58,7 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = ((uint32_t)1 << (tree_height - 3)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[8 * SPX_N]; /* Current logical node */
-        gen_leafx8( current, ctx, 8 * idx + idx_offset,
+        gen_leafx8( current, ctx, (8 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
             uint32_t j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 8; j++) {
-                set_tree_height(tree_addrx8 + j * 8, h + 1);
-                set_tree_index(tree_addrx8 + j * 8,
-                               (8 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx8 + (j * 8), h + 1);
+                set_tree_index(tree_addrx8 + (j * 8),
+                               ((8 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx8[h * 8 * SPX_N];
             thashx8( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx8.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
-#include "utilsx8.h"
 #include "wotsx8.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, ..., addr} */
     for (j = 0; j < 8; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 8) {
         for (j = 0; j < 8 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx8(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -206,8 +204,8 @@ void wots_gen_leafx8(unsigned char *dest,
     }
 
     for (j = 0; j < 8; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -216,22 +214,22 @@ void wots_gen_leafx8(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 8; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx8(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
-                   buffer + 4 * wots_offset,
-                   buffer + 5 * wots_offset,
-                   buffer + 6 * wots_offset,
-                   buffer + 7 * wots_offset,
+        prf_addrx8(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
+                   buffer + (4 * wots_offset),
+                   buffer + (5 * wots_offset),
+                   buffer + (6 * wots_offset),
+                   buffer + (7 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 8; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -239,8 +237,8 @@ void wots_gen_leafx8(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -250,42 +248,42 @@ void wots_gen_leafx8(unsigned char *dest,
 
             /* Iterate one step on all 8 chains */
             for (j = 0; j < 8; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx8(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset, 1, ctx, leaf_addr);
+            thashx8(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx8(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            dest + 4 * SPX_N,
-            dest + 5 * SPX_N,
-            dest + 6 * SPX_N,
-            dest + 7 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset,
-            pk_buffer + 4 * wots_offset,
-            pk_buffer + 5 * wots_offset,
-            pk_buffer + 6 * wots_offset,
-            pk_buffer + 7 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx8(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            dest + (4 * SPX_N),
+            dest + (5 * SPX_N),
+            dest + (6 * SPX_N),
+            dest + (7 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset),
+            pk_buffer + (4 * wots_offset),
+            pk_buffer + (5 * wots_offset),
+            pk_buffer + (6 * wots_offset),
+            pk_buffer + (7 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-sha2-192s-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/address.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/context_sha2.c
@@ -1,4 +1,9 @@
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha2_offsets.h"
+#include <stddef.h>
+#include <stdint.h>
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -22,6 +27,7 @@ static void seed_state(spx_ctx *ctx) {
     sha512_inc_init(&ctx->state_seeded_512);
     sha512_inc_blocks(&ctx->state_seeded_512, block, 1);
 }
+
 
 /* We initialize the state for the hash functions */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/fors.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/params.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/thash_sha2_simple.c
@@ -1,9 +1,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
@@ -24,7 +25,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -32,7 +33,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
 
@@ -40,7 +41,7 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
                       const spx_ctx *ctx, uint32_t addr[8]) {
     unsigned char outbuf[SPX_SHA512_OUTPUT_BYTES];
     sha512ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha512_inc_ctx_clone(&sha2_state, &ctx->state_seeded_512);
@@ -48,6 +49,6 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/utils.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/utils.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/wots.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/wots.h
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-192s-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-sha2-192s-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-sha2-256f-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-256f-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-256f-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-256f-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/address.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/context.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/context.h
@@ -19,6 +19,7 @@ typedef struct {
     uint8_t sk_seed[SPX_N];
 } spx_ctx;
 
+
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)
 void initialize_hash_function(spx_ctx *ctx);
 

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/context_sha2.c
@@ -1,6 +1,13 @@
 #include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha256avx.h"
+#include "sha2_offsets.h"
+#include "sha512x4.h"
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -40,7 +47,9 @@ static void seed_state(spx_ctx *ctx) {
     ctx->statex4_seeded_512.datalen = 0;
     ctx->statex4_seeded_512.msglen = 1024;
 
+
 }
+
 
 /* For SHA, we initialize the hash function at the start */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/fors.c
@@ -1,12 +1,13 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
+
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
@@ -71,40 +72,40 @@ static void fors_gen_leafx8(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 8; j++) {
-        set_tree_index(fors_leaf_addrx8 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx8 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx8(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
-                  leaf + 4 * SPX_N,
-                  leaf + 5 * SPX_N,
-                  leaf + 6 * SPX_N,
-                  leaf + 7 * SPX_N,
+    fors_gen_skx8(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
+                  leaf + (4 * SPX_N),
+                  leaf + (5 * SPX_N),
+                  leaf + (6 * SPX_N),
+                  leaf + (7 * SPX_N),
                   ctx, fors_leaf_addrx8);
 
     for (j = 0; j < 8; j++) {
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx8(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
+    fors_sk_to_leafx8(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
                       ctx, fors_leaf_addrx8);
 }
 
@@ -144,9 +145,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -166,7 +167,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx8(roots + i * SPX_N, sig, ctx,
+        treehashx8(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx8,
                    fors_tree_addr, &fors_info);
 
@@ -215,7 +216,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/hash_sha2x8.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/hash_sha2x8.c
@@ -1,15 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
 
-#include "address.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
-#include "utils.h"
+#include "sha2_offsets.h"
 
 /*
  * 8-way parallel version of prf_addr; takes 8x as much input and output
@@ -29,10 +27,10 @@ void prf_addrx8(unsigned char *out0,
     unsigned int j;
 
     for (j = 0; j < 8; j++) {
-        memcpy(bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES),
-               addrx8 + j * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)),
+               addrx8 + (j * 8), SPX_SHA256_ADDR_BYTES);
         memcpy(
-            bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES) + SPX_SHA256_ADDR_BYTES,
+            bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)) + SPX_SHA256_ADDR_BYTES,
             ctx->sk_seed,
             SPX_N
         );
@@ -40,36 +38,36 @@ void prf_addrx8(unsigned char *out0,
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + SPX_N),
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
         SPX_SHA256_ADDR_BYTES + SPX_N /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx8.h"
 #include "wots.h"
 #include "wotsx8.h"
@@ -52,7 +51,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/params.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/sha256avx.c
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "sha256avx.h"
@@ -99,14 +98,14 @@ void sha256_ctx_clone8x(sha256x8ctx *out, const sha256x8ctx *in) {
 }
 
 void sha256_init8x(sha256x8ctx *ctx) {
-    ctx->s[0] = _mm256_set_epi32((int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667);
+    ctx->s[0] = _mm256_set_epi32(0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667);
     ctx->s[1] = _mm256_set_epi32((int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85);
-    ctx->s[2] = _mm256_set_epi32((int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372);
+    ctx->s[2] = _mm256_set_epi32(0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372);
     ctx->s[3] = _mm256_set_epi32((int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a);
-    ctx->s[4] = _mm256_set_epi32((int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f);
+    ctx->s[4] = _mm256_set_epi32(0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f);
     ctx->s[5] = _mm256_set_epi32((int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c);
-    ctx->s[6] = _mm256_set_epi32((int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab);
-    ctx->s[7] = _mm256_set_epi32((int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19);
+    ctx->s[6] = _mm256_set_epi32(0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab);
+    ctx->s[7] = _mm256_set_epi32(0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19);
 
     ctx->datalen = 0;
     ctx->msglen = 0;
@@ -127,17 +126,17 @@ void sha256_final8x(sha256x8ctx *ctx,
     if (ctx->datalen < 56) {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
         sha256_transform8x(ctx,
@@ -156,14 +155,14 @@ void sha256_final8x(sha256x8ctx *ctx,
     // Add length of the message to each block
     ctx->msglen += ctx->datalen * 8;
     for (i = 0; i < 8; i++) {
-        ctx->msgblocks[64 * i + 63] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[64 * i + 62] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[64 * i + 61] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[64 * i + 60] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[64 * i + 59] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[64 * i + 58] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[64 * i + 57] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[64 * i + 56] = (unsigned char)(ctx->msglen >> 56);
+        ctx->msgblocks[(64 * i) + 63] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(64 * i) + 62] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(64 * i) + 61] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(64 * i) + 60] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(64 * i) + 59] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(64 * i) + 58] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(64 * i) + 57] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(64 * i) + 56] = (unsigned char)(ctx->msglen >> 56);
     }
     sha256_transform8x(ctx,
                        &ctx->msgblocks[64 * 0],

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/sha256x8.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/sha256x8.c
@@ -1,7 +1,9 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "sha256avx.h"
 #include "sha256x8.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 // Performs sha256x8 on an initialized (and perhaps seeded) state.
@@ -123,63 +125,63 @@ void mgf1x8(unsigned char *outx8, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx8 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx8 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx8 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx8 + 3 * (inlen + 4), in3, inlen);
-    memcpy(inbufx8 + 4 * (inlen + 4), in4, inlen);
-    memcpy(inbufx8 + 5 * (inlen + 4), in5, inlen);
-    memcpy(inbufx8 + 6 * (inlen + 4), in6, inlen);
-    memcpy(inbufx8 + 7 * (inlen + 4), in7, inlen);
+    memcpy(inbufx8 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx8 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx8 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx8 + (3 * (inlen + 4)), in3, inlen);
+    memcpy(inbufx8 + (4 * (inlen + 4)), in4, inlen);
+    memcpy(inbufx8 + (5 * (inlen + 4)), in5, inlen);
+    memcpy(inbufx8 + (6 * (inlen + 4)), in6, inlen);
+    memcpy(inbufx8 + (7 * (inlen + 4)), in7, inlen);
 
     /* While we can fit in at least another full block of SHA256 output.. */
     for (i = 0; (i + 1) * SPX_SHA256_OUTPUT_BYTES <= outlen; i++) {
         for (j = 0; j < 8; j++) {
-            u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
         }
 
-        sha256x8(outx8 + 0 * outlen,
-                 outx8 + 1 * outlen,
-                 outx8 + 2 * outlen,
-                 outx8 + 3 * outlen,
-                 outx8 + 4 * outlen,
-                 outx8 + 5 * outlen,
-                 outx8 + 6 * outlen,
-                 outx8 + 7 * outlen,
-                 inbufx8 + 0 * (inlen + 4),
-                 inbufx8 + 1 * (inlen + 4),
-                 inbufx8 + 2 * (inlen + 4),
-                 inbufx8 + 3 * (inlen + 4),
-                 inbufx8 + 4 * (inlen + 4),
-                 inbufx8 + 5 * (inlen + 4),
-                 inbufx8 + 6 * (inlen + 4),
-                 inbufx8 + 7 * (inlen + 4), inlen + 4);
+        sha256x8(outx8 + (0 * outlen),
+                 outx8 + (1 * outlen),
+                 outx8 + (2 * outlen),
+                 outx8 + (3 * outlen),
+                 outx8 + (4 * outlen),
+                 outx8 + (5 * outlen),
+                 outx8 + (6 * outlen),
+                 outx8 + (7 * outlen),
+                 inbufx8 + (0 * (inlen + 4)),
+                 inbufx8 + (1 * (inlen + 4)),
+                 inbufx8 + (2 * (inlen + 4)),
+                 inbufx8 + (3 * (inlen + 4)),
+                 inbufx8 + (4 * (inlen + 4)),
+                 inbufx8 + (5 * (inlen + 4)),
+                 inbufx8 + (6 * (inlen + 4)),
+                 inbufx8 + (7 * (inlen + 4)), inlen + 4);
         outx8 += SPX_SHA256_OUTPUT_BYTES;
     }
     /* Until we cannot anymore, and we fill the remainder. */
     for (j = 0; j < 8; j++) {
-        u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+        u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
     }
-    sha256x8(outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
-             inbufx8 + 0 * (inlen + 4),
-             inbufx8 + 1 * (inlen + 4),
-             inbufx8 + 2 * (inlen + 4),
-             inbufx8 + 3 * (inlen + 4),
-             inbufx8 + 4 * (inlen + 4),
-             inbufx8 + 5 * (inlen + 4),
-             inbufx8 + 6 * (inlen + 4),
-             inbufx8 + 7 * (inlen + 4), inlen + 4);
+    sha256x8(outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
+             inbufx8 + (0 * (inlen + 4)),
+             inbufx8 + (1 * (inlen + 4)),
+             inbufx8 + (2 * (inlen + 4)),
+             inbufx8 + (3 * (inlen + 4)),
+             inbufx8 + (4 * (inlen + 4)),
+             inbufx8 + (5 * (inlen + 4)),
+             inbufx8 + (6 * (inlen + 4)),
+             inbufx8 + (7 * (inlen + 4)), inlen + 4);
 
     for (j = 0; j < 8; j++) {
-        memcpy(outx8 + j * outlen,
-               outbufx8 + j * SPX_SHA256_OUTPUT_BYTES,
-               outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(outx8 + (j * outlen),
+               outbufx8 + (j * SPX_SHA256_OUTPUT_BYTES),
+               outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/sha256x8.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/sha256x8.h
@@ -4,6 +4,8 @@
 #include "params.h"
 #include "sha256avx.h"
 
+
+
 #define sha256x8_seeded SPX_NAMESPACE(sha256x8_seeded)
 void sha256x8_seeded(
     unsigned char *out0,

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/sha512x4.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/sha512x4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 /* pull in the entire thing */
 #include "sha512x4.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 typedef uint64_t u64;
@@ -40,6 +40,7 @@ static void transpose(u256 s[4]) {
     s[2] = _mm256_permute2x128_si256(tmp[0], tmp[2], 0x31);
     s[3] = _mm256_permute2x128_si256(tmp[1], tmp[3], 0x31);
 }
+
 
 void sha512_init4x(sha512x4ctx *ctx) {
 #define SET4(x) _mm256_set_epi64x((long long)(x), (long long)(x), (long long)(x), (long long)(x))
@@ -294,17 +295,17 @@ static void _sha512x4(
     if (ctx->datalen < 112) {
         for (i = 0; i < 4; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[128 * i + curlen++] = 0x80;
+            ctx->msgblocks[(128 * i) + curlen++] = 0x80;
             while (curlen < 128) {
-                ctx->msgblocks[128 * i + curlen++] = 0x00;
+                ctx->msgblocks[(128 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 4; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[128 * i + curlen++] = 0x80;
+            ctx->msgblocks[(128 * i) + curlen++] = 0x80;
             while (curlen < 128) {
-                ctx->msgblocks[128 * i + curlen++] = 0x00;
+                ctx->msgblocks[(128 * i) + curlen++] = 0x00;
             }
         }
         sha512_transform4x(
@@ -320,15 +321,15 @@ static void _sha512x4(
     // Add length of the message to each block
     ctx->msglen += (unsigned long long)(ctx->datalen) * 8;
     for (i = 0; i < 4; i++) {
-        ctx->msgblocks[128 * i + 127] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[128 * i + 126] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[128 * i + 125] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[128 * i + 124] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[128 * i + 123] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[128 * i + 122] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[128 * i + 121] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[128 * i + 120] = (unsigned char)(ctx->msglen >> 56);
-        memset( &ctx->msgblocks[128 * i + 112], 0, 8 );
+        ctx->msgblocks[(128 * i) + 127] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(128 * i) + 126] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(128 * i) + 125] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(128 * i) + 124] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(128 * i) + 123] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(128 * i) + 122] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(128 * i) + 121] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(128 * i) + 120] = (unsigned char)(ctx->msglen >> 56);
+        memset( &ctx->msgblocks[(128 * i) + 112], 0, 8 );
     }
     sha512_transform4x(
         ctx,
@@ -361,6 +362,7 @@ static void _sha512x4(
     memcpy(out3, out, 64);
 }
 
+
 /**
  * Note that inlen should be sufficiently small that it still allows for
  * an array to be allocated on the stack. Typically 'in' is merely a seed.
@@ -377,10 +379,10 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx4 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx4 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx4 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx4 + 3 * (inlen + 4), in3, inlen);
+    memcpy(inbufx4 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx4 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx4 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx4 + (3 * (inlen + 4)), in3, inlen);
 
     /* While we can fit in at least another full block of SHA512 output.. */
     unsigned long remaining = outlen;
@@ -391,7 +393,7 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
         }
         remaining -= this_step;
         for (j = 0; j < 4; j++) {
-            u32_to_bytes(inbufx4 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx4 + inlen + (j * (inlen + 4)), i);
         }
 
         sha512x4ctx ctx;
@@ -399,21 +401,21 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
 
         _sha512x4(
             &ctx,
-            outbuf + 0 * 64,
-            outbuf + 1 * 64,
-            outbuf + 2 * 64,
-            outbuf + 3 * 64,
-            inbufx4 + 0 * (inlen + 4),
-            inbufx4 + 1 * (inlen + 4),
-            inbufx4 + 2 * (inlen + 4),
-            inbufx4 + 3 * (inlen + 4),
+            outbuf + (0 * 64),
+            outbuf + (1 * 64),
+            outbuf + (2 * 64),
+            outbuf + (3 * 64),
+            inbufx4 + (0 * (inlen + 4)),
+            inbufx4 + (1 * (inlen + 4)),
+            inbufx4 + (2 * (inlen + 4)),
+            inbufx4 + (3 * (inlen + 4)),
             inlen + 4
         );
 
-        memcpy(outx4 + 0 * outlen, outbuf + 0 * 64, this_step);
-        memcpy(outx4 + 1 * outlen, outbuf + 1 * 64, this_step);
-        memcpy(outx4 + 2 * outlen, outbuf + 2 * 64, this_step);
-        memcpy(outx4 + 3 * outlen, outbuf + 3 * 64, this_step);
+        memcpy(outx4 + (0 * outlen), outbuf + (0 * 64), this_step);
+        memcpy(outx4 + (1 * outlen), outbuf + (1 * 64), this_step);
+        memcpy(outx4 + (2 * outlen), outbuf + (2 * 64), this_step);
+        memcpy(outx4 + (3 * outlen), outbuf + (3 * 64), this_step);
         outx4 += this_step;
     }
 }

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/sha512x4.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/sha512x4.h
@@ -4,6 +4,7 @@
 #include <immintrin.h>
 #include <stdint.h>
 
+
 #include "params.h"
 
 typedef struct SHA512state4x {
@@ -23,6 +24,7 @@ void sha512_transform4x(
     const unsigned char *d1,
     const unsigned char *d2,
     const unsigned char *d3);
+
 
 #define sha512x4_seeded SPX_NAMESPACE(sha512x4_seeded)
 void sha512x4_seeded(

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/thash_sha2_simple.c
@@ -1,9 +1,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
@@ -24,7 +25,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -32,7 +33,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
 
@@ -40,7 +41,7 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
                       const spx_ctx *ctx, uint32_t addr[8]) {
     unsigned char outbuf[SPX_SHA512_OUTPUT_BYTES];
     sha512ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha512_inc_ctx_clone(&sha2_state, &ctx->state_seeded_512);
@@ -48,6 +49,6 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/thash_sha2_simplex8.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/thash_sha2_simplex8.c
@@ -1,13 +1,12 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thashx8.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
 #include "utils.h"
 
@@ -67,61 +66,61 @@ void thashx8(unsigned char *out0,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }
 
 /**
@@ -153,60 +152,60 @@ static void thashx8_512(
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha512x4_seeded(
-        outbuf + 0 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 1 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 2 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 3 * SPX_SHA512_OUTPUT_BYTES,
+        outbuf + (0 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (1 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (2 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (3 * SPX_SHA512_OUTPUT_BYTES),
         &ctx->statex4_seeded_512, /* seed */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), /* in */
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), /* in */
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbuf + 0 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbuf + 1 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbuf + 2 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbuf + 3 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbuf + (0 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbuf + (1 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbuf + (2 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbuf + (3 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
 
     sha512x4_seeded(
-        outbuf + 0 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 1 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 2 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 3 * SPX_SHA512_OUTPUT_BYTES,
+        outbuf + (0 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (1 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (2 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (3 * SPX_SHA512_OUTPUT_BYTES),
         &ctx->statex4_seeded_512, /* seed */
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), /* in */
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), /* in */
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out4, outbuf + 0 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbuf + 1 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbuf + 2 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbuf + 3 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
+    memcpy(out4, outbuf + (0 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbuf + (1 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbuf + (2 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbuf + (3 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/utilsx8.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/utilsx8.c
@@ -1,5 +1,7 @@
+#include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "utils.h"
 #include "utilsx8.h"
 
@@ -56,7 +58,7 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = ((uint32_t)1 << (tree_height - 3)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[8 * SPX_N]; /* Current logical node */
-        gen_leafx8( current, ctx, 8 * idx + idx_offset,
+        gen_leafx8( current, ctx, (8 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
             uint32_t j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 8; j++) {
-                set_tree_height(tree_addrx8 + j * 8, h + 1);
-                set_tree_index(tree_addrx8 + j * 8,
-                               (8 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx8 + (j * 8), h + 1);
+                set_tree_index(tree_addrx8 + (j * 8),
+                               ((8 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx8[h * 8 * SPX_N];
             thashx8( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx8.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
-#include "utilsx8.h"
 #include "wotsx8.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, ..., addr} */
     for (j = 0; j < 8; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 8) {
         for (j = 0; j < 8 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx8(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -206,8 +204,8 @@ void wots_gen_leafx8(unsigned char *dest,
     }
 
     for (j = 0; j < 8; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -216,22 +214,22 @@ void wots_gen_leafx8(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 8; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx8(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
-                   buffer + 4 * wots_offset,
-                   buffer + 5 * wots_offset,
-                   buffer + 6 * wots_offset,
-                   buffer + 7 * wots_offset,
+        prf_addrx8(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
+                   buffer + (4 * wots_offset),
+                   buffer + (5 * wots_offset),
+                   buffer + (6 * wots_offset),
+                   buffer + (7 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 8; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -239,8 +237,8 @@ void wots_gen_leafx8(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -250,42 +248,42 @@ void wots_gen_leafx8(unsigned char *dest,
 
             /* Iterate one step on all 8 chains */
             for (j = 0; j < 8; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx8(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset, 1, ctx, leaf_addr);
+            thashx8(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx8(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            dest + 4 * SPX_N,
-            dest + 5 * SPX_N,
-            dest + 6 * SPX_N,
-            dest + 7 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset,
-            pk_buffer + 4 * wots_offset,
-            pk_buffer + 5 * wots_offset,
-            pk_buffer + 6 * wots_offset,
-            pk_buffer + 7 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx8(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            dest + (4 * SPX_N),
+            dest + (5 * SPX_N),
+            dest + (6 * SPX_N),
+            dest + (7 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset),
+            pk_buffer + (4 * wots_offset),
+            pk_buffer + (5 * wots_offset),
+            pk_buffer + (6 * wots_offset),
+            pk_buffer + (7 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-sha2-256f-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/address.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/context_sha2.c
@@ -1,4 +1,9 @@
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha2_offsets.h"
+#include <stddef.h>
+#include <stdint.h>
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -22,6 +27,7 @@ static void seed_state(spx_ctx *ctx) {
     sha512_inc_init(&ctx->state_seeded_512);
     sha512_inc_blocks(&ctx->state_seeded_512, block, 1);
 }
+
 
 /* We initialize the state for the hash functions */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/fors.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/params.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/thash_sha2_simple.c
@@ -1,9 +1,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
@@ -24,7 +25,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -32,7 +33,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
 
@@ -40,7 +41,7 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
                       const spx_ctx *ctx, uint32_t addr[8]) {
     unsigned char outbuf[SPX_SHA512_OUTPUT_BYTES];
     sha512ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha512_inc_ctx_clone(&sha2_state, &ctx->state_seeded_512);
@@ -48,6 +49,6 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/utils.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/utils.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/wots.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/wots.h
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-256f-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-sha2-256f-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-sha2-256s-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-256s-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-256s-simple/META.yml
+++ b/crypto_sign/sphincs-sha2-256s-simple/META.yml
@@ -28,9 +28,9 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/address.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/context.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/context.h
@@ -19,6 +19,7 @@ typedef struct {
     uint8_t sk_seed[SPX_N];
 } spx_ctx;
 
+
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)
 void initialize_hash_function(spx_ctx *ctx);
 

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/context_sha2.c
@@ -1,6 +1,13 @@
 #include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha256avx.h"
+#include "sha2_offsets.h"
+#include "sha512x4.h"
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -40,7 +47,9 @@ static void seed_state(spx_ctx *ctx) {
     ctx->statex4_seeded_512.datalen = 0;
     ctx->statex4_seeded_512.msglen = 1024;
 
+
 }
+
 
 /* For SHA, we initialize the hash function at the start */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/fors.c
@@ -1,12 +1,13 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
+
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
@@ -71,40 +72,40 @@ static void fors_gen_leafx8(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 8; j++) {
-        set_tree_index(fors_leaf_addrx8 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx8 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx8(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
-                  leaf + 4 * SPX_N,
-                  leaf + 5 * SPX_N,
-                  leaf + 6 * SPX_N,
-                  leaf + 7 * SPX_N,
+    fors_gen_skx8(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
+                  leaf + (4 * SPX_N),
+                  leaf + (5 * SPX_N),
+                  leaf + (6 * SPX_N),
+                  leaf + (7 * SPX_N),
                   ctx, fors_leaf_addrx8);
 
     for (j = 0; j < 8; j++) {
-        set_type(fors_leaf_addrx8 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx8 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx8(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 4 * SPX_N,
-                      leaf + 5 * SPX_N,
-                      leaf + 6 * SPX_N,
-                      leaf + 7 * SPX_N,
+    fors_sk_to_leafx8(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (4 * SPX_N),
+                      leaf + (5 * SPX_N),
+                      leaf + (6 * SPX_N),
+                      leaf + (7 * SPX_N),
                       ctx, fors_leaf_addrx8);
 }
 
@@ -144,9 +145,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -166,7 +167,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx8(roots + i * SPX_N, sig, ctx,
+        treehashx8(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx8,
                    fors_tree_addr, &fors_info);
 
@@ -215,7 +216,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/hash_sha2x8.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/hash_sha2x8.c
@@ -1,15 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 #include "hashx8.h"
 
-#include "address.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
-#include "utils.h"
+#include "sha2_offsets.h"
 
 /*
  * 8-way parallel version of prf_addr; takes 8x as much input and output
@@ -29,10 +27,10 @@ void prf_addrx8(unsigned char *out0,
     unsigned int j;
 
     for (j = 0; j < 8; j++) {
-        memcpy(bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES),
-               addrx8 + j * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)),
+               addrx8 + (j * 8), SPX_SHA256_ADDR_BYTES);
         memcpy(
-            bufx8 + j * (SPX_N + SPX_SHA256_ADDR_BYTES) + SPX_SHA256_ADDR_BYTES,
+            bufx8 + (j * (SPX_N + SPX_SHA256_ADDR_BYTES)) + SPX_SHA256_ADDR_BYTES,
             ctx->sk_seed,
             SPX_N
         );
@@ -40,36 +38,36 @@ void prf_addrx8(unsigned char *out0,
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + SPX_N),
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + SPX_N)),
         SPX_SHA256_ADDR_BYTES + SPX_N /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx8.h"
 #include "wots.h"
 #include "wotsx8.h"
@@ -52,7 +51,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/params.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/sha256avx.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/sha256avx.c
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "sha256avx.h"
@@ -99,14 +98,14 @@ void sha256_ctx_clone8x(sha256x8ctx *out, const sha256x8ctx *in) {
 }
 
 void sha256_init8x(sha256x8ctx *ctx) {
-    ctx->s[0] = _mm256_set_epi32((int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667, (int)0x6a09e667);
+    ctx->s[0] = _mm256_set_epi32(0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667);
     ctx->s[1] = _mm256_set_epi32((int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85, (int)0xbb67ae85);
-    ctx->s[2] = _mm256_set_epi32((int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372, (int)0x3c6ef372);
+    ctx->s[2] = _mm256_set_epi32(0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372, 0x3c6ef372);
     ctx->s[3] = _mm256_set_epi32((int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a, (int)0xa54ff53a);
-    ctx->s[4] = _mm256_set_epi32((int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f, (int)0x510e527f);
+    ctx->s[4] = _mm256_set_epi32(0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f, 0x510e527f);
     ctx->s[5] = _mm256_set_epi32((int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c, (int)0x9b05688c);
-    ctx->s[6] = _mm256_set_epi32((int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab, (int)0x1f83d9ab);
-    ctx->s[7] = _mm256_set_epi32((int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19, (int)0x5be0cd19);
+    ctx->s[6] = _mm256_set_epi32(0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab, 0x1f83d9ab);
+    ctx->s[7] = _mm256_set_epi32(0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19, 0x5be0cd19);
 
     ctx->datalen = 0;
     ctx->msglen = 0;
@@ -127,17 +126,17 @@ void sha256_final8x(sha256x8ctx *ctx,
     if (ctx->datalen < 56) {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 8; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[64 * i + curlen++] = 0x80;
+            ctx->msgblocks[(64 * i) + curlen++] = 0x80;
             while (curlen < 64) {
-                ctx->msgblocks[64 * i + curlen++] = 0x00;
+                ctx->msgblocks[(64 * i) + curlen++] = 0x00;
             }
         }
         sha256_transform8x(ctx,
@@ -156,14 +155,14 @@ void sha256_final8x(sha256x8ctx *ctx,
     // Add length of the message to each block
     ctx->msglen += ctx->datalen * 8;
     for (i = 0; i < 8; i++) {
-        ctx->msgblocks[64 * i + 63] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[64 * i + 62] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[64 * i + 61] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[64 * i + 60] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[64 * i + 59] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[64 * i + 58] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[64 * i + 57] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[64 * i + 56] = (unsigned char)(ctx->msglen >> 56);
+        ctx->msgblocks[(64 * i) + 63] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(64 * i) + 62] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(64 * i) + 61] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(64 * i) + 60] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(64 * i) + 59] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(64 * i) + 58] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(64 * i) + 57] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(64 * i) + 56] = (unsigned char)(ctx->msglen >> 56);
     }
     sha256_transform8x(ctx,
                        &ctx->msgblocks[64 * 0],

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/sha256x8.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/sha256x8.c
@@ -1,7 +1,9 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "sha256avx.h"
 #include "sha256x8.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 // Performs sha256x8 on an initialized (and perhaps seeded) state.
@@ -123,63 +125,63 @@ void mgf1x8(unsigned char *outx8, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx8 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx8 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx8 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx8 + 3 * (inlen + 4), in3, inlen);
-    memcpy(inbufx8 + 4 * (inlen + 4), in4, inlen);
-    memcpy(inbufx8 + 5 * (inlen + 4), in5, inlen);
-    memcpy(inbufx8 + 6 * (inlen + 4), in6, inlen);
-    memcpy(inbufx8 + 7 * (inlen + 4), in7, inlen);
+    memcpy(inbufx8 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx8 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx8 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx8 + (3 * (inlen + 4)), in3, inlen);
+    memcpy(inbufx8 + (4 * (inlen + 4)), in4, inlen);
+    memcpy(inbufx8 + (5 * (inlen + 4)), in5, inlen);
+    memcpy(inbufx8 + (6 * (inlen + 4)), in6, inlen);
+    memcpy(inbufx8 + (7 * (inlen + 4)), in7, inlen);
 
     /* While we can fit in at least another full block of SHA256 output.. */
     for (i = 0; (i + 1) * SPX_SHA256_OUTPUT_BYTES <= outlen; i++) {
         for (j = 0; j < 8; j++) {
-            u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
         }
 
-        sha256x8(outx8 + 0 * outlen,
-                 outx8 + 1 * outlen,
-                 outx8 + 2 * outlen,
-                 outx8 + 3 * outlen,
-                 outx8 + 4 * outlen,
-                 outx8 + 5 * outlen,
-                 outx8 + 6 * outlen,
-                 outx8 + 7 * outlen,
-                 inbufx8 + 0 * (inlen + 4),
-                 inbufx8 + 1 * (inlen + 4),
-                 inbufx8 + 2 * (inlen + 4),
-                 inbufx8 + 3 * (inlen + 4),
-                 inbufx8 + 4 * (inlen + 4),
-                 inbufx8 + 5 * (inlen + 4),
-                 inbufx8 + 6 * (inlen + 4),
-                 inbufx8 + 7 * (inlen + 4), inlen + 4);
+        sha256x8(outx8 + (0 * outlen),
+                 outx8 + (1 * outlen),
+                 outx8 + (2 * outlen),
+                 outx8 + (3 * outlen),
+                 outx8 + (4 * outlen),
+                 outx8 + (5 * outlen),
+                 outx8 + (6 * outlen),
+                 outx8 + (7 * outlen),
+                 inbufx8 + (0 * (inlen + 4)),
+                 inbufx8 + (1 * (inlen + 4)),
+                 inbufx8 + (2 * (inlen + 4)),
+                 inbufx8 + (3 * (inlen + 4)),
+                 inbufx8 + (4 * (inlen + 4)),
+                 inbufx8 + (5 * (inlen + 4)),
+                 inbufx8 + (6 * (inlen + 4)),
+                 inbufx8 + (7 * (inlen + 4)), inlen + 4);
         outx8 += SPX_SHA256_OUTPUT_BYTES;
     }
     /* Until we cannot anymore, and we fill the remainder. */
     for (j = 0; j < 8; j++) {
-        u32_to_bytes(inbufx8 + inlen + j * (inlen + 4), i);
+        u32_to_bytes(inbufx8 + inlen + (j * (inlen + 4)), i);
     }
-    sha256x8(outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-             outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
-             inbufx8 + 0 * (inlen + 4),
-             inbufx8 + 1 * (inlen + 4),
-             inbufx8 + 2 * (inlen + 4),
-             inbufx8 + 3 * (inlen + 4),
-             inbufx8 + 4 * (inlen + 4),
-             inbufx8 + 5 * (inlen + 4),
-             inbufx8 + 6 * (inlen + 4),
-             inbufx8 + 7 * (inlen + 4), inlen + 4);
+    sha256x8(outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+             outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
+             inbufx8 + (0 * (inlen + 4)),
+             inbufx8 + (1 * (inlen + 4)),
+             inbufx8 + (2 * (inlen + 4)),
+             inbufx8 + (3 * (inlen + 4)),
+             inbufx8 + (4 * (inlen + 4)),
+             inbufx8 + (5 * (inlen + 4)),
+             inbufx8 + (6 * (inlen + 4)),
+             inbufx8 + (7 * (inlen + 4)), inlen + 4);
 
     for (j = 0; j < 8; j++) {
-        memcpy(outx8 + j * outlen,
-               outbufx8 + j * SPX_SHA256_OUTPUT_BYTES,
-               outlen - i * SPX_SHA256_OUTPUT_BYTES);
+        memcpy(outx8 + (j * outlen),
+               outbufx8 + (j * SPX_SHA256_OUTPUT_BYTES),
+               outlen - (i * SPX_SHA256_OUTPUT_BYTES));
     }
 }

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/sha256x8.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/sha256x8.h
@@ -4,6 +4,8 @@
 #include "params.h"
 #include "sha256avx.h"
 
+
+
 #define sha256x8_seeded SPX_NAMESPACE(sha256x8_seeded)
 void sha256x8_seeded(
     unsigned char *out0,

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/sha512x4.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/sha512x4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 /* pull in the entire thing */
 #include "sha512x4.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 typedef uint64_t u64;
@@ -40,6 +40,7 @@ static void transpose(u256 s[4]) {
     s[2] = _mm256_permute2x128_si256(tmp[0], tmp[2], 0x31);
     s[3] = _mm256_permute2x128_si256(tmp[1], tmp[3], 0x31);
 }
+
 
 void sha512_init4x(sha512x4ctx *ctx) {
 #define SET4(x) _mm256_set_epi64x((long long)(x), (long long)(x), (long long)(x), (long long)(x))
@@ -294,17 +295,17 @@ static void _sha512x4(
     if (ctx->datalen < 112) {
         for (i = 0; i < 4; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[128 * i + curlen++] = 0x80;
+            ctx->msgblocks[(128 * i) + curlen++] = 0x80;
             while (curlen < 128) {
-                ctx->msgblocks[128 * i + curlen++] = 0x00;
+                ctx->msgblocks[(128 * i) + curlen++] = 0x00;
             }
         }
     } else {
         for (i = 0; i < 4; ++i) {
             curlen = ctx->datalen;
-            ctx->msgblocks[128 * i + curlen++] = 0x80;
+            ctx->msgblocks[(128 * i) + curlen++] = 0x80;
             while (curlen < 128) {
-                ctx->msgblocks[128 * i + curlen++] = 0x00;
+                ctx->msgblocks[(128 * i) + curlen++] = 0x00;
             }
         }
         sha512_transform4x(
@@ -320,15 +321,15 @@ static void _sha512x4(
     // Add length of the message to each block
     ctx->msglen += (unsigned long long)(ctx->datalen) * 8;
     for (i = 0; i < 4; i++) {
-        ctx->msgblocks[128 * i + 127] = (unsigned char)(ctx->msglen);
-        ctx->msgblocks[128 * i + 126] = (unsigned char)(ctx->msglen >> 8);
-        ctx->msgblocks[128 * i + 125] = (unsigned char)(ctx->msglen >> 16);
-        ctx->msgblocks[128 * i + 124] = (unsigned char)(ctx->msglen >> 24);
-        ctx->msgblocks[128 * i + 123] = (unsigned char)(ctx->msglen >> 32);
-        ctx->msgblocks[128 * i + 122] = (unsigned char)(ctx->msglen >> 40);
-        ctx->msgblocks[128 * i + 121] = (unsigned char)(ctx->msglen >> 48);
-        ctx->msgblocks[128 * i + 120] = (unsigned char)(ctx->msglen >> 56);
-        memset( &ctx->msgblocks[128 * i + 112], 0, 8 );
+        ctx->msgblocks[(128 * i) + 127] = (unsigned char)(ctx->msglen);
+        ctx->msgblocks[(128 * i) + 126] = (unsigned char)(ctx->msglen >> 8);
+        ctx->msgblocks[(128 * i) + 125] = (unsigned char)(ctx->msglen >> 16);
+        ctx->msgblocks[(128 * i) + 124] = (unsigned char)(ctx->msglen >> 24);
+        ctx->msgblocks[(128 * i) + 123] = (unsigned char)(ctx->msglen >> 32);
+        ctx->msgblocks[(128 * i) + 122] = (unsigned char)(ctx->msglen >> 40);
+        ctx->msgblocks[(128 * i) + 121] = (unsigned char)(ctx->msglen >> 48);
+        ctx->msgblocks[(128 * i) + 120] = (unsigned char)(ctx->msglen >> 56);
+        memset( &ctx->msgblocks[(128 * i) + 112], 0, 8 );
     }
     sha512_transform4x(
         ctx,
@@ -361,6 +362,7 @@ static void _sha512x4(
     memcpy(out3, out, 64);
 }
 
+
 /**
  * Note that inlen should be sufficiently small that it still allows for
  * an array to be allocated on the stack. Typically 'in' is merely a seed.
@@ -377,10 +379,10 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
     uint32_t i;
     unsigned int j;
 
-    memcpy(inbufx4 + 0 * (inlen + 4), in0, inlen);
-    memcpy(inbufx4 + 1 * (inlen + 4), in1, inlen);
-    memcpy(inbufx4 + 2 * (inlen + 4), in2, inlen);
-    memcpy(inbufx4 + 3 * (inlen + 4), in3, inlen);
+    memcpy(inbufx4 + (0 * (inlen + 4)), in0, inlen);
+    memcpy(inbufx4 + (1 * (inlen + 4)), in1, inlen);
+    memcpy(inbufx4 + (2 * (inlen + 4)), in2, inlen);
+    memcpy(inbufx4 + (3 * (inlen + 4)), in3, inlen);
 
     /* While we can fit in at least another full block of SHA512 output.. */
     unsigned long remaining = outlen;
@@ -391,7 +393,7 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
         }
         remaining -= this_step;
         for (j = 0; j < 4; j++) {
-            u32_to_bytes(inbufx4 + inlen + j * (inlen + 4), i);
+            u32_to_bytes(inbufx4 + inlen + (j * (inlen + 4)), i);
         }
 
         sha512x4ctx ctx;
@@ -399,21 +401,21 @@ void mgf1x4_512(unsigned char *outx4, unsigned long outlen,
 
         _sha512x4(
             &ctx,
-            outbuf + 0 * 64,
-            outbuf + 1 * 64,
-            outbuf + 2 * 64,
-            outbuf + 3 * 64,
-            inbufx4 + 0 * (inlen + 4),
-            inbufx4 + 1 * (inlen + 4),
-            inbufx4 + 2 * (inlen + 4),
-            inbufx4 + 3 * (inlen + 4),
+            outbuf + (0 * 64),
+            outbuf + (1 * 64),
+            outbuf + (2 * 64),
+            outbuf + (3 * 64),
+            inbufx4 + (0 * (inlen + 4)),
+            inbufx4 + (1 * (inlen + 4)),
+            inbufx4 + (2 * (inlen + 4)),
+            inbufx4 + (3 * (inlen + 4)),
             inlen + 4
         );
 
-        memcpy(outx4 + 0 * outlen, outbuf + 0 * 64, this_step);
-        memcpy(outx4 + 1 * outlen, outbuf + 1 * 64, this_step);
-        memcpy(outx4 + 2 * outlen, outbuf + 2 * 64, this_step);
-        memcpy(outx4 + 3 * outlen, outbuf + 3 * 64, this_step);
+        memcpy(outx4 + (0 * outlen), outbuf + (0 * 64), this_step);
+        memcpy(outx4 + (1 * outlen), outbuf + (1 * 64), this_step);
+        memcpy(outx4 + (2 * outlen), outbuf + (2 * 64), this_step);
+        memcpy(outx4 + (3 * outlen), outbuf + (3 * 64), this_step);
         outx4 += this_step;
     }
 }

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/sha512x4.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/sha512x4.h
@@ -4,6 +4,7 @@
 #include <immintrin.h>
 #include <stdint.h>
 
+
 #include "params.h"
 
 typedef struct SHA512state4x {
@@ -23,6 +24,7 @@ void sha512_transform4x(
     const unsigned char *d1,
     const unsigned char *d2,
     const unsigned char *d3);
+
 
 #define sha512x4_seeded SPX_NAMESPACE(sha512x4_seeded)
 void sha512x4_seeded(

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/thash_sha2_simple.c
@@ -1,9 +1,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
@@ -24,7 +25,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -32,7 +33,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
 
@@ -40,7 +41,7 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
                       const spx_ctx *ctx, uint32_t addr[8]) {
     unsigned char outbuf[SPX_SHA512_OUTPUT_BYTES];
     sha512ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha512_inc_ctx_clone(&sha2_state, &ctx->state_seeded_512);
@@ -48,6 +49,6 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/thash_sha2_simplex8.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/thash_sha2_simplex8.c
@@ -1,13 +1,12 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thashx8.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
-#include "sha2.h"
-#include "sha256avx.h"
 #include "sha256x8.h"
 #include "utils.h"
 
@@ -67,61 +66,61 @@ void thashx8(unsigned char *out0,
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha256x8_seeded(
         /* out */
-        outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES,
-        outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES,
+        outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES),
+        outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES),
 
         /* seed */
         &ctx->statex8_seeded,
 
         /* in */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbufx8 + 0 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbufx8 + 1 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbufx8 + 2 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbufx8 + 3 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out4, outbufx8 + 4 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbufx8 + 5 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbufx8 + 6 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbufx8 + 7 * SPX_SHA256_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbufx8 + (0 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbufx8 + (1 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbufx8 + (2 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbufx8 + (3 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out4, outbufx8 + (4 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbufx8 + (5 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbufx8 + (6 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbufx8 + (7 * SPX_SHA256_OUTPUT_BYTES), SPX_N);
 }
 
 /**
@@ -153,60 +152,60 @@ static void thashx8_512(
     unsigned int i;
 
     for (i = 0; i < 8; i++) {
-        memcpy(bufx8 + i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-               addrx8 + i * 8, SPX_SHA256_ADDR_BYTES);
+        memcpy(bufx8 + (i * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+               addrx8 + (i * 8), SPX_SHA256_ADDR_BYTES);
     }
 
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in0, inblocks * SPX_N);
+           (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in0, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in1, inblocks * SPX_N);
+           (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in1, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in2, inblocks * SPX_N);
+           (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in2, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in3, inblocks * SPX_N);
+           (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in3, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in4, inblocks * SPX_N);
+           (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in4, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in5, inblocks * SPX_N);
+           (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in5, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in6, inblocks * SPX_N);
+           (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in6, inblocks * SPX_N);
     memcpy(bufx8 + SPX_SHA256_ADDR_BYTES +
-           7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), in7, inblocks * SPX_N);
+           (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), in7, inblocks * SPX_N);
 
     sha512x4_seeded(
-        outbuf + 0 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 1 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 2 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 3 * SPX_SHA512_OUTPUT_BYTES,
+        outbuf + (0 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (1 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (2 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (3 * SPX_SHA512_OUTPUT_BYTES),
         &ctx->statex4_seeded_512, /* seed */
-        bufx8 + 0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), /* in */
-        bufx8 + 1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (0 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), /* in */
+        bufx8 + (1 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (2 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (3 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out0, outbuf + 0 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out1, outbuf + 1 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out2, outbuf + 2 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out3, outbuf + 3 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
+    memcpy(out0, outbuf + (0 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out1, outbuf + (1 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out2, outbuf + (2 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out3, outbuf + (3 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
 
     sha512x4_seeded(
-        outbuf + 0 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 1 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 2 * SPX_SHA512_OUTPUT_BYTES,
-        outbuf + 3 * SPX_SHA512_OUTPUT_BYTES,
+        outbuf + (0 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (1 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (2 * SPX_SHA512_OUTPUT_BYTES),
+        outbuf + (3 * SPX_SHA512_OUTPUT_BYTES),
         &ctx->statex4_seeded_512, /* seed */
-        bufx8 + 4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N), /* in */
-        bufx8 + 5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        bufx8 + 7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N),
-        SPX_SHA256_ADDR_BYTES + inblocks * SPX_N /* len */
+        bufx8 + (4 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)), /* in */
+        bufx8 + (5 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (6 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        bufx8 + (7 * (SPX_SHA256_ADDR_BYTES + inblocks * SPX_N)),
+        SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N) /* len */
     );
 
-    memcpy(out4, outbuf + 0 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out5, outbuf + 1 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out6, outbuf + 2 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
-    memcpy(out7, outbuf + 3 * SPX_SHA512_OUTPUT_BYTES, SPX_N);
+    memcpy(out4, outbuf + (0 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out5, outbuf + (1 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out6, outbuf + (2 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
+    memcpy(out7, outbuf + (3 * SPX_SHA512_OUTPUT_BYTES), SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/utilsx8.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/utilsx8.c
@@ -1,5 +1,7 @@
+#include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "utils.h"
 #include "utilsx8.h"
 
@@ -56,7 +58,7 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = ((uint32_t)1 << (tree_height - 3)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[8 * SPX_N]; /* Current logical node */
-        gen_leafx8( current, ctx, 8 * idx + idx_offset,
+        gen_leafx8( current, ctx, (8 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx8(unsigned char *root, unsigned char *auth_path,
             uint32_t j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 8; j++) {
-                set_tree_height(tree_addrx8 + j * 8, h + 1);
-                set_tree_index(tree_addrx8 + j * 8,
-                               (8 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx8 + (j * 8), h + 1);
+                set_tree_index(tree_addrx8 + (j * 8),
+                               ((8 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx8[h * 8 * SPX_N];
             thashx8( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx8.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx8.h"
 #include "utils.h"
-#include "utilsx8.h"
 #include "wotsx8.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, ..., addr} */
     for (j = 0; j < 8; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 8) {
         for (j = 0; j < 8 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx8(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -206,8 +204,8 @@ void wots_gen_leafx8(unsigned char *dest,
     }
 
     for (j = 0; j < 8; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -216,22 +214,22 @@ void wots_gen_leafx8(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 8; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx8(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
-                   buffer + 4 * wots_offset,
-                   buffer + 5 * wots_offset,
-                   buffer + 6 * wots_offset,
-                   buffer + 7 * wots_offset,
+        prf_addrx8(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
+                   buffer + (4 * wots_offset),
+                   buffer + (5 * wots_offset),
+                   buffer + (6 * wots_offset),
+                   buffer + (7 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 8; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -239,8 +237,8 @@ void wots_gen_leafx8(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -250,42 +248,42 @@ void wots_gen_leafx8(unsigned char *dest,
 
             /* Iterate one step on all 8 chains */
             for (j = 0; j < 8; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx8(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 4 * wots_offset,
-                    buffer + 5 * wots_offset,
-                    buffer + 6 * wots_offset,
-                    buffer + 7 * wots_offset, 1, ctx, leaf_addr);
+            thashx8(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (4 * wots_offset),
+                    buffer + (5 * wots_offset),
+                    buffer + (6 * wots_offset),
+                    buffer + (7 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx8(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            dest + 4 * SPX_N,
-            dest + 5 * SPX_N,
-            dest + 6 * SPX_N,
-            dest + 7 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset,
-            pk_buffer + 4 * wots_offset,
-            pk_buffer + 5 * wots_offset,
-            pk_buffer + 6 * wots_offset,
-            pk_buffer + 7 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx8(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            dest + (4 * SPX_N),
+            dest + (5 * SPX_N),
+            dest + (6 * SPX_N),
+            dest + (7 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset),
+            pk_buffer + (4 * wots_offset),
+            pk_buffer + (5 * wots_offset),
+            pk_buffer + (6 * wots_offset),
+            pk_buffer + (7 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-sha2-256s-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/address.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "sha2_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/context_sha2.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/context_sha2.c
@@ -1,4 +1,9 @@
 #include "context.h"
+#include "params.h"
+#include "sha2.h"
+#include "sha2_offsets.h"
+#include <stddef.h>
+#include <stdint.h>
 
 /**
  * Absorb the constant pub_seed using one round of the compression function
@@ -22,6 +27,7 @@ static void seed_state(spx_ctx *ctx) {
     sha512_inc_init(&ctx->state_seeded_512);
     sha512_inc_blocks(&ctx->state_seeded_512, block, 1);
 }
+
 
 /* We initialize the state for the hash functions */
 void initialize_hash_function(spx_ctx *ctx) {

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/fors.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/hash.h
@@ -23,6 +23,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
 #   define SPX_SHA256_ADDR_BYTES 22
 
 #   define mgf1_256 SPX_NAMESPACE(mgf1_256)

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/params.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/params.h
@@ -51,10 +51,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "sha2_offsets.h"
 

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/thash_sha2_simple.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/thash_sha2_simple.c
@@ -1,9 +1,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
+#include "sha2_offsets.h"
 #include "thash.h"
 
-#include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "sha2.h"
@@ -24,7 +25,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
 
     unsigned char outbuf[SPX_SHA256_OUTPUT_BYTES];
     sha256ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha256_inc_ctx_clone(&sha2_state, &ctx->state_seeded);
@@ -32,7 +33,7 @@ void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha256_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }
 
@@ -40,7 +41,7 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
                       const spx_ctx *ctx, uint32_t addr[8]) {
     unsigned char outbuf[SPX_SHA512_OUTPUT_BYTES];
     sha512ctx sha2_state;
-    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
 
     /* Retrieve precomputed state containing pub_seed */
     sha512_inc_ctx_clone(&sha2_state, &ctx->state_seeded_512);
@@ -48,6 +49,6 @@ static void thash_512(unsigned char *out, const unsigned char *in, unsigned int 
     memcpy(buf, addr, SPX_SHA256_ADDR_BYTES);
     memcpy(buf + SPX_SHA256_ADDR_BYTES, in, inblocks * SPX_N);
 
-    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + inblocks * SPX_N);
+    sha512_inc_finalize(outbuf, &sha2_state, buf, SPX_SHA256_ADDR_BYTES + (inblocks * SPX_N));
     memcpy(out, outbuf, SPX_N);
 }

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/utils.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/utils.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/wots.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/wots.h
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-sha2-256s-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-sha2-256s-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-shake-128f-simple/META.yml
+++ b/crypto_sign/sphincs-shake-128f-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-128f-simple/META.yml
+++ b/crypto_sign/sphincs-shake-128f-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/address.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/f1600x2.h
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/f1600x2.h
@@ -1,8 +1,10 @@
 #ifndef SPX_F1600X2_H
 #define SPX_F1600X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define f1600_RC SPX_NAMESPACE(f1600_RC)
 extern uint64_t f1600_RC[24];
 extern void _f1600x2(uint64_t *a, uint64_t *rc);
 

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/f1600x2_const.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/f1600x2_const.c
@@ -1,4 +1,5 @@
 #include "f1600x2.h"
+#include <stdint.h>
 
 uint64_t f1600_RC[24] = {
     0x0000000000000001,

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/fips202x2.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/fips202x2.c
@@ -35,8 +35,8 @@ static void keccak_absorb2x(uint64_t *s,
 
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            s[2 * i + 0] ^= load64(m0 + 8 * i);
-            s[2 * i + 1] ^= load64(m1 + 8 * i);
+            s[(2 * i) + 0] ^= load64(m0 + (8 * i));
+            s[(2 * i) + 1] ^= load64(m1 + (8 * i));
         }
 
         f1600x2(s);
@@ -61,10 +61,11 @@ static void keccak_absorb2x(uint64_t *s,
     t1[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        s[2 * i + 0] ^= load64(t0 + 8 * i);
-        s[2 * i + 1] ^= load64(t1 + 8 * i);
+        s[(2 * i) + 0] ^= load64(t0 + (8 * i));
+        s[(2 * i) + 1] ^= load64(t1 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks2x(unsigned char *h0,
                                    unsigned char *h1,
@@ -76,14 +77,16 @@ static void keccak_squeezeblocks2x(unsigned char *h0,
     while (nblocks > 0) {
         f1600x2(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, s[2 * i + 0]);
-            store64(h1 + 8 * i, s[2 * i + 1]);
+            store64(h0 + (8 * i), s[(2 * i) + 0]);
+            store64(h1 + (8 * i), s[(2 * i) + 1]);
         }
         h0 += r;
         h1 += r;
         nblocks--;
     }
 }
+
+
 
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
@@ -113,6 +116,7 @@ void shake128x2(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/fips202x2.h
@@ -6,6 +6,7 @@
 uint64_t load64(const unsigned char *x);
 void store64(uint8_t *x, uint64_t u);
 
+
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/fips202x2.h
@@ -1,12 +1,15 @@
 #ifndef SPX_FIPS202X2_H
 #define SPX_FIPS202X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define load64 SPX_NAMESPACE(load64)
 uint64_t load64(const unsigned char *x);
+#define store64 SPX_NAMESPACE(store64)
 void store64(uint8_t *x, uint64_t u);
 
-
+#define shake128x2 SPX_NAMESPACE(shake128x2)
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,
@@ -14,6 +17,7 @@ void shake128x2(unsigned char *out0,
                 unsigned char *in1,
                 unsigned long long inlen);
 
+#define shake256x2 SPX_NAMESPACE(shake256x2)
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/fors.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx2.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx2.h"
 #include "utils.h"
@@ -55,22 +55,22 @@ static void fors_gen_leafx2(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 2; j++) {
-        set_tree_index(fors_leaf_addrx2 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx2 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx2(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
+    fors_gen_skx2(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
                   ctx, fors_leaf_addrx2);
 
     for (j = 0; j < 2; j++) {
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx2(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
+    fors_sk_to_leafx2(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
                       ctx, fors_leaf_addrx2);
 }
 
@@ -110,9 +110,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 2; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -132,7 +132,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx2(roots + i * SPX_N, sig, ctx,
+        treehashx2(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx2,
                    fors_tree_addr, &fors_info);
 
@@ -181,7 +181,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/hash.h
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/hash_shake.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/hash_shakex2.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/hash_shakex2.c
@@ -1,9 +1,8 @@
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx2.h"
 
-#include "address.h"
 #include "f1600x2.h"
 #include "fips202x2.h"
 #include "params.h"
@@ -20,33 +19,33 @@ void prf_addrx2(unsigned char *out0,
     uint64_t state[50] = {0};
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->pub_seed + 8 * i);
+        uint64_t x = load64(ctx->pub_seed + (8 * i));
         state[2 * i] = x;
-        state[2 * i + 1] = x;
+        state[(2 * i) + 1] = x;
     }
     for (int i = 0; i < 4; i++) {
-        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                      | (uint64_t)addrx2[2 * i];
-        state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                         | (uint64_t)addrx2[8 + 2 * i];
+        state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                           | (uint64_t)addrx2[8 + (2 * i)];
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->sk_seed + 8 * i);
+        uint64_t x = load64(ctx->sk_seed + (8 * i));
         state[2 * (SPX_N / 8 + i + 4)] = x;
-        state[2 * (SPX_N / 8 + i + 4) + 1] = x;
+        state[(2 * (SPX_N / 8 + i + 4)) + 1] = x;
     }
 
     /* SHAKE domain separator and padding. */
     state[2 * (SPX_N / 4 + 4)] = 0x1f;
-    state[2 * (SPX_N / 4 + 4) + 1] = 0x1f;
+    state[(2 * (SPX_N / 4 + 4)) + 1] = 0x1f;
 
     state[2 * 16] = 0x80ULL << 56;
-    state[2 * 16 + 1] = 0x80ULL << 56;
+    state[(2 * 16) + 1] = 0x80ULL << 56;
 
     f1600x2(state);
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        store64(out0 + 8 * i, state[2 * i]);
-        store64(out1 + 8 * i, state[2 * i + 1]);
+        store64(out0 + (8 * i), state[2 * i]);
+        store64(out1 + (8 * i), state[(2 * i) + 1]);
     }
 }

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx2.h"
 #include "wots.h"
 #include "wotsx2.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/params.h
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/sign.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/thash_shake_simplex2.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/thash_shake_simplex2.c
@@ -1,15 +1,16 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 #include "thashx2.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
 #include "f1600x2.h"
 #include "fips202x2.h"
+
 
 void thash(unsigned char *out,
            const unsigned char *in,
@@ -36,47 +37,47 @@ void thashx2(unsigned char *out0,
          * build and extract from the twoway SHAKE256 state by hand. */
         uint64_t state[50] = {0};
         for (int i = 0; i < SPX_N / 8; i++) {
-            uint64_t x = load64(ctx->pub_seed + 8 * i);
+            uint64_t x = load64(ctx->pub_seed + (8 * i));
             state[2 * i] = x;
-            state[2 * i + 1] = x;
+            state[(2 * i) + 1] = x;
         }
         for (int i = 0; i < 4; i++) {
-            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                          | (uint64_t)addrx2[2 * i];
-            state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                             | (uint64_t)addrx2[8 + 2 * i];
+            state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                               | (uint64_t)addrx2[8 + (2 * i)];
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + 8 * i);
-            state[2 * (SPX_N / 8 + 4 + i) + 1] = load64(in1 + 8 * i);
+            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + (8 * i));
+            state[(2 * (SPX_N / 8 + 4 + i)) + 1] = load64(in1 + (8 * i));
         }
 
         /* Domain separator and padding. */
         state[2 * 16] = 0x80ULL << 56;
-        state[2 * 16 + 1] = 0x80ULL << 56;
+        state[(2 * 16) + 1] = 0x80ULL << 56;
 
         state[2 * ((SPX_N / 8) * (1 + inblocks) + 4)] ^= 0x1f;
-        state[2 * ((SPX_N / 8) * (1 + inblocks) + 4) + 1] ^= 0x1f;
+        state[(2 * ((SPX_N / 8) * (1 + inblocks) + 4)) + 1] ^= 0x1f;
 
         f1600x2(state);
 
         for (int i = 0; i < SPX_N / 8; i++) {
-            store64(out0 + 8 * i, state[2 * i]);
-            store64(out1 + 8 * i, state[2 * i + 1]);
+            store64(out0 + (8 * i), state[2 * i]);
+            store64(out1 + (8 * i), state[(2 * i) + 1]);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx2 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx2 + 1 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx2 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx2 + (1 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
 
         shake256x2(out0, out1, SPX_N,
-                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/utils.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/utils.h
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/wots.c
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/wots.c
@@ -2,15 +2,14 @@
 #include <string.h>
 
 #include "wots.h"
+#include "context.h"
 #include "wotsx2.h"
 
 #include "address.h"
-#include "hash.h"
 #include "hashx2.h"
 #include "params.h"
 #include "thashx2.h"
 #include "utils.h"
-#include "utilsx2.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -39,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr} */
     for (j = 0; j < 2; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -64,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 2) {
         for (j = 0; j < 2 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -92,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx2(bufs[0], bufs[1],
@@ -203,8 +202,8 @@ void wots_gen_leafx2(unsigned char *dest,
     }
 
     for (j = 0; j < 2; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -213,15 +212,15 @@ void wots_gen_leafx2(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 2; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx2(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
+        prf_addrx2(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
                    ctx, leaf_addr);
         for (j = 0; j < 2; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -229,8 +228,8 @@ void wots_gen_leafx2(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -240,20 +239,20 @@ void wots_gen_leafx2(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 2; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx2(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
+            thashx2(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
                     1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx2(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
+    thashx2(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
             SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-128f-simple/aarch64/wots.h
+++ b/crypto_sign/sphincs-shake-128f-simple/aarch64/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/address.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/fips202x4.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/fips202x4.c
@@ -46,12 +46,13 @@ static void keccak_absorb4x(__m256i *s,
 
     unsigned long long *ss = (unsigned long long *)s;
 
+
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            ss[4 * i + 0] ^= load64(m0 + 8 * i);
-            ss[4 * i + 1] ^= load64(m1 + 8 * i);
-            ss[4 * i + 2] ^= load64(m2 + 8 * i);
-            ss[4 * i + 3] ^= load64(m3 + 8 * i);
+            ss[(4 * i) + 0] ^= load64(m0 + (8 * i));
+            ss[(4 * i) + 1] ^= load64(m1 + (8 * i));
+            ss[(4 * i) + 2] ^= load64(m2 + (8 * i));
+            ss[(4 * i) + 3] ^= load64(m3 + (8 * i));
         }
 
         KeccakF1600_StatePermute4x(s);
@@ -86,12 +87,13 @@ static void keccak_absorb4x(__m256i *s,
     t3[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        ss[4 * i + 0] ^= load64(t0 + 8 * i);
-        ss[4 * i + 1] ^= load64(t1 + 8 * i);
-        ss[4 * i + 2] ^= load64(t2 + 8 * i);
-        ss[4 * i + 3] ^= load64(t3 + 8 * i);
+        ss[(4 * i) + 0] ^= load64(t0 + (8 * i));
+        ss[(4 * i) + 1] ^= load64(t1 + (8 * i));
+        ss[(4 * i) + 2] ^= load64(t2 + (8 * i));
+        ss[(4 * i) + 3] ^= load64(t3 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks4x(unsigned char *h0,
                                    unsigned char *h1,
@@ -107,10 +109,10 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
     while (nblocks > 0) {
         KeccakF1600_StatePermute4x(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, ss[4 * i + 0]);
-            store64(h1 + 8 * i, ss[4 * i + 1]);
-            store64(h2 + 8 * i, ss[4 * i + 2]);
-            store64(h3 + 8 * i, ss[4 * i + 3]);
+            store64(h0 + (8 * i), ss[(4 * i) + 0]);
+            store64(h1 + (8 * i), ss[(4 * i) + 1]);
+            store64(h2 + (8 * i), ss[(4 * i) + 2]);
+            store64(h3 + (8 * i), ss[(4 * i) + 3]);
         }
         h0 += r;
         h1 += r;
@@ -119,6 +121,8 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
         nblocks--;
     }
 }
+
+
 
 void shake128x4(unsigned char *out0,
                 unsigned char *out1,
@@ -161,6 +165,7 @@ void shake128x4(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x4(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx4.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -60,28 +60,28 @@ static void fors_gen_leafx4(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 4; j++) {
-        set_tree_index(fors_leaf_addrx4 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx4 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx4(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
+    fors_gen_skx4(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
                   ctx, fors_leaf_addrx4);
 
     for (j = 0; j < 4; j++) {
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx4(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
+    fors_sk_to_leafx4(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
                       ctx, fors_leaf_addrx4);
 }
 
@@ -121,9 +121,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 4; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -143,7 +143,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx4(roots + i * SPX_N, sig, ctx,
+        treehashx4(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx4,
                    fors_tree_addr, &fors_info);
 
@@ -192,7 +192,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/hash_shake.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/hash_shakex4.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/hash_shakex4.c
@@ -1,10 +1,9 @@
+#include <immintrin.h>
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx4.h"
 
-#include "address.h"
-#include "fips202x4.h"
 #include "params.h"
 
 extern void KeccakP1600times4_PermuteAll_24rounds(__m256i *s);
@@ -26,24 +25,24 @@ void prf_addrx4(unsigned char *out0,
         state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
     }
     for (int i = 0; i < 4; i++) {
-        state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                   (int)addrx4[3 * 8 + 1 + 2 * i],
-                                   (int)addrx4[3 * 8 + 2 * i],
-                                   (int)addrx4[2 * 8 + 1 + 2 * i],
-                                   (int)addrx4[2 * 8 + 2 * i],
-                                   (int)addrx4[8 + 1 + 2 * i],
-                                   (int)addrx4[8 + 2 * i],
-                                   (int)addrx4[1 + 2 * i],
-                                   (int)addrx4[2 * i]
-                               );
+        state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                     (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(3 * 8) + (2 * i)],
+                                     (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(2 * 8) + (2 * i)],
+                                     (int)addrx4[8 + 1 + (2 * i)],
+                                     (int)addrx4[8 + (2 * i)],
+                                     (int)addrx4[1 + (2 * i)],
+                                     (int)addrx4[2 * i]
+                                 );
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        state[SPX_N / 8 + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
+        state[(SPX_N / 8) + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
     }
 
     /* SHAKE domain separator and padding. */
-    state[SPX_N / 4 + 4] = _mm256_set1_epi64x(0x1f);
-    for (int i = SPX_N / 4 + 5; i < 16; i++) {
+    state[(SPX_N / 4) + 4] = _mm256_set1_epi64x(0x1f);
+    for (int i = (SPX_N / 4) + 5; i < 16; i++) {
         state[i] = _mm256_set1_epi64x(0);
     }
     // shift unsigned and then cast to avoid UB

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx4.h"
 #include "wots.h"
 #include "wotsx4.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/params.h
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/thash_shake_simplex4.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/thash_shake_simplex4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thashx4.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -31,34 +31,34 @@ void thashx4(unsigned char *out0,
             state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
         }
         for (int i = 0; i < 4; i++) {
-            state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                       (int)addrx4[3 * 8 + 1 + 2 * i],
-                                       (int)addrx4[3 * 8 + 2 * i],
-                                       (int)addrx4[2 * 8 + 1 + 2 * i],
-                                       (int)addrx4[2 * 8 + 2 * i],
-                                       (int)addrx4[8 + 1 + 2 * i],
-                                       (int)addrx4[8 + 2 * i],
-                                       (int)addrx4[1 + 2 * i],
-                                       (int)addrx4[2 * i]
-                                   );
+            state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                         (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(3 * 8) + (2 * i)],
+                                         (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(2 * 8) + (2 * i)],
+                                         (int)addrx4[8 + 1 + (2 * i)],
+                                         (int)addrx4[8 + (2 * i)],
+                                         (int)addrx4[1 + (2 * i)],
+                                         (int)addrx4[2 * i]
+                                     );
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[SPX_N / 8 + 4 + i] = _mm256_set_epi64x(
-                                           ((int64_t *)in3)[i],
-                                           ((int64_t *)in2)[i],
-                                           ((int64_t *)in1)[i],
-                                           ((int64_t *)in0)[i]
-                                       );
+            state[(SPX_N / 8) + 4 + i] = _mm256_set_epi64x(
+                                             ((int64_t *)in3)[i],
+                                             ((int64_t *)in2)[i],
+                                             ((int64_t *)in1)[i],
+                                             ((int64_t *)in0)[i]
+                                         );
         }
 
         /* Domain separator and padding. */
-        for (size_t i = (SPX_N / 8) * (1 + inblocks) + 4; i < 16; i++) {
+        for (size_t i = ((SPX_N / 8) * (1 + inblocks)) + 4; i < 16; i++) {
             state[i] = _mm256_set1_epi64x(0);
         }
         state[16] = _mm256_set1_epi64x((long long)(0x80ULL << 56));
-        state[(SPX_N / 8) * (1 + inblocks) + 4] = _mm256_xor_si256(
-                state[(SPX_N / 8) * (1 + inblocks) + 4],
+        state[((SPX_N / 8) * (1 + inblocks)) + 4] = _mm256_xor_si256(
+                state[((SPX_N / 8) * (1 + inblocks)) + 4],
                 _mm256_set1_epi64x(0x1f)
             );
         for (int i = 17; i < 25; i++) {
@@ -74,25 +74,25 @@ void thashx4(unsigned char *out0,
             ((int64_t *)out3)[i] = _mm256_extract_epi64(state[i], 3);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
         memcpy(buf2, ctx->pub_seed, SPX_N);
         memcpy(buf3, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx4 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx4 + 1 * 8, SPX_ADDR_BYTES);
-        memcpy(buf2 + SPX_N, addrx4 + 2 * 8, SPX_ADDR_BYTES);
-        memcpy(buf3 + SPX_N, addrx4 + 3 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx4 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx4 + (1 * 8), SPX_ADDR_BYTES);
+        memcpy(buf2 + SPX_N, addrx4 + (2 * 8), SPX_ADDR_BYTES);
+        memcpy(buf3 + SPX_N, addrx4 + (3 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
         memcpy(buf2 + SPX_N + SPX_ADDR_BYTES, in2, inblocks * SPX_N);
         memcpy(buf3 + SPX_N + SPX_ADDR_BYTES, in3, inblocks * SPX_N);
 
         shake256x4(out0, out1, out2, out3, SPX_N,
-                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/utilsx4.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/utilsx4.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx4.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -56,7 +58,7 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = (1U << (tree_height - 2)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[4 * SPX_N]; /* Current logical node */
-        gen_leafx4( current, ctx, 4 * idx + idx_offset,
+        gen_leafx4( current, ctx, (4 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
             unsigned int j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 4; j++) {
-                set_tree_height(tree_addrx4 + j * 8, h + 1);
-                set_tree_index(tree_addrx4 + j * 8,
-                               (4 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx4 + (j * 8), h + 1);
+                set_tree_index(tree_addrx4 + (j * 8),
+                               ((4 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx4[h * 4 * SPX_N];
             thashx4( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx4.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
-#include "utilsx4.h"
 #include "wotsx4.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, addr, addr} */
     for (j = 0; j < 4; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 4) {
         for (j = 0; j < 4 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx4(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -147,7 +145,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -204,8 +202,8 @@ void wots_gen_leafx4(unsigned char *dest,
     }
 
     for (j = 0; j < 4; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -214,18 +212,18 @@ void wots_gen_leafx4(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 4; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx4(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
+        prf_addrx4(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 4; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -233,8 +231,8 @@ void wots_gen_leafx4(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -244,26 +242,26 @@ void wots_gen_leafx4(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 4; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx4(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset, 1, ctx, leaf_addr);
+            thashx4(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx4(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx4(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-128f-simple/avx2/wotsx4.h
+++ b/crypto_sign/sphincs-shake-128f-simple/avx2/wotsx4.h
@@ -24,7 +24,7 @@ struct leaf_info_x4 {
 /* Used only by the benchmark code */
 #define INITIALIZE_LEAF_INFO_X4(info, addr, step_buffer) { \
         (info).wots_sig = 0;             \
-        (info).wots_sign_leaf = ~0;      \
+        (info).wots_sign_leaf = ~0U;     \
         (info).wots_steps = step_buffer; \
         int i;                         \
         for (i=0; i<4; i++) {          \

--- a/crypto_sign/sphincs-shake-128f-simple/clean/address.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-128f-simple/clean/context.h
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/context.h
@@ -10,6 +10,7 @@ typedef struct {
     uint8_t pub_seed[SPX_N];
     uint8_t sk_seed[SPX_N];
 
+
 } spx_ctx;
 
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)

--- a/crypto_sign/sphincs-shake-128f-simple/clean/fors.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-128f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-128f-simple/clean/hash_shake.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-128f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-128f-simple/clean/params.h
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-128f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-128f-simple/clean/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-128f-simple/clean/utils.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-128f-simple/clean/utils.h
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-128f-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-shake-128f-simple/clean/wots.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-shake-128f-simple/clean/wots.h
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-128f-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-shake-128f-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-shake-128s-simple/META.yml
+++ b/crypto_sign/sphincs-shake-128s-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-128s-simple/META.yml
+++ b/crypto_sign/sphincs-shake-128s-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/address.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/f1600x2.h
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/f1600x2.h
@@ -1,8 +1,10 @@
 #ifndef SPX_F1600X2_H
 #define SPX_F1600X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define f1600_RC SPX_NAMESPACE(f1600_RC)
 extern uint64_t f1600_RC[24];
 extern void _f1600x2(uint64_t *a, uint64_t *rc);
 

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/f1600x2_const.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/f1600x2_const.c
@@ -1,4 +1,5 @@
 #include "f1600x2.h"
+#include <stdint.h>
 
 uint64_t f1600_RC[24] = {
     0x0000000000000001,

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/fips202x2.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/fips202x2.c
@@ -35,8 +35,8 @@ static void keccak_absorb2x(uint64_t *s,
 
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            s[2 * i + 0] ^= load64(m0 + 8 * i);
-            s[2 * i + 1] ^= load64(m1 + 8 * i);
+            s[(2 * i) + 0] ^= load64(m0 + (8 * i));
+            s[(2 * i) + 1] ^= load64(m1 + (8 * i));
         }
 
         f1600x2(s);
@@ -61,10 +61,11 @@ static void keccak_absorb2x(uint64_t *s,
     t1[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        s[2 * i + 0] ^= load64(t0 + 8 * i);
-        s[2 * i + 1] ^= load64(t1 + 8 * i);
+        s[(2 * i) + 0] ^= load64(t0 + (8 * i));
+        s[(2 * i) + 1] ^= load64(t1 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks2x(unsigned char *h0,
                                    unsigned char *h1,
@@ -76,14 +77,16 @@ static void keccak_squeezeblocks2x(unsigned char *h0,
     while (nblocks > 0) {
         f1600x2(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, s[2 * i + 0]);
-            store64(h1 + 8 * i, s[2 * i + 1]);
+            store64(h0 + (8 * i), s[(2 * i) + 0]);
+            store64(h1 + (8 * i), s[(2 * i) + 1]);
         }
         h0 += r;
         h1 += r;
         nblocks--;
     }
 }
+
+
 
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
@@ -113,6 +116,7 @@ void shake128x2(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/fips202x2.h
@@ -6,6 +6,7 @@
 uint64_t load64(const unsigned char *x);
 void store64(uint8_t *x, uint64_t u);
 
+
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/fips202x2.h
@@ -1,12 +1,15 @@
 #ifndef SPX_FIPS202X2_H
 #define SPX_FIPS202X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define load64 SPX_NAMESPACE(load64)
 uint64_t load64(const unsigned char *x);
+#define store64 SPX_NAMESPACE(store64)
 void store64(uint8_t *x, uint64_t u);
 
-
+#define shake128x2 SPX_NAMESPACE(shake128x2)
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,
@@ -14,6 +17,7 @@ void shake128x2(unsigned char *out0,
                 unsigned char *in1,
                 unsigned long long inlen);
 
+#define shake256x2 SPX_NAMESPACE(shake256x2)
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/fors.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx2.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx2.h"
 #include "utils.h"
@@ -55,22 +55,22 @@ static void fors_gen_leafx2(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 2; j++) {
-        set_tree_index(fors_leaf_addrx2 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx2 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx2(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
+    fors_gen_skx2(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
                   ctx, fors_leaf_addrx2);
 
     for (j = 0; j < 2; j++) {
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx2(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
+    fors_sk_to_leafx2(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
                       ctx, fors_leaf_addrx2);
 }
 
@@ -110,9 +110,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 2; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -132,7 +132,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx2(roots + i * SPX_N, sig, ctx,
+        treehashx2(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx2,
                    fors_tree_addr, &fors_info);
 
@@ -181,7 +181,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/hash.h
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/hash_shake.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/hash_shakex2.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/hash_shakex2.c
@@ -1,9 +1,8 @@
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx2.h"
 
-#include "address.h"
 #include "f1600x2.h"
 #include "fips202x2.h"
 #include "params.h"
@@ -20,33 +19,33 @@ void prf_addrx2(unsigned char *out0,
     uint64_t state[50] = {0};
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->pub_seed + 8 * i);
+        uint64_t x = load64(ctx->pub_seed + (8 * i));
         state[2 * i] = x;
-        state[2 * i + 1] = x;
+        state[(2 * i) + 1] = x;
     }
     for (int i = 0; i < 4; i++) {
-        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                      | (uint64_t)addrx2[2 * i];
-        state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                         | (uint64_t)addrx2[8 + 2 * i];
+        state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                           | (uint64_t)addrx2[8 + (2 * i)];
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->sk_seed + 8 * i);
+        uint64_t x = load64(ctx->sk_seed + (8 * i));
         state[2 * (SPX_N / 8 + i + 4)] = x;
-        state[2 * (SPX_N / 8 + i + 4) + 1] = x;
+        state[(2 * (SPX_N / 8 + i + 4)) + 1] = x;
     }
 
     /* SHAKE domain separator and padding. */
     state[2 * (SPX_N / 4 + 4)] = 0x1f;
-    state[2 * (SPX_N / 4 + 4) + 1] = 0x1f;
+    state[(2 * (SPX_N / 4 + 4)) + 1] = 0x1f;
 
     state[2 * 16] = 0x80ULL << 56;
-    state[2 * 16 + 1] = 0x80ULL << 56;
+    state[(2 * 16) + 1] = 0x80ULL << 56;
 
     f1600x2(state);
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        store64(out0 + 8 * i, state[2 * i]);
-        store64(out1 + 8 * i, state[2 * i + 1]);
+        store64(out0 + (8 * i), state[2 * i]);
+        store64(out1 + (8 * i), state[(2 * i) + 1]);
     }
 }

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx2.h"
 #include "wots.h"
 #include "wotsx2.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/params.h
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/sign.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/thash_shake_simplex2.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/thash_shake_simplex2.c
@@ -1,15 +1,16 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 #include "thashx2.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
 #include "f1600x2.h"
 #include "fips202x2.h"
+
 
 void thash(unsigned char *out,
            const unsigned char *in,
@@ -36,47 +37,47 @@ void thashx2(unsigned char *out0,
          * build and extract from the twoway SHAKE256 state by hand. */
         uint64_t state[50] = {0};
         for (int i = 0; i < SPX_N / 8; i++) {
-            uint64_t x = load64(ctx->pub_seed + 8 * i);
+            uint64_t x = load64(ctx->pub_seed + (8 * i));
             state[2 * i] = x;
-            state[2 * i + 1] = x;
+            state[(2 * i) + 1] = x;
         }
         for (int i = 0; i < 4; i++) {
-            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                          | (uint64_t)addrx2[2 * i];
-            state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                             | (uint64_t)addrx2[8 + 2 * i];
+            state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                               | (uint64_t)addrx2[8 + (2 * i)];
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + 8 * i);
-            state[2 * (SPX_N / 8 + 4 + i) + 1] = load64(in1 + 8 * i);
+            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + (8 * i));
+            state[(2 * (SPX_N / 8 + 4 + i)) + 1] = load64(in1 + (8 * i));
         }
 
         /* Domain separator and padding. */
         state[2 * 16] = 0x80ULL << 56;
-        state[2 * 16 + 1] = 0x80ULL << 56;
+        state[(2 * 16) + 1] = 0x80ULL << 56;
 
         state[2 * ((SPX_N / 8) * (1 + inblocks) + 4)] ^= 0x1f;
-        state[2 * ((SPX_N / 8) * (1 + inblocks) + 4) + 1] ^= 0x1f;
+        state[(2 * ((SPX_N / 8) * (1 + inblocks) + 4)) + 1] ^= 0x1f;
 
         f1600x2(state);
 
         for (int i = 0; i < SPX_N / 8; i++) {
-            store64(out0 + 8 * i, state[2 * i]);
-            store64(out1 + 8 * i, state[2 * i + 1]);
+            store64(out0 + (8 * i), state[2 * i]);
+            store64(out1 + (8 * i), state[(2 * i) + 1]);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx2 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx2 + 1 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx2 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx2 + (1 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
 
         shake256x2(out0, out1, SPX_N,
-                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/utils.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/utils.h
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/wots.c
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/wots.c
@@ -2,15 +2,14 @@
 #include <string.h>
 
 #include "wots.h"
+#include "context.h"
 #include "wotsx2.h"
 
 #include "address.h"
-#include "hash.h"
 #include "hashx2.h"
 #include "params.h"
 #include "thashx2.h"
 #include "utils.h"
-#include "utilsx2.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -39,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr} */
     for (j = 0; j < 2; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -64,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 2) {
         for (j = 0; j < 2 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -92,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx2(bufs[0], bufs[1],
@@ -203,8 +202,8 @@ void wots_gen_leafx2(unsigned char *dest,
     }
 
     for (j = 0; j < 2; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -213,15 +212,15 @@ void wots_gen_leafx2(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 2; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx2(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
+        prf_addrx2(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
                    ctx, leaf_addr);
         for (j = 0; j < 2; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -229,8 +228,8 @@ void wots_gen_leafx2(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -240,20 +239,20 @@ void wots_gen_leafx2(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 2; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx2(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
+            thashx2(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
                     1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx2(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
+    thashx2(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
             SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-128s-simple/aarch64/wots.h
+++ b/crypto_sign/sphincs-shake-128s-simple/aarch64/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/address.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/fips202x4.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/fips202x4.c
@@ -46,12 +46,13 @@ static void keccak_absorb4x(__m256i *s,
 
     unsigned long long *ss = (unsigned long long *)s;
 
+
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            ss[4 * i + 0] ^= load64(m0 + 8 * i);
-            ss[4 * i + 1] ^= load64(m1 + 8 * i);
-            ss[4 * i + 2] ^= load64(m2 + 8 * i);
-            ss[4 * i + 3] ^= load64(m3 + 8 * i);
+            ss[(4 * i) + 0] ^= load64(m0 + (8 * i));
+            ss[(4 * i) + 1] ^= load64(m1 + (8 * i));
+            ss[(4 * i) + 2] ^= load64(m2 + (8 * i));
+            ss[(4 * i) + 3] ^= load64(m3 + (8 * i));
         }
 
         KeccakF1600_StatePermute4x(s);
@@ -86,12 +87,13 @@ static void keccak_absorb4x(__m256i *s,
     t3[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        ss[4 * i + 0] ^= load64(t0 + 8 * i);
-        ss[4 * i + 1] ^= load64(t1 + 8 * i);
-        ss[4 * i + 2] ^= load64(t2 + 8 * i);
-        ss[4 * i + 3] ^= load64(t3 + 8 * i);
+        ss[(4 * i) + 0] ^= load64(t0 + (8 * i));
+        ss[(4 * i) + 1] ^= load64(t1 + (8 * i));
+        ss[(4 * i) + 2] ^= load64(t2 + (8 * i));
+        ss[(4 * i) + 3] ^= load64(t3 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks4x(unsigned char *h0,
                                    unsigned char *h1,
@@ -107,10 +109,10 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
     while (nblocks > 0) {
         KeccakF1600_StatePermute4x(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, ss[4 * i + 0]);
-            store64(h1 + 8 * i, ss[4 * i + 1]);
-            store64(h2 + 8 * i, ss[4 * i + 2]);
-            store64(h3 + 8 * i, ss[4 * i + 3]);
+            store64(h0 + (8 * i), ss[(4 * i) + 0]);
+            store64(h1 + (8 * i), ss[(4 * i) + 1]);
+            store64(h2 + (8 * i), ss[(4 * i) + 2]);
+            store64(h3 + (8 * i), ss[(4 * i) + 3]);
         }
         h0 += r;
         h1 += r;
@@ -119,6 +121,8 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
         nblocks--;
     }
 }
+
+
 
 void shake128x4(unsigned char *out0,
                 unsigned char *out1,
@@ -161,6 +165,7 @@ void shake128x4(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x4(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx4.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -60,28 +60,28 @@ static void fors_gen_leafx4(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 4; j++) {
-        set_tree_index(fors_leaf_addrx4 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx4 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx4(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
+    fors_gen_skx4(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
                   ctx, fors_leaf_addrx4);
 
     for (j = 0; j < 4; j++) {
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx4(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
+    fors_sk_to_leafx4(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
                       ctx, fors_leaf_addrx4);
 }
 
@@ -121,9 +121,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 4; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -143,7 +143,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx4(roots + i * SPX_N, sig, ctx,
+        treehashx4(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx4,
                    fors_tree_addr, &fors_info);
 
@@ -192,7 +192,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/hash_shake.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/hash_shakex4.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/hash_shakex4.c
@@ -1,10 +1,9 @@
+#include <immintrin.h>
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx4.h"
 
-#include "address.h"
-#include "fips202x4.h"
 #include "params.h"
 
 extern void KeccakP1600times4_PermuteAll_24rounds(__m256i *s);
@@ -26,24 +25,24 @@ void prf_addrx4(unsigned char *out0,
         state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
     }
     for (int i = 0; i < 4; i++) {
-        state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                   (int)addrx4[3 * 8 + 1 + 2 * i],
-                                   (int)addrx4[3 * 8 + 2 * i],
-                                   (int)addrx4[2 * 8 + 1 + 2 * i],
-                                   (int)addrx4[2 * 8 + 2 * i],
-                                   (int)addrx4[8 + 1 + 2 * i],
-                                   (int)addrx4[8 + 2 * i],
-                                   (int)addrx4[1 + 2 * i],
-                                   (int)addrx4[2 * i]
-                               );
+        state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                     (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(3 * 8) + (2 * i)],
+                                     (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(2 * 8) + (2 * i)],
+                                     (int)addrx4[8 + 1 + (2 * i)],
+                                     (int)addrx4[8 + (2 * i)],
+                                     (int)addrx4[1 + (2 * i)],
+                                     (int)addrx4[2 * i]
+                                 );
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        state[SPX_N / 8 + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
+        state[(SPX_N / 8) + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
     }
 
     /* SHAKE domain separator and padding. */
-    state[SPX_N / 4 + 4] = _mm256_set1_epi64x(0x1f);
-    for (int i = SPX_N / 4 + 5; i < 16; i++) {
+    state[(SPX_N / 4) + 4] = _mm256_set1_epi64x(0x1f);
+    for (int i = (SPX_N / 4) + 5; i < 16; i++) {
         state[i] = _mm256_set1_epi64x(0);
     }
     // shift unsigned and then cast to avoid UB

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx4.h"
 #include "wots.h"
 #include "wotsx4.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/params.h
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/thash_shake_simplex4.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/thash_shake_simplex4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thashx4.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -31,34 +31,34 @@ void thashx4(unsigned char *out0,
             state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
         }
         for (int i = 0; i < 4; i++) {
-            state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                       (int)addrx4[3 * 8 + 1 + 2 * i],
-                                       (int)addrx4[3 * 8 + 2 * i],
-                                       (int)addrx4[2 * 8 + 1 + 2 * i],
-                                       (int)addrx4[2 * 8 + 2 * i],
-                                       (int)addrx4[8 + 1 + 2 * i],
-                                       (int)addrx4[8 + 2 * i],
-                                       (int)addrx4[1 + 2 * i],
-                                       (int)addrx4[2 * i]
-                                   );
+            state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                         (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(3 * 8) + (2 * i)],
+                                         (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(2 * 8) + (2 * i)],
+                                         (int)addrx4[8 + 1 + (2 * i)],
+                                         (int)addrx4[8 + (2 * i)],
+                                         (int)addrx4[1 + (2 * i)],
+                                         (int)addrx4[2 * i]
+                                     );
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[SPX_N / 8 + 4 + i] = _mm256_set_epi64x(
-                                           ((int64_t *)in3)[i],
-                                           ((int64_t *)in2)[i],
-                                           ((int64_t *)in1)[i],
-                                           ((int64_t *)in0)[i]
-                                       );
+            state[(SPX_N / 8) + 4 + i] = _mm256_set_epi64x(
+                                             ((int64_t *)in3)[i],
+                                             ((int64_t *)in2)[i],
+                                             ((int64_t *)in1)[i],
+                                             ((int64_t *)in0)[i]
+                                         );
         }
 
         /* Domain separator and padding. */
-        for (size_t i = (SPX_N / 8) * (1 + inblocks) + 4; i < 16; i++) {
+        for (size_t i = ((SPX_N / 8) * (1 + inblocks)) + 4; i < 16; i++) {
             state[i] = _mm256_set1_epi64x(0);
         }
         state[16] = _mm256_set1_epi64x((long long)(0x80ULL << 56));
-        state[(SPX_N / 8) * (1 + inblocks) + 4] = _mm256_xor_si256(
-                state[(SPX_N / 8) * (1 + inblocks) + 4],
+        state[((SPX_N / 8) * (1 + inblocks)) + 4] = _mm256_xor_si256(
+                state[((SPX_N / 8) * (1 + inblocks)) + 4],
                 _mm256_set1_epi64x(0x1f)
             );
         for (int i = 17; i < 25; i++) {
@@ -74,25 +74,25 @@ void thashx4(unsigned char *out0,
             ((int64_t *)out3)[i] = _mm256_extract_epi64(state[i], 3);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
         memcpy(buf2, ctx->pub_seed, SPX_N);
         memcpy(buf3, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx4 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx4 + 1 * 8, SPX_ADDR_BYTES);
-        memcpy(buf2 + SPX_N, addrx4 + 2 * 8, SPX_ADDR_BYTES);
-        memcpy(buf3 + SPX_N, addrx4 + 3 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx4 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx4 + (1 * 8), SPX_ADDR_BYTES);
+        memcpy(buf2 + SPX_N, addrx4 + (2 * 8), SPX_ADDR_BYTES);
+        memcpy(buf3 + SPX_N, addrx4 + (3 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
         memcpy(buf2 + SPX_N + SPX_ADDR_BYTES, in2, inblocks * SPX_N);
         memcpy(buf3 + SPX_N + SPX_ADDR_BYTES, in3, inblocks * SPX_N);
 
         shake256x4(out0, out1, out2, out3, SPX_N,
-                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/utilsx4.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/utilsx4.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx4.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -56,7 +58,7 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = (1U << (tree_height - 2)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[4 * SPX_N]; /* Current logical node */
-        gen_leafx4( current, ctx, 4 * idx + idx_offset,
+        gen_leafx4( current, ctx, (4 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
             unsigned int j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 4; j++) {
-                set_tree_height(tree_addrx4 + j * 8, h + 1);
-                set_tree_index(tree_addrx4 + j * 8,
-                               (4 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx4 + (j * 8), h + 1);
+                set_tree_index(tree_addrx4 + (j * 8),
+                               ((4 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx4[h * 4 * SPX_N];
             thashx4( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx4.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
-#include "utilsx4.h"
 #include "wotsx4.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, addr, addr} */
     for (j = 0; j < 4; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 4) {
         for (j = 0; j < 4 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx4(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -147,7 +145,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -204,8 +202,8 @@ void wots_gen_leafx4(unsigned char *dest,
     }
 
     for (j = 0; j < 4; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -214,18 +212,18 @@ void wots_gen_leafx4(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 4; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx4(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
+        prf_addrx4(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 4; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -233,8 +231,8 @@ void wots_gen_leafx4(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -244,26 +242,26 @@ void wots_gen_leafx4(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 4; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx4(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset, 1, ctx, leaf_addr);
+            thashx4(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx4(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx4(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-128s-simple/avx2/wotsx4.h
+++ b/crypto_sign/sphincs-shake-128s-simple/avx2/wotsx4.h
@@ -24,7 +24,7 @@ struct leaf_info_x4 {
 /* Used only by the benchmark code */
 #define INITIALIZE_LEAF_INFO_X4(info, addr, step_buffer) { \
         (info).wots_sig = 0;             \
-        (info).wots_sign_leaf = ~0;      \
+        (info).wots_sign_leaf = ~0U;     \
         (info).wots_steps = step_buffer; \
         int i;                         \
         for (i=0; i<4; i++) {          \

--- a/crypto_sign/sphincs-shake-128s-simple/clean/address.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-128s-simple/clean/context.h
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/context.h
@@ -10,6 +10,7 @@ typedef struct {
     uint8_t pub_seed[SPX_N];
     uint8_t sk_seed[SPX_N];
 
+
 } spx_ctx;
 
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)

--- a/crypto_sign/sphincs-shake-128s-simple/clean/fors.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-128s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-128s-simple/clean/hash_shake.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-128s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-128s-simple/clean/params.h
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-128s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-128s-simple/clean/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-128s-simple/clean/utils.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-128s-simple/clean/utils.h
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-128s-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-shake-128s-simple/clean/wots.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-shake-128s-simple/clean/wots.h
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-128s-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-shake-128s-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-shake-192f-simple/META.yml
+++ b/crypto_sign/sphincs-shake-192f-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-192f-simple/META.yml
+++ b/crypto_sign/sphincs-shake-192f-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/address.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/f1600x2.h
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/f1600x2.h
@@ -1,8 +1,10 @@
 #ifndef SPX_F1600X2_H
 #define SPX_F1600X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define f1600_RC SPX_NAMESPACE(f1600_RC)
 extern uint64_t f1600_RC[24];
 extern void _f1600x2(uint64_t *a, uint64_t *rc);
 

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/f1600x2_const.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/f1600x2_const.c
@@ -1,4 +1,5 @@
 #include "f1600x2.h"
+#include <stdint.h>
 
 uint64_t f1600_RC[24] = {
     0x0000000000000001,

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/fips202x2.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/fips202x2.c
@@ -35,8 +35,8 @@ static void keccak_absorb2x(uint64_t *s,
 
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            s[2 * i + 0] ^= load64(m0 + 8 * i);
-            s[2 * i + 1] ^= load64(m1 + 8 * i);
+            s[(2 * i) + 0] ^= load64(m0 + (8 * i));
+            s[(2 * i) + 1] ^= load64(m1 + (8 * i));
         }
 
         f1600x2(s);
@@ -61,10 +61,11 @@ static void keccak_absorb2x(uint64_t *s,
     t1[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        s[2 * i + 0] ^= load64(t0 + 8 * i);
-        s[2 * i + 1] ^= load64(t1 + 8 * i);
+        s[(2 * i) + 0] ^= load64(t0 + (8 * i));
+        s[(2 * i) + 1] ^= load64(t1 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks2x(unsigned char *h0,
                                    unsigned char *h1,
@@ -76,14 +77,16 @@ static void keccak_squeezeblocks2x(unsigned char *h0,
     while (nblocks > 0) {
         f1600x2(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, s[2 * i + 0]);
-            store64(h1 + 8 * i, s[2 * i + 1]);
+            store64(h0 + (8 * i), s[(2 * i) + 0]);
+            store64(h1 + (8 * i), s[(2 * i) + 1]);
         }
         h0 += r;
         h1 += r;
         nblocks--;
     }
 }
+
+
 
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
@@ -113,6 +116,7 @@ void shake128x2(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/fips202x2.h
@@ -6,6 +6,7 @@
 uint64_t load64(const unsigned char *x);
 void store64(uint8_t *x, uint64_t u);
 
+
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/fips202x2.h
@@ -1,12 +1,15 @@
 #ifndef SPX_FIPS202X2_H
 #define SPX_FIPS202X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define load64 SPX_NAMESPACE(load64)
 uint64_t load64(const unsigned char *x);
+#define store64 SPX_NAMESPACE(store64)
 void store64(uint8_t *x, uint64_t u);
 
-
+#define shake128x2 SPX_NAMESPACE(shake128x2)
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,
@@ -14,6 +17,7 @@ void shake128x2(unsigned char *out0,
                 unsigned char *in1,
                 unsigned long long inlen);
 
+#define shake256x2 SPX_NAMESPACE(shake256x2)
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/fors.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx2.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx2.h"
 #include "utils.h"
@@ -55,22 +55,22 @@ static void fors_gen_leafx2(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 2; j++) {
-        set_tree_index(fors_leaf_addrx2 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx2 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx2(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
+    fors_gen_skx2(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
                   ctx, fors_leaf_addrx2);
 
     for (j = 0; j < 2; j++) {
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx2(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
+    fors_sk_to_leafx2(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
                       ctx, fors_leaf_addrx2);
 }
 
@@ -110,9 +110,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 2; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -132,7 +132,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx2(roots + i * SPX_N, sig, ctx,
+        treehashx2(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx2,
                    fors_tree_addr, &fors_info);
 
@@ -181,7 +181,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/hash.h
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/hash_shake.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/hash_shakex2.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/hash_shakex2.c
@@ -1,9 +1,8 @@
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx2.h"
 
-#include "address.h"
 #include "f1600x2.h"
 #include "fips202x2.h"
 #include "params.h"
@@ -20,33 +19,33 @@ void prf_addrx2(unsigned char *out0,
     uint64_t state[50] = {0};
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->pub_seed + 8 * i);
+        uint64_t x = load64(ctx->pub_seed + (8 * i));
         state[2 * i] = x;
-        state[2 * i + 1] = x;
+        state[(2 * i) + 1] = x;
     }
     for (int i = 0; i < 4; i++) {
-        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                      | (uint64_t)addrx2[2 * i];
-        state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                         | (uint64_t)addrx2[8 + 2 * i];
+        state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                           | (uint64_t)addrx2[8 + (2 * i)];
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->sk_seed + 8 * i);
+        uint64_t x = load64(ctx->sk_seed + (8 * i));
         state[2 * (SPX_N / 8 + i + 4)] = x;
-        state[2 * (SPX_N / 8 + i + 4) + 1] = x;
+        state[(2 * (SPX_N / 8 + i + 4)) + 1] = x;
     }
 
     /* SHAKE domain separator and padding. */
     state[2 * (SPX_N / 4 + 4)] = 0x1f;
-    state[2 * (SPX_N / 4 + 4) + 1] = 0x1f;
+    state[(2 * (SPX_N / 4 + 4)) + 1] = 0x1f;
 
     state[2 * 16] = 0x80ULL << 56;
-    state[2 * 16 + 1] = 0x80ULL << 56;
+    state[(2 * 16) + 1] = 0x80ULL << 56;
 
     f1600x2(state);
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        store64(out0 + 8 * i, state[2 * i]);
-        store64(out1 + 8 * i, state[2 * i + 1]);
+        store64(out0 + (8 * i), state[2 * i]);
+        store64(out1 + (8 * i), state[(2 * i) + 1]);
     }
 }

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx2.h"
 #include "wots.h"
 #include "wotsx2.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/params.h
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/sign.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/thash_shake_simplex2.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/thash_shake_simplex2.c
@@ -1,15 +1,16 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 #include "thashx2.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
 #include "f1600x2.h"
 #include "fips202x2.h"
+
 
 void thash(unsigned char *out,
            const unsigned char *in,
@@ -36,47 +37,47 @@ void thashx2(unsigned char *out0,
          * build and extract from the twoway SHAKE256 state by hand. */
         uint64_t state[50] = {0};
         for (int i = 0; i < SPX_N / 8; i++) {
-            uint64_t x = load64(ctx->pub_seed + 8 * i);
+            uint64_t x = load64(ctx->pub_seed + (8 * i));
             state[2 * i] = x;
-            state[2 * i + 1] = x;
+            state[(2 * i) + 1] = x;
         }
         for (int i = 0; i < 4; i++) {
-            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                          | (uint64_t)addrx2[2 * i];
-            state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                             | (uint64_t)addrx2[8 + 2 * i];
+            state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                               | (uint64_t)addrx2[8 + (2 * i)];
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + 8 * i);
-            state[2 * (SPX_N / 8 + 4 + i) + 1] = load64(in1 + 8 * i);
+            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + (8 * i));
+            state[(2 * (SPX_N / 8 + 4 + i)) + 1] = load64(in1 + (8 * i));
         }
 
         /* Domain separator and padding. */
         state[2 * 16] = 0x80ULL << 56;
-        state[2 * 16 + 1] = 0x80ULL << 56;
+        state[(2 * 16) + 1] = 0x80ULL << 56;
 
         state[2 * ((SPX_N / 8) * (1 + inblocks) + 4)] ^= 0x1f;
-        state[2 * ((SPX_N / 8) * (1 + inblocks) + 4) + 1] ^= 0x1f;
+        state[(2 * ((SPX_N / 8) * (1 + inblocks) + 4)) + 1] ^= 0x1f;
 
         f1600x2(state);
 
         for (int i = 0; i < SPX_N / 8; i++) {
-            store64(out0 + 8 * i, state[2 * i]);
-            store64(out1 + 8 * i, state[2 * i + 1]);
+            store64(out0 + (8 * i), state[2 * i]);
+            store64(out1 + (8 * i), state[(2 * i) + 1]);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx2 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx2 + 1 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx2 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx2 + (1 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
 
         shake256x2(out0, out1, SPX_N,
-                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/utils.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/utils.h
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/wots.c
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/wots.c
@@ -2,15 +2,14 @@
 #include <string.h>
 
 #include "wots.h"
+#include "context.h"
 #include "wotsx2.h"
 
 #include "address.h"
-#include "hash.h"
 #include "hashx2.h"
 #include "params.h"
 #include "thashx2.h"
 #include "utils.h"
-#include "utilsx2.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -39,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr} */
     for (j = 0; j < 2; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -64,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 2) {
         for (j = 0; j < 2 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -92,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx2(bufs[0], bufs[1],
@@ -203,8 +202,8 @@ void wots_gen_leafx2(unsigned char *dest,
     }
 
     for (j = 0; j < 2; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -213,15 +212,15 @@ void wots_gen_leafx2(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 2; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx2(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
+        prf_addrx2(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
                    ctx, leaf_addr);
         for (j = 0; j < 2; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -229,8 +228,8 @@ void wots_gen_leafx2(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -240,20 +239,20 @@ void wots_gen_leafx2(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 2; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx2(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
+            thashx2(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
                     1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx2(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
+    thashx2(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
             SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-192f-simple/aarch64/wots.h
+++ b/crypto_sign/sphincs-shake-192f-simple/aarch64/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/address.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/fips202x4.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/fips202x4.c
@@ -46,12 +46,13 @@ static void keccak_absorb4x(__m256i *s,
 
     unsigned long long *ss = (unsigned long long *)s;
 
+
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            ss[4 * i + 0] ^= load64(m0 + 8 * i);
-            ss[4 * i + 1] ^= load64(m1 + 8 * i);
-            ss[4 * i + 2] ^= load64(m2 + 8 * i);
-            ss[4 * i + 3] ^= load64(m3 + 8 * i);
+            ss[(4 * i) + 0] ^= load64(m0 + (8 * i));
+            ss[(4 * i) + 1] ^= load64(m1 + (8 * i));
+            ss[(4 * i) + 2] ^= load64(m2 + (8 * i));
+            ss[(4 * i) + 3] ^= load64(m3 + (8 * i));
         }
 
         KeccakF1600_StatePermute4x(s);
@@ -86,12 +87,13 @@ static void keccak_absorb4x(__m256i *s,
     t3[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        ss[4 * i + 0] ^= load64(t0 + 8 * i);
-        ss[4 * i + 1] ^= load64(t1 + 8 * i);
-        ss[4 * i + 2] ^= load64(t2 + 8 * i);
-        ss[4 * i + 3] ^= load64(t3 + 8 * i);
+        ss[(4 * i) + 0] ^= load64(t0 + (8 * i));
+        ss[(4 * i) + 1] ^= load64(t1 + (8 * i));
+        ss[(4 * i) + 2] ^= load64(t2 + (8 * i));
+        ss[(4 * i) + 3] ^= load64(t3 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks4x(unsigned char *h0,
                                    unsigned char *h1,
@@ -107,10 +109,10 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
     while (nblocks > 0) {
         KeccakF1600_StatePermute4x(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, ss[4 * i + 0]);
-            store64(h1 + 8 * i, ss[4 * i + 1]);
-            store64(h2 + 8 * i, ss[4 * i + 2]);
-            store64(h3 + 8 * i, ss[4 * i + 3]);
+            store64(h0 + (8 * i), ss[(4 * i) + 0]);
+            store64(h1 + (8 * i), ss[(4 * i) + 1]);
+            store64(h2 + (8 * i), ss[(4 * i) + 2]);
+            store64(h3 + (8 * i), ss[(4 * i) + 3]);
         }
         h0 += r;
         h1 += r;
@@ -119,6 +121,8 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
         nblocks--;
     }
 }
+
+
 
 void shake128x4(unsigned char *out0,
                 unsigned char *out1,
@@ -161,6 +165,7 @@ void shake128x4(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x4(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx4.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -60,28 +60,28 @@ static void fors_gen_leafx4(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 4; j++) {
-        set_tree_index(fors_leaf_addrx4 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx4 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx4(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
+    fors_gen_skx4(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
                   ctx, fors_leaf_addrx4);
 
     for (j = 0; j < 4; j++) {
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx4(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
+    fors_sk_to_leafx4(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
                       ctx, fors_leaf_addrx4);
 }
 
@@ -121,9 +121,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 4; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -143,7 +143,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx4(roots + i * SPX_N, sig, ctx,
+        treehashx4(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx4,
                    fors_tree_addr, &fors_info);
 
@@ -192,7 +192,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/hash_shake.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/hash_shakex4.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/hash_shakex4.c
@@ -1,10 +1,9 @@
+#include <immintrin.h>
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx4.h"
 
-#include "address.h"
-#include "fips202x4.h"
 #include "params.h"
 
 extern void KeccakP1600times4_PermuteAll_24rounds(__m256i *s);
@@ -26,24 +25,24 @@ void prf_addrx4(unsigned char *out0,
         state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
     }
     for (int i = 0; i < 4; i++) {
-        state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                   (int)addrx4[3 * 8 + 1 + 2 * i],
-                                   (int)addrx4[3 * 8 + 2 * i],
-                                   (int)addrx4[2 * 8 + 1 + 2 * i],
-                                   (int)addrx4[2 * 8 + 2 * i],
-                                   (int)addrx4[8 + 1 + 2 * i],
-                                   (int)addrx4[8 + 2 * i],
-                                   (int)addrx4[1 + 2 * i],
-                                   (int)addrx4[2 * i]
-                               );
+        state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                     (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(3 * 8) + (2 * i)],
+                                     (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(2 * 8) + (2 * i)],
+                                     (int)addrx4[8 + 1 + (2 * i)],
+                                     (int)addrx4[8 + (2 * i)],
+                                     (int)addrx4[1 + (2 * i)],
+                                     (int)addrx4[2 * i]
+                                 );
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        state[SPX_N / 8 + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
+        state[(SPX_N / 8) + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
     }
 
     /* SHAKE domain separator and padding. */
-    state[SPX_N / 4 + 4] = _mm256_set1_epi64x(0x1f);
-    for (int i = SPX_N / 4 + 5; i < 16; i++) {
+    state[(SPX_N / 4) + 4] = _mm256_set1_epi64x(0x1f);
+    for (int i = (SPX_N / 4) + 5; i < 16; i++) {
         state[i] = _mm256_set1_epi64x(0);
     }
     // shift unsigned and then cast to avoid UB

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx4.h"
 #include "wots.h"
 #include "wotsx4.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/params.h
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/thash_shake_simplex4.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/thash_shake_simplex4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thashx4.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -31,34 +31,34 @@ void thashx4(unsigned char *out0,
             state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
         }
         for (int i = 0; i < 4; i++) {
-            state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                       (int)addrx4[3 * 8 + 1 + 2 * i],
-                                       (int)addrx4[3 * 8 + 2 * i],
-                                       (int)addrx4[2 * 8 + 1 + 2 * i],
-                                       (int)addrx4[2 * 8 + 2 * i],
-                                       (int)addrx4[8 + 1 + 2 * i],
-                                       (int)addrx4[8 + 2 * i],
-                                       (int)addrx4[1 + 2 * i],
-                                       (int)addrx4[2 * i]
-                                   );
+            state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                         (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(3 * 8) + (2 * i)],
+                                         (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(2 * 8) + (2 * i)],
+                                         (int)addrx4[8 + 1 + (2 * i)],
+                                         (int)addrx4[8 + (2 * i)],
+                                         (int)addrx4[1 + (2 * i)],
+                                         (int)addrx4[2 * i]
+                                     );
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[SPX_N / 8 + 4 + i] = _mm256_set_epi64x(
-                                           ((int64_t *)in3)[i],
-                                           ((int64_t *)in2)[i],
-                                           ((int64_t *)in1)[i],
-                                           ((int64_t *)in0)[i]
-                                       );
+            state[(SPX_N / 8) + 4 + i] = _mm256_set_epi64x(
+                                             ((int64_t *)in3)[i],
+                                             ((int64_t *)in2)[i],
+                                             ((int64_t *)in1)[i],
+                                             ((int64_t *)in0)[i]
+                                         );
         }
 
         /* Domain separator and padding. */
-        for (size_t i = (SPX_N / 8) * (1 + inblocks) + 4; i < 16; i++) {
+        for (size_t i = ((SPX_N / 8) * (1 + inblocks)) + 4; i < 16; i++) {
             state[i] = _mm256_set1_epi64x(0);
         }
         state[16] = _mm256_set1_epi64x((long long)(0x80ULL << 56));
-        state[(SPX_N / 8) * (1 + inblocks) + 4] = _mm256_xor_si256(
-                state[(SPX_N / 8) * (1 + inblocks) + 4],
+        state[((SPX_N / 8) * (1 + inblocks)) + 4] = _mm256_xor_si256(
+                state[((SPX_N / 8) * (1 + inblocks)) + 4],
                 _mm256_set1_epi64x(0x1f)
             );
         for (int i = 17; i < 25; i++) {
@@ -74,25 +74,25 @@ void thashx4(unsigned char *out0,
             ((int64_t *)out3)[i] = _mm256_extract_epi64(state[i], 3);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
         memcpy(buf2, ctx->pub_seed, SPX_N);
         memcpy(buf3, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx4 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx4 + 1 * 8, SPX_ADDR_BYTES);
-        memcpy(buf2 + SPX_N, addrx4 + 2 * 8, SPX_ADDR_BYTES);
-        memcpy(buf3 + SPX_N, addrx4 + 3 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx4 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx4 + (1 * 8), SPX_ADDR_BYTES);
+        memcpy(buf2 + SPX_N, addrx4 + (2 * 8), SPX_ADDR_BYTES);
+        memcpy(buf3 + SPX_N, addrx4 + (3 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
         memcpy(buf2 + SPX_N + SPX_ADDR_BYTES, in2, inblocks * SPX_N);
         memcpy(buf3 + SPX_N + SPX_ADDR_BYTES, in3, inblocks * SPX_N);
 
         shake256x4(out0, out1, out2, out3, SPX_N,
-                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/utilsx4.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/utilsx4.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx4.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -56,7 +58,7 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = (1U << (tree_height - 2)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[4 * SPX_N]; /* Current logical node */
-        gen_leafx4( current, ctx, 4 * idx + idx_offset,
+        gen_leafx4( current, ctx, (4 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
             unsigned int j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 4; j++) {
-                set_tree_height(tree_addrx4 + j * 8, h + 1);
-                set_tree_index(tree_addrx4 + j * 8,
-                               (4 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx4 + (j * 8), h + 1);
+                set_tree_index(tree_addrx4 + (j * 8),
+                               ((4 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx4[h * 4 * SPX_N];
             thashx4( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx4.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
-#include "utilsx4.h"
 #include "wotsx4.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, addr, addr} */
     for (j = 0; j < 4; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 4) {
         for (j = 0; j < 4 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx4(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -147,7 +145,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -204,8 +202,8 @@ void wots_gen_leafx4(unsigned char *dest,
     }
 
     for (j = 0; j < 4; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -214,18 +212,18 @@ void wots_gen_leafx4(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 4; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx4(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
+        prf_addrx4(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 4; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -233,8 +231,8 @@ void wots_gen_leafx4(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -244,26 +242,26 @@ void wots_gen_leafx4(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 4; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx4(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset, 1, ctx, leaf_addr);
+            thashx4(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx4(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx4(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-192f-simple/avx2/wotsx4.h
+++ b/crypto_sign/sphincs-shake-192f-simple/avx2/wotsx4.h
@@ -24,7 +24,7 @@ struct leaf_info_x4 {
 /* Used only by the benchmark code */
 #define INITIALIZE_LEAF_INFO_X4(info, addr, step_buffer) { \
         (info).wots_sig = 0;             \
-        (info).wots_sign_leaf = ~0;      \
+        (info).wots_sign_leaf = ~0U;     \
         (info).wots_steps = step_buffer; \
         int i;                         \
         for (i=0; i<4; i++) {          \

--- a/crypto_sign/sphincs-shake-192f-simple/clean/address.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-192f-simple/clean/context.h
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/context.h
@@ -10,6 +10,7 @@ typedef struct {
     uint8_t pub_seed[SPX_N];
     uint8_t sk_seed[SPX_N];
 
+
 } spx_ctx;
 
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)

--- a/crypto_sign/sphincs-shake-192f-simple/clean/fors.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-192f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-192f-simple/clean/hash_shake.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-192f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-192f-simple/clean/params.h
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-192f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-192f-simple/clean/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-192f-simple/clean/utils.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-192f-simple/clean/utils.h
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-192f-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-shake-192f-simple/clean/wots.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-shake-192f-simple/clean/wots.h
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-192f-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-shake-192f-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-shake-192s-simple/META.yml
+++ b/crypto_sign/sphincs-shake-192s-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-192s-simple/META.yml
+++ b/crypto_sign/sphincs-shake-192s-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/address.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/f1600x2.h
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/f1600x2.h
@@ -1,8 +1,10 @@
 #ifndef SPX_F1600X2_H
 #define SPX_F1600X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define f1600_RC SPX_NAMESPACE(f1600_RC)
 extern uint64_t f1600_RC[24];
 extern void _f1600x2(uint64_t *a, uint64_t *rc);
 

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/f1600x2_const.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/f1600x2_const.c
@@ -1,4 +1,5 @@
 #include "f1600x2.h"
+#include <stdint.h>
 
 uint64_t f1600_RC[24] = {
     0x0000000000000001,

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/fips202x2.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/fips202x2.c
@@ -35,8 +35,8 @@ static void keccak_absorb2x(uint64_t *s,
 
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            s[2 * i + 0] ^= load64(m0 + 8 * i);
-            s[2 * i + 1] ^= load64(m1 + 8 * i);
+            s[(2 * i) + 0] ^= load64(m0 + (8 * i));
+            s[(2 * i) + 1] ^= load64(m1 + (8 * i));
         }
 
         f1600x2(s);
@@ -61,10 +61,11 @@ static void keccak_absorb2x(uint64_t *s,
     t1[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        s[2 * i + 0] ^= load64(t0 + 8 * i);
-        s[2 * i + 1] ^= load64(t1 + 8 * i);
+        s[(2 * i) + 0] ^= load64(t0 + (8 * i));
+        s[(2 * i) + 1] ^= load64(t1 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks2x(unsigned char *h0,
                                    unsigned char *h1,
@@ -76,14 +77,16 @@ static void keccak_squeezeblocks2x(unsigned char *h0,
     while (nblocks > 0) {
         f1600x2(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, s[2 * i + 0]);
-            store64(h1 + 8 * i, s[2 * i + 1]);
+            store64(h0 + (8 * i), s[(2 * i) + 0]);
+            store64(h1 + (8 * i), s[(2 * i) + 1]);
         }
         h0 += r;
         h1 += r;
         nblocks--;
     }
 }
+
+
 
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
@@ -113,6 +116,7 @@ void shake128x2(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/fips202x2.h
@@ -6,6 +6,7 @@
 uint64_t load64(const unsigned char *x);
 void store64(uint8_t *x, uint64_t u);
 
+
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/fips202x2.h
@@ -1,12 +1,15 @@
 #ifndef SPX_FIPS202X2_H
 #define SPX_FIPS202X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define load64 SPX_NAMESPACE(load64)
 uint64_t load64(const unsigned char *x);
+#define store64 SPX_NAMESPACE(store64)
 void store64(uint8_t *x, uint64_t u);
 
-
+#define shake128x2 SPX_NAMESPACE(shake128x2)
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,
@@ -14,6 +17,7 @@ void shake128x2(unsigned char *out0,
                 unsigned char *in1,
                 unsigned long long inlen);
 
+#define shake256x2 SPX_NAMESPACE(shake256x2)
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/fors.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx2.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx2.h"
 #include "utils.h"
@@ -55,22 +55,22 @@ static void fors_gen_leafx2(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 2; j++) {
-        set_tree_index(fors_leaf_addrx2 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx2 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx2(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
+    fors_gen_skx2(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
                   ctx, fors_leaf_addrx2);
 
     for (j = 0; j < 2; j++) {
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx2(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
+    fors_sk_to_leafx2(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
                       ctx, fors_leaf_addrx2);
 }
 
@@ -110,9 +110,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 2; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -132,7 +132,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx2(roots + i * SPX_N, sig, ctx,
+        treehashx2(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx2,
                    fors_tree_addr, &fors_info);
 
@@ -181,7 +181,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/hash.h
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/hash_shake.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/hash_shakex2.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/hash_shakex2.c
@@ -1,9 +1,8 @@
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx2.h"
 
-#include "address.h"
 #include "f1600x2.h"
 #include "fips202x2.h"
 #include "params.h"
@@ -20,33 +19,33 @@ void prf_addrx2(unsigned char *out0,
     uint64_t state[50] = {0};
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->pub_seed + 8 * i);
+        uint64_t x = load64(ctx->pub_seed + (8 * i));
         state[2 * i] = x;
-        state[2 * i + 1] = x;
+        state[(2 * i) + 1] = x;
     }
     for (int i = 0; i < 4; i++) {
-        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                      | (uint64_t)addrx2[2 * i];
-        state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                         | (uint64_t)addrx2[8 + 2 * i];
+        state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                           | (uint64_t)addrx2[8 + (2 * i)];
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->sk_seed + 8 * i);
+        uint64_t x = load64(ctx->sk_seed + (8 * i));
         state[2 * (SPX_N / 8 + i + 4)] = x;
-        state[2 * (SPX_N / 8 + i + 4) + 1] = x;
+        state[(2 * (SPX_N / 8 + i + 4)) + 1] = x;
     }
 
     /* SHAKE domain separator and padding. */
     state[2 * (SPX_N / 4 + 4)] = 0x1f;
-    state[2 * (SPX_N / 4 + 4) + 1] = 0x1f;
+    state[(2 * (SPX_N / 4 + 4)) + 1] = 0x1f;
 
     state[2 * 16] = 0x80ULL << 56;
-    state[2 * 16 + 1] = 0x80ULL << 56;
+    state[(2 * 16) + 1] = 0x80ULL << 56;
 
     f1600x2(state);
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        store64(out0 + 8 * i, state[2 * i]);
-        store64(out1 + 8 * i, state[2 * i + 1]);
+        store64(out0 + (8 * i), state[2 * i]);
+        store64(out1 + (8 * i), state[(2 * i) + 1]);
     }
 }

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx2.h"
 #include "wots.h"
 #include "wotsx2.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/params.h
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/sign.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/thash_shake_simplex2.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/thash_shake_simplex2.c
@@ -1,15 +1,16 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 #include "thashx2.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
 #include "f1600x2.h"
 #include "fips202x2.h"
+
 
 void thash(unsigned char *out,
            const unsigned char *in,
@@ -36,47 +37,47 @@ void thashx2(unsigned char *out0,
          * build and extract from the twoway SHAKE256 state by hand. */
         uint64_t state[50] = {0};
         for (int i = 0; i < SPX_N / 8; i++) {
-            uint64_t x = load64(ctx->pub_seed + 8 * i);
+            uint64_t x = load64(ctx->pub_seed + (8 * i));
             state[2 * i] = x;
-            state[2 * i + 1] = x;
+            state[(2 * i) + 1] = x;
         }
         for (int i = 0; i < 4; i++) {
-            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                          | (uint64_t)addrx2[2 * i];
-            state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                             | (uint64_t)addrx2[8 + 2 * i];
+            state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                               | (uint64_t)addrx2[8 + (2 * i)];
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + 8 * i);
-            state[2 * (SPX_N / 8 + 4 + i) + 1] = load64(in1 + 8 * i);
+            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + (8 * i));
+            state[(2 * (SPX_N / 8 + 4 + i)) + 1] = load64(in1 + (8 * i));
         }
 
         /* Domain separator and padding. */
         state[2 * 16] = 0x80ULL << 56;
-        state[2 * 16 + 1] = 0x80ULL << 56;
+        state[(2 * 16) + 1] = 0x80ULL << 56;
 
         state[2 * ((SPX_N / 8) * (1 + inblocks) + 4)] ^= 0x1f;
-        state[2 * ((SPX_N / 8) * (1 + inblocks) + 4) + 1] ^= 0x1f;
+        state[(2 * ((SPX_N / 8) * (1 + inblocks) + 4)) + 1] ^= 0x1f;
 
         f1600x2(state);
 
         for (int i = 0; i < SPX_N / 8; i++) {
-            store64(out0 + 8 * i, state[2 * i]);
-            store64(out1 + 8 * i, state[2 * i + 1]);
+            store64(out0 + (8 * i), state[2 * i]);
+            store64(out1 + (8 * i), state[(2 * i) + 1]);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx2 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx2 + 1 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx2 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx2 + (1 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
 
         shake256x2(out0, out1, SPX_N,
-                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/utils.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/utils.h
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/wots.c
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/wots.c
@@ -2,15 +2,14 @@
 #include <string.h>
 
 #include "wots.h"
+#include "context.h"
 #include "wotsx2.h"
 
 #include "address.h"
-#include "hash.h"
 #include "hashx2.h"
 #include "params.h"
 #include "thashx2.h"
 #include "utils.h"
-#include "utilsx2.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -39,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr} */
     for (j = 0; j < 2; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -64,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 2) {
         for (j = 0; j < 2 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -92,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx2(bufs[0], bufs[1],
@@ -203,8 +202,8 @@ void wots_gen_leafx2(unsigned char *dest,
     }
 
     for (j = 0; j < 2; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -213,15 +212,15 @@ void wots_gen_leafx2(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 2; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx2(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
+        prf_addrx2(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
                    ctx, leaf_addr);
         for (j = 0; j < 2; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -229,8 +228,8 @@ void wots_gen_leafx2(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -240,20 +239,20 @@ void wots_gen_leafx2(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 2; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx2(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
+            thashx2(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
                     1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx2(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
+    thashx2(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
             SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-192s-simple/aarch64/wots.h
+++ b/crypto_sign/sphincs-shake-192s-simple/aarch64/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/address.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/fips202x4.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/fips202x4.c
@@ -46,12 +46,13 @@ static void keccak_absorb4x(__m256i *s,
 
     unsigned long long *ss = (unsigned long long *)s;
 
+
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            ss[4 * i + 0] ^= load64(m0 + 8 * i);
-            ss[4 * i + 1] ^= load64(m1 + 8 * i);
-            ss[4 * i + 2] ^= load64(m2 + 8 * i);
-            ss[4 * i + 3] ^= load64(m3 + 8 * i);
+            ss[(4 * i) + 0] ^= load64(m0 + (8 * i));
+            ss[(4 * i) + 1] ^= load64(m1 + (8 * i));
+            ss[(4 * i) + 2] ^= load64(m2 + (8 * i));
+            ss[(4 * i) + 3] ^= load64(m3 + (8 * i));
         }
 
         KeccakF1600_StatePermute4x(s);
@@ -86,12 +87,13 @@ static void keccak_absorb4x(__m256i *s,
     t3[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        ss[4 * i + 0] ^= load64(t0 + 8 * i);
-        ss[4 * i + 1] ^= load64(t1 + 8 * i);
-        ss[4 * i + 2] ^= load64(t2 + 8 * i);
-        ss[4 * i + 3] ^= load64(t3 + 8 * i);
+        ss[(4 * i) + 0] ^= load64(t0 + (8 * i));
+        ss[(4 * i) + 1] ^= load64(t1 + (8 * i));
+        ss[(4 * i) + 2] ^= load64(t2 + (8 * i));
+        ss[(4 * i) + 3] ^= load64(t3 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks4x(unsigned char *h0,
                                    unsigned char *h1,
@@ -107,10 +109,10 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
     while (nblocks > 0) {
         KeccakF1600_StatePermute4x(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, ss[4 * i + 0]);
-            store64(h1 + 8 * i, ss[4 * i + 1]);
-            store64(h2 + 8 * i, ss[4 * i + 2]);
-            store64(h3 + 8 * i, ss[4 * i + 3]);
+            store64(h0 + (8 * i), ss[(4 * i) + 0]);
+            store64(h1 + (8 * i), ss[(4 * i) + 1]);
+            store64(h2 + (8 * i), ss[(4 * i) + 2]);
+            store64(h3 + (8 * i), ss[(4 * i) + 3]);
         }
         h0 += r;
         h1 += r;
@@ -119,6 +121,8 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
         nblocks--;
     }
 }
+
+
 
 void shake128x4(unsigned char *out0,
                 unsigned char *out1,
@@ -161,6 +165,7 @@ void shake128x4(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x4(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx4.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -60,28 +60,28 @@ static void fors_gen_leafx4(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 4; j++) {
-        set_tree_index(fors_leaf_addrx4 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx4 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx4(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
+    fors_gen_skx4(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
                   ctx, fors_leaf_addrx4);
 
     for (j = 0; j < 4; j++) {
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx4(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
+    fors_sk_to_leafx4(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
                       ctx, fors_leaf_addrx4);
 }
 
@@ -121,9 +121,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 4; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -143,7 +143,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx4(roots + i * SPX_N, sig, ctx,
+        treehashx4(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx4,
                    fors_tree_addr, &fors_info);
 
@@ -192,7 +192,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/hash_shake.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/hash_shakex4.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/hash_shakex4.c
@@ -1,10 +1,9 @@
+#include <immintrin.h>
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx4.h"
 
-#include "address.h"
-#include "fips202x4.h"
 #include "params.h"
 
 extern void KeccakP1600times4_PermuteAll_24rounds(__m256i *s);
@@ -26,24 +25,24 @@ void prf_addrx4(unsigned char *out0,
         state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
     }
     for (int i = 0; i < 4; i++) {
-        state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                   (int)addrx4[3 * 8 + 1 + 2 * i],
-                                   (int)addrx4[3 * 8 + 2 * i],
-                                   (int)addrx4[2 * 8 + 1 + 2 * i],
-                                   (int)addrx4[2 * 8 + 2 * i],
-                                   (int)addrx4[8 + 1 + 2 * i],
-                                   (int)addrx4[8 + 2 * i],
-                                   (int)addrx4[1 + 2 * i],
-                                   (int)addrx4[2 * i]
-                               );
+        state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                     (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(3 * 8) + (2 * i)],
+                                     (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(2 * 8) + (2 * i)],
+                                     (int)addrx4[8 + 1 + (2 * i)],
+                                     (int)addrx4[8 + (2 * i)],
+                                     (int)addrx4[1 + (2 * i)],
+                                     (int)addrx4[2 * i]
+                                 );
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        state[SPX_N / 8 + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
+        state[(SPX_N / 8) + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
     }
 
     /* SHAKE domain separator and padding. */
-    state[SPX_N / 4 + 4] = _mm256_set1_epi64x(0x1f);
-    for (int i = SPX_N / 4 + 5; i < 16; i++) {
+    state[(SPX_N / 4) + 4] = _mm256_set1_epi64x(0x1f);
+    for (int i = (SPX_N / 4) + 5; i < 16; i++) {
         state[i] = _mm256_set1_epi64x(0);
     }
     // shift unsigned and then cast to avoid UB

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx4.h"
 #include "wots.h"
 #include "wotsx4.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/params.h
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/thash_shake_simplex4.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/thash_shake_simplex4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thashx4.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -31,34 +31,34 @@ void thashx4(unsigned char *out0,
             state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
         }
         for (int i = 0; i < 4; i++) {
-            state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                       (int)addrx4[3 * 8 + 1 + 2 * i],
-                                       (int)addrx4[3 * 8 + 2 * i],
-                                       (int)addrx4[2 * 8 + 1 + 2 * i],
-                                       (int)addrx4[2 * 8 + 2 * i],
-                                       (int)addrx4[8 + 1 + 2 * i],
-                                       (int)addrx4[8 + 2 * i],
-                                       (int)addrx4[1 + 2 * i],
-                                       (int)addrx4[2 * i]
-                                   );
+            state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                         (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(3 * 8) + (2 * i)],
+                                         (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(2 * 8) + (2 * i)],
+                                         (int)addrx4[8 + 1 + (2 * i)],
+                                         (int)addrx4[8 + (2 * i)],
+                                         (int)addrx4[1 + (2 * i)],
+                                         (int)addrx4[2 * i]
+                                     );
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[SPX_N / 8 + 4 + i] = _mm256_set_epi64x(
-                                           ((int64_t *)in3)[i],
-                                           ((int64_t *)in2)[i],
-                                           ((int64_t *)in1)[i],
-                                           ((int64_t *)in0)[i]
-                                       );
+            state[(SPX_N / 8) + 4 + i] = _mm256_set_epi64x(
+                                             ((int64_t *)in3)[i],
+                                             ((int64_t *)in2)[i],
+                                             ((int64_t *)in1)[i],
+                                             ((int64_t *)in0)[i]
+                                         );
         }
 
         /* Domain separator and padding. */
-        for (size_t i = (SPX_N / 8) * (1 + inblocks) + 4; i < 16; i++) {
+        for (size_t i = ((SPX_N / 8) * (1 + inblocks)) + 4; i < 16; i++) {
             state[i] = _mm256_set1_epi64x(0);
         }
         state[16] = _mm256_set1_epi64x((long long)(0x80ULL << 56));
-        state[(SPX_N / 8) * (1 + inblocks) + 4] = _mm256_xor_si256(
-                state[(SPX_N / 8) * (1 + inblocks) + 4],
+        state[((SPX_N / 8) * (1 + inblocks)) + 4] = _mm256_xor_si256(
+                state[((SPX_N / 8) * (1 + inblocks)) + 4],
                 _mm256_set1_epi64x(0x1f)
             );
         for (int i = 17; i < 25; i++) {
@@ -74,25 +74,25 @@ void thashx4(unsigned char *out0,
             ((int64_t *)out3)[i] = _mm256_extract_epi64(state[i], 3);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
         memcpy(buf2, ctx->pub_seed, SPX_N);
         memcpy(buf3, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx4 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx4 + 1 * 8, SPX_ADDR_BYTES);
-        memcpy(buf2 + SPX_N, addrx4 + 2 * 8, SPX_ADDR_BYTES);
-        memcpy(buf3 + SPX_N, addrx4 + 3 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx4 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx4 + (1 * 8), SPX_ADDR_BYTES);
+        memcpy(buf2 + SPX_N, addrx4 + (2 * 8), SPX_ADDR_BYTES);
+        memcpy(buf3 + SPX_N, addrx4 + (3 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
         memcpy(buf2 + SPX_N + SPX_ADDR_BYTES, in2, inblocks * SPX_N);
         memcpy(buf3 + SPX_N + SPX_ADDR_BYTES, in3, inblocks * SPX_N);
 
         shake256x4(out0, out1, out2, out3, SPX_N,
-                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/utilsx4.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/utilsx4.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx4.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -56,7 +58,7 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = (1U << (tree_height - 2)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[4 * SPX_N]; /* Current logical node */
-        gen_leafx4( current, ctx, 4 * idx + idx_offset,
+        gen_leafx4( current, ctx, (4 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
             unsigned int j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 4; j++) {
-                set_tree_height(tree_addrx4 + j * 8, h + 1);
-                set_tree_index(tree_addrx4 + j * 8,
-                               (4 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx4 + (j * 8), h + 1);
+                set_tree_index(tree_addrx4 + (j * 8),
+                               ((4 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx4[h * 4 * SPX_N];
             thashx4( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx4.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
-#include "utilsx4.h"
 #include "wotsx4.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, addr, addr} */
     for (j = 0; j < 4; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 4) {
         for (j = 0; j < 4 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx4(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -147,7 +145,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -204,8 +202,8 @@ void wots_gen_leafx4(unsigned char *dest,
     }
 
     for (j = 0; j < 4; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -214,18 +212,18 @@ void wots_gen_leafx4(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 4; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx4(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
+        prf_addrx4(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 4; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -233,8 +231,8 @@ void wots_gen_leafx4(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -244,26 +242,26 @@ void wots_gen_leafx4(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 4; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx4(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset, 1, ctx, leaf_addr);
+            thashx4(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx4(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx4(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-192s-simple/avx2/wotsx4.h
+++ b/crypto_sign/sphincs-shake-192s-simple/avx2/wotsx4.h
@@ -24,7 +24,7 @@ struct leaf_info_x4 {
 /* Used only by the benchmark code */
 #define INITIALIZE_LEAF_INFO_X4(info, addr, step_buffer) { \
         (info).wots_sig = 0;             \
-        (info).wots_sign_leaf = ~0;      \
+        (info).wots_sign_leaf = ~0U;     \
         (info).wots_steps = step_buffer; \
         int i;                         \
         for (i=0; i<4; i++) {          \

--- a/crypto_sign/sphincs-shake-192s-simple/clean/address.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-192s-simple/clean/context.h
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/context.h
@@ -10,6 +10,7 @@ typedef struct {
     uint8_t pub_seed[SPX_N];
     uint8_t sk_seed[SPX_N];
 
+
 } spx_ctx;
 
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)

--- a/crypto_sign/sphincs-shake-192s-simple/clean/fors.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-192s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-192s-simple/clean/hash_shake.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-192s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-192s-simple/clean/params.h
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-192s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-192s-simple/clean/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-192s-simple/clean/utils.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-192s-simple/clean/utils.h
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-192s-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-shake-192s-simple/clean/wots.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-shake-192s-simple/clean/wots.h
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-192s-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-shake-192s-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-shake-256f-simple/META.yml
+++ b/crypto_sign/sphincs-shake-256f-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-256f-simple/META.yml
+++ b/crypto_sign/sphincs-shake-256f-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/address.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/f1600x2.h
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/f1600x2.h
@@ -1,8 +1,10 @@
 #ifndef SPX_F1600X2_H
 #define SPX_F1600X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define f1600_RC SPX_NAMESPACE(f1600_RC)
 extern uint64_t f1600_RC[24];
 extern void _f1600x2(uint64_t *a, uint64_t *rc);
 

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/f1600x2_const.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/f1600x2_const.c
@@ -1,4 +1,5 @@
 #include "f1600x2.h"
+#include <stdint.h>
 
 uint64_t f1600_RC[24] = {
     0x0000000000000001,

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/fips202x2.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/fips202x2.c
@@ -35,8 +35,8 @@ static void keccak_absorb2x(uint64_t *s,
 
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            s[2 * i + 0] ^= load64(m0 + 8 * i);
-            s[2 * i + 1] ^= load64(m1 + 8 * i);
+            s[(2 * i) + 0] ^= load64(m0 + (8 * i));
+            s[(2 * i) + 1] ^= load64(m1 + (8 * i));
         }
 
         f1600x2(s);
@@ -61,10 +61,11 @@ static void keccak_absorb2x(uint64_t *s,
     t1[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        s[2 * i + 0] ^= load64(t0 + 8 * i);
-        s[2 * i + 1] ^= load64(t1 + 8 * i);
+        s[(2 * i) + 0] ^= load64(t0 + (8 * i));
+        s[(2 * i) + 1] ^= load64(t1 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks2x(unsigned char *h0,
                                    unsigned char *h1,
@@ -76,14 +77,16 @@ static void keccak_squeezeblocks2x(unsigned char *h0,
     while (nblocks > 0) {
         f1600x2(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, s[2 * i + 0]);
-            store64(h1 + 8 * i, s[2 * i + 1]);
+            store64(h0 + (8 * i), s[(2 * i) + 0]);
+            store64(h1 + (8 * i), s[(2 * i) + 1]);
         }
         h0 += r;
         h1 += r;
         nblocks--;
     }
 }
+
+
 
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
@@ -113,6 +116,7 @@ void shake128x2(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/fips202x2.h
@@ -6,6 +6,7 @@
 uint64_t load64(const unsigned char *x);
 void store64(uint8_t *x, uint64_t u);
 
+
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/fips202x2.h
@@ -1,12 +1,15 @@
 #ifndef SPX_FIPS202X2_H
 #define SPX_FIPS202X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define load64 SPX_NAMESPACE(load64)
 uint64_t load64(const unsigned char *x);
+#define store64 SPX_NAMESPACE(store64)
 void store64(uint8_t *x, uint64_t u);
 
-
+#define shake128x2 SPX_NAMESPACE(shake128x2)
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,
@@ -14,6 +17,7 @@ void shake128x2(unsigned char *out0,
                 unsigned char *in1,
                 unsigned long long inlen);
 
+#define shake256x2 SPX_NAMESPACE(shake256x2)
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/fors.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx2.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx2.h"
 #include "utils.h"
@@ -55,22 +55,22 @@ static void fors_gen_leafx2(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 2; j++) {
-        set_tree_index(fors_leaf_addrx2 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx2 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx2(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
+    fors_gen_skx2(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
                   ctx, fors_leaf_addrx2);
 
     for (j = 0; j < 2; j++) {
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx2(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
+    fors_sk_to_leafx2(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
                       ctx, fors_leaf_addrx2);
 }
 
@@ -110,9 +110,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 2; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -132,7 +132,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx2(roots + i * SPX_N, sig, ctx,
+        treehashx2(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx2,
                    fors_tree_addr, &fors_info);
 
@@ -181,7 +181,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/hash.h
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/hash_shake.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/hash_shakex2.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/hash_shakex2.c
@@ -1,9 +1,8 @@
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx2.h"
 
-#include "address.h"
 #include "f1600x2.h"
 #include "fips202x2.h"
 #include "params.h"
@@ -20,33 +19,33 @@ void prf_addrx2(unsigned char *out0,
     uint64_t state[50] = {0};
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->pub_seed + 8 * i);
+        uint64_t x = load64(ctx->pub_seed + (8 * i));
         state[2 * i] = x;
-        state[2 * i + 1] = x;
+        state[(2 * i) + 1] = x;
     }
     for (int i = 0; i < 4; i++) {
-        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                      | (uint64_t)addrx2[2 * i];
-        state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                         | (uint64_t)addrx2[8 + 2 * i];
+        state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                           | (uint64_t)addrx2[8 + (2 * i)];
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->sk_seed + 8 * i);
+        uint64_t x = load64(ctx->sk_seed + (8 * i));
         state[2 * (SPX_N / 8 + i + 4)] = x;
-        state[2 * (SPX_N / 8 + i + 4) + 1] = x;
+        state[(2 * (SPX_N / 8 + i + 4)) + 1] = x;
     }
 
     /* SHAKE domain separator and padding. */
     state[2 * (SPX_N / 4 + 4)] = 0x1f;
-    state[2 * (SPX_N / 4 + 4) + 1] = 0x1f;
+    state[(2 * (SPX_N / 4 + 4)) + 1] = 0x1f;
 
     state[2 * 16] = 0x80ULL << 56;
-    state[2 * 16 + 1] = 0x80ULL << 56;
+    state[(2 * 16) + 1] = 0x80ULL << 56;
 
     f1600x2(state);
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        store64(out0 + 8 * i, state[2 * i]);
-        store64(out1 + 8 * i, state[2 * i + 1]);
+        store64(out0 + (8 * i), state[2 * i]);
+        store64(out1 + (8 * i), state[(2 * i) + 1]);
     }
 }

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx2.h"
 #include "wots.h"
 #include "wotsx2.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/params.h
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/sign.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/thash_shake_simplex2.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/thash_shake_simplex2.c
@@ -1,15 +1,16 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 #include "thashx2.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
 #include "f1600x2.h"
 #include "fips202x2.h"
+
 
 void thash(unsigned char *out,
            const unsigned char *in,
@@ -36,47 +37,47 @@ void thashx2(unsigned char *out0,
          * build and extract from the twoway SHAKE256 state by hand. */
         uint64_t state[50] = {0};
         for (int i = 0; i < SPX_N / 8; i++) {
-            uint64_t x = load64(ctx->pub_seed + 8 * i);
+            uint64_t x = load64(ctx->pub_seed + (8 * i));
             state[2 * i] = x;
-            state[2 * i + 1] = x;
+            state[(2 * i) + 1] = x;
         }
         for (int i = 0; i < 4; i++) {
-            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                          | (uint64_t)addrx2[2 * i];
-            state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                             | (uint64_t)addrx2[8 + 2 * i];
+            state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                               | (uint64_t)addrx2[8 + (2 * i)];
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + 8 * i);
-            state[2 * (SPX_N / 8 + 4 + i) + 1] = load64(in1 + 8 * i);
+            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + (8 * i));
+            state[(2 * (SPX_N / 8 + 4 + i)) + 1] = load64(in1 + (8 * i));
         }
 
         /* Domain separator and padding. */
         state[2 * 16] = 0x80ULL << 56;
-        state[2 * 16 + 1] = 0x80ULL << 56;
+        state[(2 * 16) + 1] = 0x80ULL << 56;
 
         state[2 * ((SPX_N / 8) * (1 + inblocks) + 4)] ^= 0x1f;
-        state[2 * ((SPX_N / 8) * (1 + inblocks) + 4) + 1] ^= 0x1f;
+        state[(2 * ((SPX_N / 8) * (1 + inblocks) + 4)) + 1] ^= 0x1f;
 
         f1600x2(state);
 
         for (int i = 0; i < SPX_N / 8; i++) {
-            store64(out0 + 8 * i, state[2 * i]);
-            store64(out1 + 8 * i, state[2 * i + 1]);
+            store64(out0 + (8 * i), state[2 * i]);
+            store64(out1 + (8 * i), state[(2 * i) + 1]);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx2 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx2 + 1 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx2 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx2 + (1 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
 
         shake256x2(out0, out1, SPX_N,
-                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/utils.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/utils.h
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/wots.c
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/wots.c
@@ -2,15 +2,14 @@
 #include <string.h>
 
 #include "wots.h"
+#include "context.h"
 #include "wotsx2.h"
 
 #include "address.h"
-#include "hash.h"
 #include "hashx2.h"
 #include "params.h"
 #include "thashx2.h"
 #include "utils.h"
-#include "utilsx2.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -39,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr} */
     for (j = 0; j < 2; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -64,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 2) {
         for (j = 0; j < 2 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -92,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx2(bufs[0], bufs[1],
@@ -203,8 +202,8 @@ void wots_gen_leafx2(unsigned char *dest,
     }
 
     for (j = 0; j < 2; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -213,15 +212,15 @@ void wots_gen_leafx2(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 2; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx2(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
+        prf_addrx2(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
                    ctx, leaf_addr);
         for (j = 0; j < 2; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -229,8 +228,8 @@ void wots_gen_leafx2(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -240,20 +239,20 @@ void wots_gen_leafx2(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 2; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx2(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
+            thashx2(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
                     1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx2(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
+    thashx2(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
             SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-256f-simple/aarch64/wots.h
+++ b/crypto_sign/sphincs-shake-256f-simple/aarch64/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/address.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/fips202x4.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/fips202x4.c
@@ -46,12 +46,13 @@ static void keccak_absorb4x(__m256i *s,
 
     unsigned long long *ss = (unsigned long long *)s;
 
+
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            ss[4 * i + 0] ^= load64(m0 + 8 * i);
-            ss[4 * i + 1] ^= load64(m1 + 8 * i);
-            ss[4 * i + 2] ^= load64(m2 + 8 * i);
-            ss[4 * i + 3] ^= load64(m3 + 8 * i);
+            ss[(4 * i) + 0] ^= load64(m0 + (8 * i));
+            ss[(4 * i) + 1] ^= load64(m1 + (8 * i));
+            ss[(4 * i) + 2] ^= load64(m2 + (8 * i));
+            ss[(4 * i) + 3] ^= load64(m3 + (8 * i));
         }
 
         KeccakF1600_StatePermute4x(s);
@@ -86,12 +87,13 @@ static void keccak_absorb4x(__m256i *s,
     t3[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        ss[4 * i + 0] ^= load64(t0 + 8 * i);
-        ss[4 * i + 1] ^= load64(t1 + 8 * i);
-        ss[4 * i + 2] ^= load64(t2 + 8 * i);
-        ss[4 * i + 3] ^= load64(t3 + 8 * i);
+        ss[(4 * i) + 0] ^= load64(t0 + (8 * i));
+        ss[(4 * i) + 1] ^= load64(t1 + (8 * i));
+        ss[(4 * i) + 2] ^= load64(t2 + (8 * i));
+        ss[(4 * i) + 3] ^= load64(t3 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks4x(unsigned char *h0,
                                    unsigned char *h1,
@@ -107,10 +109,10 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
     while (nblocks > 0) {
         KeccakF1600_StatePermute4x(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, ss[4 * i + 0]);
-            store64(h1 + 8 * i, ss[4 * i + 1]);
-            store64(h2 + 8 * i, ss[4 * i + 2]);
-            store64(h3 + 8 * i, ss[4 * i + 3]);
+            store64(h0 + (8 * i), ss[(4 * i) + 0]);
+            store64(h1 + (8 * i), ss[(4 * i) + 1]);
+            store64(h2 + (8 * i), ss[(4 * i) + 2]);
+            store64(h3 + (8 * i), ss[(4 * i) + 3]);
         }
         h0 += r;
         h1 += r;
@@ -119,6 +121,8 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
         nblocks--;
     }
 }
+
+
 
 void shake128x4(unsigned char *out0,
                 unsigned char *out1,
@@ -161,6 +165,7 @@ void shake128x4(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x4(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx4.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -60,28 +60,28 @@ static void fors_gen_leafx4(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 4; j++) {
-        set_tree_index(fors_leaf_addrx4 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx4 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx4(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
+    fors_gen_skx4(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
                   ctx, fors_leaf_addrx4);
 
     for (j = 0; j < 4; j++) {
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx4(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
+    fors_sk_to_leafx4(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
                       ctx, fors_leaf_addrx4);
 }
 
@@ -121,9 +121,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 4; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -143,7 +143,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx4(roots + i * SPX_N, sig, ctx,
+        treehashx4(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx4,
                    fors_tree_addr, &fors_info);
 
@@ -192,7 +192,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/hash_shake.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/hash_shakex4.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/hash_shakex4.c
@@ -1,10 +1,9 @@
+#include <immintrin.h>
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx4.h"
 
-#include "address.h"
-#include "fips202x4.h"
 #include "params.h"
 
 extern void KeccakP1600times4_PermuteAll_24rounds(__m256i *s);
@@ -26,24 +25,24 @@ void prf_addrx4(unsigned char *out0,
         state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
     }
     for (int i = 0; i < 4; i++) {
-        state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                   (int)addrx4[3 * 8 + 1 + 2 * i],
-                                   (int)addrx4[3 * 8 + 2 * i],
-                                   (int)addrx4[2 * 8 + 1 + 2 * i],
-                                   (int)addrx4[2 * 8 + 2 * i],
-                                   (int)addrx4[8 + 1 + 2 * i],
-                                   (int)addrx4[8 + 2 * i],
-                                   (int)addrx4[1 + 2 * i],
-                                   (int)addrx4[2 * i]
-                               );
+        state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                     (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(3 * 8) + (2 * i)],
+                                     (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(2 * 8) + (2 * i)],
+                                     (int)addrx4[8 + 1 + (2 * i)],
+                                     (int)addrx4[8 + (2 * i)],
+                                     (int)addrx4[1 + (2 * i)],
+                                     (int)addrx4[2 * i]
+                                 );
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        state[SPX_N / 8 + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
+        state[(SPX_N / 8) + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
     }
 
     /* SHAKE domain separator and padding. */
-    state[SPX_N / 4 + 4] = _mm256_set1_epi64x(0x1f);
-    for (int i = SPX_N / 4 + 5; i < 16; i++) {
+    state[(SPX_N / 4) + 4] = _mm256_set1_epi64x(0x1f);
+    for (int i = (SPX_N / 4) + 5; i < 16; i++) {
         state[i] = _mm256_set1_epi64x(0);
     }
     // shift unsigned and then cast to avoid UB

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx4.h"
 #include "wots.h"
 #include "wotsx4.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/params.h
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/thash_shake_simplex4.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/thash_shake_simplex4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thashx4.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -31,34 +31,34 @@ void thashx4(unsigned char *out0,
             state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
         }
         for (int i = 0; i < 4; i++) {
-            state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                       (int)addrx4[3 * 8 + 1 + 2 * i],
-                                       (int)addrx4[3 * 8 + 2 * i],
-                                       (int)addrx4[2 * 8 + 1 + 2 * i],
-                                       (int)addrx4[2 * 8 + 2 * i],
-                                       (int)addrx4[8 + 1 + 2 * i],
-                                       (int)addrx4[8 + 2 * i],
-                                       (int)addrx4[1 + 2 * i],
-                                       (int)addrx4[2 * i]
-                                   );
+            state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                         (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(3 * 8) + (2 * i)],
+                                         (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(2 * 8) + (2 * i)],
+                                         (int)addrx4[8 + 1 + (2 * i)],
+                                         (int)addrx4[8 + (2 * i)],
+                                         (int)addrx4[1 + (2 * i)],
+                                         (int)addrx4[2 * i]
+                                     );
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[SPX_N / 8 + 4 + i] = _mm256_set_epi64x(
-                                           ((int64_t *)in3)[i],
-                                           ((int64_t *)in2)[i],
-                                           ((int64_t *)in1)[i],
-                                           ((int64_t *)in0)[i]
-                                       );
+            state[(SPX_N / 8) + 4 + i] = _mm256_set_epi64x(
+                                             ((int64_t *)in3)[i],
+                                             ((int64_t *)in2)[i],
+                                             ((int64_t *)in1)[i],
+                                             ((int64_t *)in0)[i]
+                                         );
         }
 
         /* Domain separator and padding. */
-        for (size_t i = (SPX_N / 8) * (1 + inblocks) + 4; i < 16; i++) {
+        for (size_t i = ((SPX_N / 8) * (1 + inblocks)) + 4; i < 16; i++) {
             state[i] = _mm256_set1_epi64x(0);
         }
         state[16] = _mm256_set1_epi64x((long long)(0x80ULL << 56));
-        state[(SPX_N / 8) * (1 + inblocks) + 4] = _mm256_xor_si256(
-                state[(SPX_N / 8) * (1 + inblocks) + 4],
+        state[((SPX_N / 8) * (1 + inblocks)) + 4] = _mm256_xor_si256(
+                state[((SPX_N / 8) * (1 + inblocks)) + 4],
                 _mm256_set1_epi64x(0x1f)
             );
         for (int i = 17; i < 25; i++) {
@@ -74,25 +74,25 @@ void thashx4(unsigned char *out0,
             ((int64_t *)out3)[i] = _mm256_extract_epi64(state[i], 3);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
         memcpy(buf2, ctx->pub_seed, SPX_N);
         memcpy(buf3, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx4 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx4 + 1 * 8, SPX_ADDR_BYTES);
-        memcpy(buf2 + SPX_N, addrx4 + 2 * 8, SPX_ADDR_BYTES);
-        memcpy(buf3 + SPX_N, addrx4 + 3 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx4 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx4 + (1 * 8), SPX_ADDR_BYTES);
+        memcpy(buf2 + SPX_N, addrx4 + (2 * 8), SPX_ADDR_BYTES);
+        memcpy(buf3 + SPX_N, addrx4 + (3 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
         memcpy(buf2 + SPX_N + SPX_ADDR_BYTES, in2, inblocks * SPX_N);
         memcpy(buf3 + SPX_N + SPX_ADDR_BYTES, in3, inblocks * SPX_N);
 
         shake256x4(out0, out1, out2, out3, SPX_N,
-                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/utilsx4.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/utilsx4.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx4.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -56,7 +58,7 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = (1U << (tree_height - 2)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[4 * SPX_N]; /* Current logical node */
-        gen_leafx4( current, ctx, 4 * idx + idx_offset,
+        gen_leafx4( current, ctx, (4 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
             unsigned int j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 4; j++) {
-                set_tree_height(tree_addrx4 + j * 8, h + 1);
-                set_tree_index(tree_addrx4 + j * 8,
-                               (4 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx4 + (j * 8), h + 1);
+                set_tree_index(tree_addrx4 + (j * 8),
+                               ((4 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx4[h * 4 * SPX_N];
             thashx4( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx4.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
-#include "utilsx4.h"
 #include "wotsx4.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, addr, addr} */
     for (j = 0; j < 4; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 4) {
         for (j = 0; j < 4 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx4(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -147,7 +145,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -204,8 +202,8 @@ void wots_gen_leafx4(unsigned char *dest,
     }
 
     for (j = 0; j < 4; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -214,18 +212,18 @@ void wots_gen_leafx4(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 4; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx4(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
+        prf_addrx4(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 4; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -233,8 +231,8 @@ void wots_gen_leafx4(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -244,26 +242,26 @@ void wots_gen_leafx4(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 4; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx4(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset, 1, ctx, leaf_addr);
+            thashx4(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx4(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx4(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-256f-simple/avx2/wotsx4.h
+++ b/crypto_sign/sphincs-shake-256f-simple/avx2/wotsx4.h
@@ -24,7 +24,7 @@ struct leaf_info_x4 {
 /* Used only by the benchmark code */
 #define INITIALIZE_LEAF_INFO_X4(info, addr, step_buffer) { \
         (info).wots_sig = 0;             \
-        (info).wots_sign_leaf = ~0;      \
+        (info).wots_sign_leaf = ~0U;     \
         (info).wots_steps = step_buffer; \
         int i;                         \
         for (i=0; i<4; i++) {          \

--- a/crypto_sign/sphincs-shake-256f-simple/clean/address.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-256f-simple/clean/context.h
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/context.h
@@ -10,6 +10,7 @@ typedef struct {
     uint8_t pub_seed[SPX_N];
     uint8_t sk_seed[SPX_N];
 
+
 } spx_ctx;
 
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)

--- a/crypto_sign/sphincs-shake-256f-simple/clean/fors.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-256f-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-256f-simple/clean/hash_shake.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-256f-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-256f-simple/clean/params.h
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-256f-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-256f-simple/clean/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-256f-simple/clean/utils.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-256f-simple/clean/utils.h
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-256f-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-shake-256f-simple/clean/wots.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-shake-256f-simple/clean/wots.h
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-256f-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-shake-256f-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */

--- a/crypto_sign/sphincs-shake-256s-simple/META.yml
+++ b/crypto_sign/sphincs-shake-256s-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
+    version: https://github.com/mkannwischer/sphincsplus/tree/ae132f7bf9f90205834c1cbdf5cfb9187d51f48e
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-256s-simple/META.yml
+++ b/crypto_sign/sphincs-shake-256s-simple/META.yml
@@ -28,14 +28,14 @@ auxiliary-submitters:
   - Bas Westerbaan
 implementations:
   - name: clean
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
   - name: avx2
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: x86_64
         required_flags: ['avx2']
   - name: aarch64
-    version: https://github.com/sphincs/sphincsplus/commit/f38d4fdaff9c5889a086955a027f6bd71d8a4a96
+    version: https://github.com/sphincs/sphincsplus/commit/ed15dd78658f63288c7492c00260d86154b84637
     supported_platforms:
       - architecture: arm_8
         required_flags: ['sha3']

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/address.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/f1600x2.h
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/f1600x2.h
@@ -1,8 +1,10 @@
 #ifndef SPX_F1600X2_H
 #define SPX_F1600X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define f1600_RC SPX_NAMESPACE(f1600_RC)
 extern uint64_t f1600_RC[24];
 extern void _f1600x2(uint64_t *a, uint64_t *rc);
 

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/f1600x2_const.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/f1600x2_const.c
@@ -1,4 +1,5 @@
 #include "f1600x2.h"
+#include <stdint.h>
 
 uint64_t f1600_RC[24] = {
     0x0000000000000001,

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/fips202x2.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/fips202x2.c
@@ -35,8 +35,8 @@ static void keccak_absorb2x(uint64_t *s,
 
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            s[2 * i + 0] ^= load64(m0 + 8 * i);
-            s[2 * i + 1] ^= load64(m1 + 8 * i);
+            s[(2 * i) + 0] ^= load64(m0 + (8 * i));
+            s[(2 * i) + 1] ^= load64(m1 + (8 * i));
         }
 
         f1600x2(s);
@@ -61,10 +61,11 @@ static void keccak_absorb2x(uint64_t *s,
     t1[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        s[2 * i + 0] ^= load64(t0 + 8 * i);
-        s[2 * i + 1] ^= load64(t1 + 8 * i);
+        s[(2 * i) + 0] ^= load64(t0 + (8 * i));
+        s[(2 * i) + 1] ^= load64(t1 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks2x(unsigned char *h0,
                                    unsigned char *h1,
@@ -76,14 +77,16 @@ static void keccak_squeezeblocks2x(unsigned char *h0,
     while (nblocks > 0) {
         f1600x2(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, s[2 * i + 0]);
-            store64(h1 + 8 * i, s[2 * i + 1]);
+            store64(h0 + (8 * i), s[(2 * i) + 0]);
+            store64(h1 + (8 * i), s[(2 * i) + 1]);
         }
         h0 += r;
         h1 += r;
         nblocks--;
     }
 }
+
+
 
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
@@ -113,6 +116,7 @@ void shake128x2(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/fips202x2.h
@@ -6,6 +6,7 @@
 uint64_t load64(const unsigned char *x);
 void store64(uint8_t *x, uint64_t u);
 
+
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/fips202x2.h
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/fips202x2.h
@@ -1,12 +1,15 @@
 #ifndef SPX_FIPS202X2_H
 #define SPX_FIPS202X2_H
 
+#include "context.h"
+#include "params.h"
 #include <stdint.h>
-
+#define load64 SPX_NAMESPACE(load64)
 uint64_t load64(const unsigned char *x);
+#define store64 SPX_NAMESPACE(store64)
 void store64(uint8_t *x, uint64_t u);
 
-
+#define shake128x2 SPX_NAMESPACE(shake128x2)
 void shake128x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,
@@ -14,6 +17,7 @@ void shake128x2(unsigned char *out0,
                 unsigned char *in1,
                 unsigned long long inlen);
 
+#define shake256x2 SPX_NAMESPACE(shake256x2)
 void shake256x2(unsigned char *out0,
                 unsigned char *out1,
                 unsigned long long outlen,

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/fors.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx2.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx2.h"
 #include "utils.h"
@@ -55,22 +55,22 @@ static void fors_gen_leafx2(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 2; j++) {
-        set_tree_index(fors_leaf_addrx2 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx2 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx2(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
+    fors_gen_skx2(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
                   ctx, fors_leaf_addrx2);
 
     for (j = 0; j < 2; j++) {
-        set_type(fors_leaf_addrx2 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx2 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx2(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
+    fors_sk_to_leafx2(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
                       ctx, fors_leaf_addrx2);
 }
 
@@ -110,9 +110,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 2; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -132,7 +132,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx2(roots + i * SPX_N, sig, ctx,
+        treehashx2(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx2,
                    fors_tree_addr, &fors_info);
 
@@ -181,7 +181,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/hash.h
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/hash_shake.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/hash_shakex2.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/hash_shakex2.c
@@ -1,9 +1,8 @@
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx2.h"
 
-#include "address.h"
 #include "f1600x2.h"
 #include "fips202x2.h"
 #include "params.h"
@@ -20,33 +19,33 @@ void prf_addrx2(unsigned char *out0,
     uint64_t state[50] = {0};
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->pub_seed + 8 * i);
+        uint64_t x = load64(ctx->pub_seed + (8 * i));
         state[2 * i] = x;
-        state[2 * i + 1] = x;
+        state[(2 * i) + 1] = x;
     }
     for (int i = 0; i < 4; i++) {
-        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+        state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                      | (uint64_t)addrx2[2 * i];
-        state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                         | (uint64_t)addrx2[8 + 2 * i];
+        state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                           | (uint64_t)addrx2[8 + (2 * i)];
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        uint64_t x = load64(ctx->sk_seed + 8 * i);
+        uint64_t x = load64(ctx->sk_seed + (8 * i));
         state[2 * (SPX_N / 8 + i + 4)] = x;
-        state[2 * (SPX_N / 8 + i + 4) + 1] = x;
+        state[(2 * (SPX_N / 8 + i + 4)) + 1] = x;
     }
 
     /* SHAKE domain separator and padding. */
     state[2 * (SPX_N / 4 + 4)] = 0x1f;
-    state[2 * (SPX_N / 4 + 4) + 1] = 0x1f;
+    state[(2 * (SPX_N / 4 + 4)) + 1] = 0x1f;
 
     state[2 * 16] = 0x80ULL << 56;
-    state[2 * 16 + 1] = 0x80ULL << 56;
+    state[(2 * 16) + 1] = 0x80ULL << 56;
 
     f1600x2(state);
 
     for (int i = 0; i < SPX_N / 8; i++) {
-        store64(out0 + 8 * i, state[2 * i]);
-        store64(out1 + 8 * i, state[2 * i + 1]);
+        store64(out0 + (8 * i), state[2 * i]);
+        store64(out1 + (8 * i), state[(2 * i) + 1]);
     }
 }

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/merkle.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx2.h"
 #include "wots.h"
 #include "wotsx2.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/params.h
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/sign.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/thash_shake_simplex2.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/thash_shake_simplex2.c
@@ -1,15 +1,16 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 #include "thashx2.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
 #include "f1600x2.h"
 #include "fips202x2.h"
+
 
 void thash(unsigned char *out,
            const unsigned char *in,
@@ -36,47 +37,47 @@ void thashx2(unsigned char *out0,
          * build and extract from the twoway SHAKE256 state by hand. */
         uint64_t state[50] = {0};
         for (int i = 0; i < SPX_N / 8; i++) {
-            uint64_t x = load64(ctx->pub_seed + 8 * i);
+            uint64_t x = load64(ctx->pub_seed + (8 * i));
             state[2 * i] = x;
-            state[2 * i + 1] = x;
+            state[(2 * i) + 1] = x;
         }
         for (int i = 0; i < 4; i++) {
-            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + 2 * i]) << 32)
+            state[2 * (SPX_N / 8 + i)] = (((uint64_t)addrx2[1 + (2 * i)]) << 32)
                                          | (uint64_t)addrx2[2 * i];
-            state[2 * (SPX_N / 8 + i) + 1] = (((uint64_t)addrx2[8 + 1 + 2 * i]) << 32)
-                                             | (uint64_t)addrx2[8 + 2 * i];
+            state[(2 * (SPX_N / 8 + i)) + 1] = (((uint64_t)addrx2[8 + 1 + (2 * i)]) << 32)
+                                               | (uint64_t)addrx2[8 + (2 * i)];
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + 8 * i);
-            state[2 * (SPX_N / 8 + 4 + i) + 1] = load64(in1 + 8 * i);
+            state[2 * (SPX_N / 8 + 4 + i)] = load64(in0 + (8 * i));
+            state[(2 * (SPX_N / 8 + 4 + i)) + 1] = load64(in1 + (8 * i));
         }
 
         /* Domain separator and padding. */
         state[2 * 16] = 0x80ULL << 56;
-        state[2 * 16 + 1] = 0x80ULL << 56;
+        state[(2 * 16) + 1] = 0x80ULL << 56;
 
         state[2 * ((SPX_N / 8) * (1 + inblocks) + 4)] ^= 0x1f;
-        state[2 * ((SPX_N / 8) * (1 + inblocks) + 4) + 1] ^= 0x1f;
+        state[(2 * ((SPX_N / 8) * (1 + inblocks) + 4)) + 1] ^= 0x1f;
 
         f1600x2(state);
 
         for (int i = 0; i < SPX_N / 8; i++) {
-            store64(out0 + 8 * i, state[2 * i]);
-            store64(out1 + 8 * i, state[2 * i + 1]);
+            store64(out0 + (8 * i), state[2 * i]);
+            store64(out1 + (8 * i), state[(2 * i) + 1]);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx2 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx2 + 1 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx2 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx2 + (1 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
 
         shake256x2(out0, out1, SPX_N,
-                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/utils.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/utils.h
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/wots.c
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/wots.c
@@ -2,15 +2,14 @@
 #include <string.h>
 
 #include "wots.h"
+#include "context.h"
 #include "wotsx2.h"
 
 #include "address.h"
-#include "hash.h"
 #include "hashx2.h"
 #include "params.h"
 #include "thashx2.h"
 #include "utils.h"
-#include "utilsx2.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -39,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr} */
     for (j = 0; j < 2; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -64,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 2) {
         for (j = 0; j < 2 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -92,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx2(bufs[0], bufs[1],
@@ -203,8 +202,8 @@ void wots_gen_leafx2(unsigned char *dest,
     }
 
     for (j = 0; j < 2; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -213,15 +212,15 @@ void wots_gen_leafx2(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 2; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx2(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
+        prf_addrx2(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
                    ctx, leaf_addr);
         for (j = 0; j < 2; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -229,8 +228,8 @@ void wots_gen_leafx2(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -240,20 +239,20 @@ void wots_gen_leafx2(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 2; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx2(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
+            thashx2(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
                     1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx2(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
+    thashx2(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
             SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-256s-simple/aarch64/wots.h
+++ b/crypto_sign/sphincs-shake-256s-simple/aarch64/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/address.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/fips202x4.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/fips202x4.c
@@ -46,12 +46,13 @@ static void keccak_absorb4x(__m256i *s,
 
     unsigned long long *ss = (unsigned long long *)s;
 
+
     while (mlen >= r) {
         for (i = 0; i < r / 8; ++i) {
-            ss[4 * i + 0] ^= load64(m0 + 8 * i);
-            ss[4 * i + 1] ^= load64(m1 + 8 * i);
-            ss[4 * i + 2] ^= load64(m2 + 8 * i);
-            ss[4 * i + 3] ^= load64(m3 + 8 * i);
+            ss[(4 * i) + 0] ^= load64(m0 + (8 * i));
+            ss[(4 * i) + 1] ^= load64(m1 + (8 * i));
+            ss[(4 * i) + 2] ^= load64(m2 + (8 * i));
+            ss[(4 * i) + 3] ^= load64(m3 + (8 * i));
         }
 
         KeccakF1600_StatePermute4x(s);
@@ -86,12 +87,13 @@ static void keccak_absorb4x(__m256i *s,
     t3[r - 1] |= 128;
 
     for (i = 0; i < r / 8; ++i) {
-        ss[4 * i + 0] ^= load64(t0 + 8 * i);
-        ss[4 * i + 1] ^= load64(t1 + 8 * i);
-        ss[4 * i + 2] ^= load64(t2 + 8 * i);
-        ss[4 * i + 3] ^= load64(t3 + 8 * i);
+        ss[(4 * i) + 0] ^= load64(t0 + (8 * i));
+        ss[(4 * i) + 1] ^= load64(t1 + (8 * i));
+        ss[(4 * i) + 2] ^= load64(t2 + (8 * i));
+        ss[(4 * i) + 3] ^= load64(t3 + (8 * i));
     }
 }
+
 
 static void keccak_squeezeblocks4x(unsigned char *h0,
                                    unsigned char *h1,
@@ -107,10 +109,10 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
     while (nblocks > 0) {
         KeccakF1600_StatePermute4x(s);
         for (i = 0; i < (r >> 3); i++) {
-            store64(h0 + 8 * i, ss[4 * i + 0]);
-            store64(h1 + 8 * i, ss[4 * i + 1]);
-            store64(h2 + 8 * i, ss[4 * i + 2]);
-            store64(h3 + 8 * i, ss[4 * i + 3]);
+            store64(h0 + (8 * i), ss[(4 * i) + 0]);
+            store64(h1 + (8 * i), ss[(4 * i) + 1]);
+            store64(h2 + (8 * i), ss[(4 * i) + 2]);
+            store64(h3 + (8 * i), ss[(4 * i) + 3]);
         }
         h0 += r;
         h1 += r;
@@ -119,6 +121,8 @@ static void keccak_squeezeblocks4x(unsigned char *h0,
         nblocks--;
     }
 }
+
+
 
 void shake128x4(unsigned char *out0,
                 unsigned char *out1,
@@ -161,6 +165,7 @@ void shake128x4(unsigned char *out0,
         }
     }
 }
+
 
 void shake256x4(unsigned char *out0,
                 unsigned char *out1,

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/fors.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/fors.c
@@ -1,12 +1,12 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
 #include "hashx4.h"
+#include "params.h"
 #include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -60,28 +60,28 @@ static void fors_gen_leafx4(unsigned char *leaf,
 
     /* Only set the parts that the caller doesn't set */
     for (j = 0; j < 4; j++) {
-        set_tree_index(fors_leaf_addrx4 + j * 8, addr_idx + j);
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSPRF);
+        set_tree_index(fors_leaf_addrx4 + (j * 8), addr_idx + j);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSPRF);
     }
 
-    fors_gen_skx4(leaf + 0 * SPX_N,
-                  leaf + 1 * SPX_N,
-                  leaf + 2 * SPX_N,
-                  leaf + 3 * SPX_N,
+    fors_gen_skx4(leaf + (0 * SPX_N),
+                  leaf + (1 * SPX_N),
+                  leaf + (2 * SPX_N),
+                  leaf + (3 * SPX_N),
                   ctx, fors_leaf_addrx4);
 
     for (j = 0; j < 4; j++) {
-        set_type(fors_leaf_addrx4 + j * 8, SPX_ADDR_TYPE_FORSTREE);
+        set_type(fors_leaf_addrx4 + (j * 8), SPX_ADDR_TYPE_FORSTREE);
     }
 
-    fors_sk_to_leafx4(leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
-                      leaf + 0 * SPX_N,
-                      leaf + 1 * SPX_N,
-                      leaf + 2 * SPX_N,
-                      leaf + 3 * SPX_N,
+    fors_sk_to_leafx4(leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
+                      leaf + (0 * SPX_N),
+                      leaf + (1 * SPX_N),
+                      leaf + (2 * SPX_N),
+                      leaf + (3 * SPX_N),
                       ctx, fors_leaf_addrx4);
 }
 
@@ -121,9 +121,9 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
     unsigned int i;
 
     for (i = 0; i < 4; i++) {
-        copy_keypair_addr(fors_tree_addr + 8 * i, fors_addr);
-        set_type(fors_tree_addr + 8 * i, SPX_ADDR_TYPE_FORSTREE);
-        copy_keypair_addr(fors_leaf_addr + 8 * i, fors_addr);
+        copy_keypair_addr(fors_tree_addr + (8 * i), fors_addr);
+        set_type(fors_tree_addr + (8 * i), SPX_ADDR_TYPE_FORSTREE);
+        copy_keypair_addr(fors_leaf_addr + (8 * i), fors_addr);
     }
     copy_keypair_addr(fors_pk_addr, fors_addr);
     set_type(fors_pk_addr, SPX_ADDR_TYPE_FORSPK);
@@ -143,7 +143,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx4(roots + i * SPX_N, sig, ctx,
+        treehashx4(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx4,
                    fors_tree_addr, &fors_info);
 
@@ -192,7 +192,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/hash.h
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/hash_shake.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/hash_shakex4.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/hash_shakex4.c
@@ -1,10 +1,9 @@
+#include <immintrin.h>
 #include <stdint.h>
-#include <string.h>
 
+#include "context.h"
 #include "hashx4.h"
 
-#include "address.h"
-#include "fips202x4.h"
 #include "params.h"
 
 extern void KeccakP1600times4_PermuteAll_24rounds(__m256i *s);
@@ -26,24 +25,24 @@ void prf_addrx4(unsigned char *out0,
         state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
     }
     for (int i = 0; i < 4; i++) {
-        state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                   (int)addrx4[3 * 8 + 1 + 2 * i],
-                                   (int)addrx4[3 * 8 + 2 * i],
-                                   (int)addrx4[2 * 8 + 1 + 2 * i],
-                                   (int)addrx4[2 * 8 + 2 * i],
-                                   (int)addrx4[8 + 1 + 2 * i],
-                                   (int)addrx4[8 + 2 * i],
-                                   (int)addrx4[1 + 2 * i],
-                                   (int)addrx4[2 * i]
-                               );
+        state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                     (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(3 * 8) + (2 * i)],
+                                     (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                     (int)addrx4[(2 * 8) + (2 * i)],
+                                     (int)addrx4[8 + 1 + (2 * i)],
+                                     (int)addrx4[8 + (2 * i)],
+                                     (int)addrx4[1 + (2 * i)],
+                                     (int)addrx4[2 * i]
+                                 );
     }
     for (int i = 0; i < SPX_N / 8; i++) {
-        state[SPX_N / 8 + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
+        state[(SPX_N / 8) + i + 4] = _mm256_set1_epi64x(((int64_t *)ctx->sk_seed)[i]);
     }
 
     /* SHAKE domain separator and padding. */
-    state[SPX_N / 4 + 4] = _mm256_set1_epi64x(0x1f);
-    for (int i = SPX_N / 4 + 5; i < 16; i++) {
+    state[(SPX_N / 4) + 4] = _mm256_set1_epi64x(0x1f);
+    for (int i = (SPX_N / 4) + 5; i < 16; i++) {
         state[i] = _mm256_set1_epi64x(0);
     }
     // shift unsigned and then cast to avoid UB

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/merkle.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/merkle.c
@@ -1,11 +1,10 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "merkle.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx4.h"
 #include "wots.h"
 #include "wotsx4.h"
@@ -51,7 +50,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/params.h
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/sign.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/thash_shake_simplex4.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/thash_shake_simplex4.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thashx4.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -31,34 +31,34 @@ void thashx4(unsigned char *out0,
             state[i] = _mm256_set1_epi64x(((int64_t *)ctx->pub_seed)[i]);
         }
         for (int i = 0; i < 4; i++) {
-            state[SPX_N / 8 + i] = _mm256_set_epi32(
-                                       (int)addrx4[3 * 8 + 1 + 2 * i],
-                                       (int)addrx4[3 * 8 + 2 * i],
-                                       (int)addrx4[2 * 8 + 1 + 2 * i],
-                                       (int)addrx4[2 * 8 + 2 * i],
-                                       (int)addrx4[8 + 1 + 2 * i],
-                                       (int)addrx4[8 + 2 * i],
-                                       (int)addrx4[1 + 2 * i],
-                                       (int)addrx4[2 * i]
-                                   );
+            state[(SPX_N / 8) + i] = _mm256_set_epi32(
+                                         (int)addrx4[(3 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(3 * 8) + (2 * i)],
+                                         (int)addrx4[(2 * 8) + 1 + (2 * i)],
+                                         (int)addrx4[(2 * 8) + (2 * i)],
+                                         (int)addrx4[8 + 1 + (2 * i)],
+                                         (int)addrx4[8 + (2 * i)],
+                                         (int)addrx4[1 + (2 * i)],
+                                         (int)addrx4[2 * i]
+                                     );
         }
 
         for (unsigned int i = 0; i < (SPX_N / 8) * inblocks; i++) {
-            state[SPX_N / 8 + 4 + i] = _mm256_set_epi64x(
-                                           ((int64_t *)in3)[i],
-                                           ((int64_t *)in2)[i],
-                                           ((int64_t *)in1)[i],
-                                           ((int64_t *)in0)[i]
-                                       );
+            state[(SPX_N / 8) + 4 + i] = _mm256_set_epi64x(
+                                             ((int64_t *)in3)[i],
+                                             ((int64_t *)in2)[i],
+                                             ((int64_t *)in1)[i],
+                                             ((int64_t *)in0)[i]
+                                         );
         }
 
         /* Domain separator and padding. */
-        for (size_t i = (SPX_N / 8) * (1 + inblocks) + 4; i < 16; i++) {
+        for (size_t i = ((SPX_N / 8) * (1 + inblocks)) + 4; i < 16; i++) {
             state[i] = _mm256_set1_epi64x(0);
         }
         state[16] = _mm256_set1_epi64x((long long)(0x80ULL << 56));
-        state[(SPX_N / 8) * (1 + inblocks) + 4] = _mm256_xor_si256(
-                state[(SPX_N / 8) * (1 + inblocks) + 4],
+        state[((SPX_N / 8) * (1 + inblocks)) + 4] = _mm256_xor_si256(
+                state[((SPX_N / 8) * (1 + inblocks)) + 4],
                 _mm256_set1_epi64x(0x1f)
             );
         for (int i = 17; i < 25; i++) {
@@ -74,25 +74,25 @@ void thashx4(unsigned char *out0,
             ((int64_t *)out3)[i] = _mm256_extract_epi64(state[i], 3);
         }
     } else {
-        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
-        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+        PQCLEAN_VLA(unsigned char, buf0, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf1, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf2, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
+        PQCLEAN_VLA(unsigned char, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
         memcpy(buf0, ctx->pub_seed, SPX_N);
         memcpy(buf1, ctx->pub_seed, SPX_N);
         memcpy(buf2, ctx->pub_seed, SPX_N);
         memcpy(buf3, ctx->pub_seed, SPX_N);
-        memcpy(buf0 + SPX_N, addrx4 + 0 * 8, SPX_ADDR_BYTES);
-        memcpy(buf1 + SPX_N, addrx4 + 1 * 8, SPX_ADDR_BYTES);
-        memcpy(buf2 + SPX_N, addrx4 + 2 * 8, SPX_ADDR_BYTES);
-        memcpy(buf3 + SPX_N, addrx4 + 3 * 8, SPX_ADDR_BYTES);
+        memcpy(buf0 + SPX_N, addrx4 + (0 * 8), SPX_ADDR_BYTES);
+        memcpy(buf1 + SPX_N, addrx4 + (1 * 8), SPX_ADDR_BYTES);
+        memcpy(buf2 + SPX_N, addrx4 + (2 * 8), SPX_ADDR_BYTES);
+        memcpy(buf3 + SPX_N, addrx4 + (3 * 8), SPX_ADDR_BYTES);
         memcpy(buf0 + SPX_N + SPX_ADDR_BYTES, in0, inblocks * SPX_N);
         memcpy(buf1 + SPX_N + SPX_ADDR_BYTES, in1, inblocks * SPX_N);
         memcpy(buf2 + SPX_N + SPX_ADDR_BYTES, in2, inblocks * SPX_N);
         memcpy(buf3 + SPX_N + SPX_ADDR_BYTES, in3, inblocks * SPX_N);
 
         shake256x4(out0, out1, out2, out3, SPX_N,
-                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+                   buf0, buf1, buf2, buf3, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
     }
 }

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/utils.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/utils.h
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/utilsx4.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/utilsx4.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx4.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thashx4.h"
 #include "utils.h"
@@ -56,7 +58,7 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
     uint32_t max_idx = (1U << (tree_height - 2)) - 1;
     for (idx = 0;; idx++) {
         unsigned char current[4 * SPX_N]; /* Current logical node */
-        gen_leafx4( current, ctx, 4 * idx + idx_offset,
+        gen_leafx4( current, ctx, (4 * idx) + idx_offset,
                     info );
 
         /* Now combine the freshly generated right node with previously */
@@ -115,9 +117,9 @@ void treehashx4(unsigned char *root, unsigned char *auth_path,
             unsigned int j;
             internal_idx_offset >>= 1;
             for (j = 0; j < 4; j++) {
-                set_tree_height(tree_addrx4 + j * 8, h + 1);
-                set_tree_index(tree_addrx4 + j * 8,
-                               (4 / 2) * (internal_idx & ~1U) + j - left_adj + internal_idx_offset );
+                set_tree_height(tree_addrx4 + (j * 8), h + 1);
+                set_tree_index(tree_addrx4 + (j * 8),
+                               ((4 / 2) * (internal_idx & ~1U)) + j - left_adj + internal_idx_offset );
             }
             unsigned char *left = &stackx4[h * 4 * SPX_N];
             thashx4( &current[0 * SPX_N],

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/wots.c
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/wots.c
@@ -4,13 +4,11 @@
 #include "wots.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "hashx4.h"
 #include "params.h"
-#include "thash.h"
 #include "thashx4.h"
 #include "utils.h"
-#include "utilsx4.h"
 #include "wotsx4.h"
 
 // TODO clarify address expectations, and make them more uniform.
@@ -40,7 +38,7 @@ static void gen_chains(
 
     /* set addrs = {addr, addr, addr, addr} */
     for (j = 0; j < 4; j++) {
-        memcpy(addrs + j * 8, addr, sizeof(uint32_t) * 8);
+        memcpy(addrs + (j * 8), addr, sizeof(uint32_t) * 8);
     }
 
     /* Initialize out with the value at position 'start'. */
@@ -65,7 +63,7 @@ static void gen_chains(
     for (i = 0; i < SPX_WOTS_LEN; i += 4) {
         for (j = 0; j < 4 && i + j < SPX_WOTS_LEN; j++) {
             idx = idxs[i + j];
-            set_chain_addr(addrs + j * 8, idx);
+            set_chain_addr(addrs + (j * 8), idx);
             bufs[j] = out + SPX_N * idx;
         }
 
@@ -93,7 +91,7 @@ static void gen_chains(
                 break;
             }
             for (j = 0; j < watching + 1; j++) {
-                set_hash_addr(addrs + j * 8, k + start[idxs[i + j]]);
+                set_hash_addr(addrs + (j * 8), k + start[idxs[i + j]]);
             }
 
             thashx4(bufs[0], bufs[1], bufs[2], bufs[3],
@@ -147,7 +145,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -204,8 +202,8 @@ void wots_gen_leafx4(unsigned char *dest,
     }
 
     for (j = 0; j < 4; j++) {
-        set_keypair_addr( leaf_addr + j * 8, leaf_idx + j );
-        set_keypair_addr( pk_addr + j * 8, leaf_idx + j );
+        set_keypair_addr( leaf_addr + (j * 8), leaf_idx + j );
+        set_keypair_addr( pk_addr + (j * 8), leaf_idx + j );
     }
 
     for (i = 0, buffer = pk_buffer; i < SPX_WOTS_LEN; i++, buffer += SPX_N) {
@@ -214,18 +212,18 @@ void wots_gen_leafx4(unsigned char *dest,
 
         /* Start with the secret seed */
         for (j = 0; j < 4; j++) {
-            set_chain_addr(leaf_addr + j * 8, i);
-            set_hash_addr(leaf_addr + j * 8, 0);
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTSPRF);
+            set_chain_addr(leaf_addr + (j * 8), i);
+            set_hash_addr(leaf_addr + (j * 8), 0);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTSPRF);
         }
-        prf_addrx4(buffer + 0 * wots_offset,
-                   buffer + 1 * wots_offset,
-                   buffer + 2 * wots_offset,
-                   buffer + 3 * wots_offset,
+        prf_addrx4(buffer + (0 * wots_offset),
+                   buffer + (1 * wots_offset),
+                   buffer + (2 * wots_offset),
+                   buffer + (3 * wots_offset),
                    ctx, leaf_addr);
 
         for (j = 0; j < 4; j++) {
-            set_type(leaf_addr + j * 8, SPX_ADDR_TYPE_WOTS);
+            set_type(leaf_addr + (j * 8), SPX_ADDR_TYPE_WOTS);
         }
 
         /* Iterate down the WOTS chain */
@@ -233,8 +231,8 @@ void wots_gen_leafx4(unsigned char *dest,
             /* Check if one of the values we have needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N,
-                        buffer + wots_sign_index * wots_offset, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N),
+                        buffer + (wots_sign_index * wots_offset), SPX_N );
             }
 
             /* Check if we hit the top of the chain */
@@ -244,26 +242,26 @@ void wots_gen_leafx4(unsigned char *dest,
 
             /* Iterate one step on all 4 chains */
             for (j = 0; j < 4; j++) {
-                set_hash_addr(leaf_addr + j * 8, k);
+                set_hash_addr(leaf_addr + (j * 8), k);
             }
-            thashx4(buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset,
-                    buffer + 0 * wots_offset,
-                    buffer + 1 * wots_offset,
-                    buffer + 2 * wots_offset,
-                    buffer + 3 * wots_offset, 1, ctx, leaf_addr);
+            thashx4(buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset),
+                    buffer + (0 * wots_offset),
+                    buffer + (1 * wots_offset),
+                    buffer + (2 * wots_offset),
+                    buffer + (3 * wots_offset), 1, ctx, leaf_addr);
         }
     }
 
     /* Do the final thash to generate the public keys */
-    thashx4(dest + 0 * SPX_N,
-            dest + 1 * SPX_N,
-            dest + 2 * SPX_N,
-            dest + 3 * SPX_N,
-            pk_buffer + 0 * wots_offset,
-            pk_buffer + 1 * wots_offset,
-            pk_buffer + 2 * wots_offset,
-            pk_buffer + 3 * wots_offset, SPX_WOTS_LEN, ctx, pk_addr);
+    thashx4(dest + (0 * SPX_N),
+            dest + (1 * SPX_N),
+            dest + (2 * SPX_N),
+            dest + (3 * SPX_N),
+            pk_buffer + (0 * wots_offset),
+            pk_buffer + (1 * wots_offset),
+            pk_buffer + (2 * wots_offset),
+            pk_buffer + (3 * wots_offset), SPX_WOTS_LEN, ctx, pk_addr);
 }

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/wots.h
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-256s-simple/avx2/wotsx4.h
+++ b/crypto_sign/sphincs-shake-256s-simple/avx2/wotsx4.h
@@ -24,7 +24,7 @@ struct leaf_info_x4 {
 /* Used only by the benchmark code */
 #define INITIALIZE_LEAF_INFO_X4(info, addr, step_buffer) { \
         (info).wots_sig = 0;             \
-        (info).wots_sign_leaf = ~0;      \
+        (info).wots_sign_leaf = ~0U;     \
         (info).wots_steps = step_buffer; \
         int i;                         \
         for (i=0; i<4; i++) {          \

--- a/crypto_sign/sphincs-shake-256s-simple/clean/address.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/address.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 #include "address.h"
-#include "params.h"
+#include "shake_offsets.h"
 #include "utils.h"
 
 /*

--- a/crypto_sign/sphincs-shake-256s-simple/clean/context.h
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/context.h
@@ -10,6 +10,7 @@ typedef struct {
     uint8_t pub_seed[SPX_N];
     uint8_t sk_seed[SPX_N];
 
+
 } spx_ctx;
 
 #define initialize_hash_function SPX_NAMESPACE(initialize_hash_function)

--- a/crypto_sign/sphincs-shake-256s-simple/clean/fors.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/fors.c
@@ -1,11 +1,11 @@
 #include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "fors.h"
 
 #include "address.h"
+#include "context.h"
 #include "hash.h"
+#include "params.h"
 #include "thash.h"
 #include "utils.h"
 #include "utilsx1.h"
@@ -97,7 +97,7 @@ void fors_sign(unsigned char *sig, unsigned char *pk,
         sig += SPX_N;
 
         /* Compute the authentication path for this leaf node. */
-        treehashx1(roots + i * SPX_N, sig, ctx,
+        treehashx1(roots + (i * SPX_N), sig, ctx,
                    indices[i], idx_offset, SPX_FORS_HEIGHT, fors_gen_leafx1,
                    fors_tree_addr, &fors_info);
 
@@ -146,7 +146,7 @@ void fors_pk_from_sig(unsigned char *pk,
         sig += SPX_N;
 
         /* Derive the corresponding root node of this tree. */
-        compute_root(roots + i * SPX_N, leaf, indices[i], idx_offset,
+        compute_root(roots + (i * SPX_N), leaf, indices[i], idx_offset,
                      sig, SPX_FORS_HEIGHT, ctx, fors_tree_addr);
         sig += SPX_N * SPX_FORS_HEIGHT;
     }

--- a/crypto_sign/sphincs-shake-256s-simple/clean/hash.h
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/hash.h
@@ -23,4 +23,6 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
                   const unsigned char *m, size_t mlen,
                   const spx_ctx *ctx);
 
+
+
 #endif

--- a/crypto_sign/sphincs-shake-256s-simple/clean/hash_shake.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/hash_shake.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "hash.h"
 
-#include "address.h"
 #include "fips202.h"
 #include "params.h"
 #include "utils.h"
@@ -13,13 +13,13 @@
  */
 void prf_addr(unsigned char *out, const spx_ctx *ctx,
               const uint32_t addr[8]) {
-    unsigned char buf[2 * SPX_N + SPX_ADDR_BYTES];
+    unsigned char buf[(2 * SPX_N) + SPX_ADDR_BYTES];
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, ctx->sk_seed, SPX_N);
 
-    shake256(out, SPX_N, buf, 2 * SPX_N + SPX_ADDR_BYTES);
+    shake256(out, SPX_N, buf, (2 * SPX_N) + SPX_ADDR_BYTES);
 }
 
 /**
@@ -72,6 +72,7 @@ void hash_message(unsigned char *digest, uint64_t *tree, uint32_t *leaf_idx,
 
     memcpy(digest, bufp, SPX_FORS_MSG_BYTES);
     bufp += SPX_FORS_MSG_BYTES;
+
 
     *tree = bytes_to_ull(bufp, SPX_TREE_BYTES);
     *tree &= (~(uint64_t)0) >> (64 - SPX_TREE_BITS);

--- a/crypto_sign/sphincs-shake-256s-simple/clean/merkle.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/merkle.c
@@ -1,10 +1,9 @@
 #include <stdint.h>
-#include <string.h>
 
 #include "address.h"
+#include "context.h"
 #include "merkle.h"
 #include "params.h"
-#include "utils.h"
 #include "utilsx1.h"
 #include "wots.h"
 #include "wotsx1.h"
@@ -46,7 +45,7 @@ void merkle_gen_root(unsigned char *root, const spx_ctx *ctx) {
     /* We do not need the auth path in key generation, but it simplifies the
        code to have just one treehash routine that computes both root and path
        in one function. */
-    unsigned char auth_path[SPX_TREE_HEIGHT * SPX_N + SPX_WOTS_BYTES];
+    unsigned char auth_path[(SPX_TREE_HEIGHT * SPX_N) + SPX_WOTS_BYTES];
     uint32_t top_tree_addr[8] = {0};
     uint32_t wots_addr[8] = {0};
 

--- a/crypto_sign/sphincs-shake-256s-simple/clean/params.h
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/params.h
@@ -46,10 +46,10 @@
 #define SPX_FORS_PK_BYTES SPX_N
 
 /* Resulting SPX sizes. */
-#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + SPX_D * SPX_WOTS_BYTES +\
-                   SPX_FULL_HEIGHT * SPX_N)
+#define SPX_BYTES (SPX_N + SPX_FORS_BYTES + (SPX_D * SPX_WOTS_BYTES) +\
+                   (SPX_FULL_HEIGHT * SPX_N))
 #define SPX_PK_BYTES (2 * SPX_N)
-#define SPX_SK_BYTES (2 * SPX_N + SPX_PK_BYTES)
+#define SPX_SK_BYTES ((2 * SPX_N) + SPX_PK_BYTES)
 
 #include "shake_offsets.h"
 

--- a/crypto_sign/sphincs-shake-256s-simple/clean/sign.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/sign.c
@@ -54,7 +54,7 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     /* Initialize SK_SEED, SK_PRF and PUB_SEED from seed. */
     memcpy(sk, seed, CRYPTO_SEEDBYTES);
 
-    memcpy(pk, sk + 2 * SPX_N, SPX_N);
+    memcpy(pk, sk + (2 * SPX_N), SPX_N);
 
     memcpy(ctx.pub_seed, pk, SPX_N);
     memcpy(ctx.sk_seed, sk, SPX_N);
@@ -64,12 +64,12 @@ int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk,
     initialize_hash_function(&ctx);
 
     /* Compute root node of the top-most subtree. */
-    merkle_gen_root(sk + 3 * SPX_N, &ctx);
+    merkle_gen_root(sk + (3 * SPX_N), &ctx);
 
     // cleanup
     free_hash_function(&ctx);
 
-    memcpy(pk + SPX_N, sk + 3 * SPX_N, SPX_N);
+    memcpy(pk + SPX_N, sk + (3 * SPX_N), SPX_N);
 
     return 0;
 }
@@ -95,7 +95,7 @@ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
     spx_ctx ctx;
 
     const uint8_t *sk_prf = sk + SPX_N;
-    const uint8_t *pk = sk + 2 * SPX_N;
+    const uint8_t *pk = sk + (2 * SPX_N);
 
     uint8_t optrand[SPX_N];
     uint8_t mhash[SPX_FORS_MSG_BYTES];
@@ -239,6 +239,7 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen,
 
     return 0;
 }
+
 
 /**
  * Returns an array containing the signature followed by the message.

--- a/crypto_sign/sphincs-shake-256s-simple/clean/thash_shake_simple.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/thash_shake_simple.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "context.h"
 #include "thash.h"
 
-#include "address.h"
 #include "params.h"
 #include "utils.h"
 
@@ -14,11 +14,11 @@
  */
 void thash(unsigned char *out, const unsigned char *in, unsigned int inblocks,
            const spx_ctx *ctx, uint32_t addr[8]) {
-    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    PQCLEAN_VLA(uint8_t, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 
     memcpy(buf, ctx->pub_seed, SPX_N);
     memcpy(buf + SPX_N, addr, SPX_ADDR_BYTES);
     memcpy(buf + SPX_N + SPX_ADDR_BYTES, in, inblocks * SPX_N);
 
-    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + inblocks * SPX_N);
+    shake256(out, SPX_N, buf, SPX_N + SPX_ADDR_BYTES + (inblocks * SPX_N));
 }

--- a/crypto_sign/sphincs-shake-256s-simple/clean/utils.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/utils.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utils.h"
 
 #include "address.h"
-#include "hash.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 
@@ -112,13 +113,13 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
 
     for (idx = 0; idx < (uint32_t)(1 << tree_height); idx++) {
         /* Add the next leaf node to the stack. */
-        gen_leaf(stack + offset * SPX_N, ctx, idx + idx_offset, tree_addr);
+        gen_leaf(stack + (offset * SPX_N), ctx, idx + idx_offset, tree_addr);
         offset++;
         heights[offset - 1] = 0;
 
         /* If this is a node we need for the auth path.. */
         if ((leaf_idx ^ 0x1) == idx) {
-            memcpy(auth_path, stack + (offset - 1)*SPX_N, SPX_N);
+            memcpy(auth_path, stack + ((offset - 1)*SPX_N), SPX_N);
         }
 
         /* While the top-most nodes are of equal height.. */
@@ -131,16 +132,16 @@ void treehash(unsigned char *root, unsigned char *auth_path, const spx_ctx *ctx,
             set_tree_index(tree_addr,
                            tree_idx + (idx_offset >> (heights[offset - 1] + 1)));
             /* Hash the top-most nodes from the stack together. */
-            thash(stack + (offset - 2)*SPX_N,
-                  stack + (offset - 2)*SPX_N, 2, ctx, tree_addr);
+            thash(stack + ((offset - 2)*SPX_N),
+                  stack + ((offset - 2)*SPX_N), 2, ctx, tree_addr);
             offset--;
             /* Note that the top-most node is now one layer higher. */
             heights[offset - 1]++;
 
             /* If this is a node we need for the auth path.. */
             if (((leaf_idx >> heights[offset - 1]) ^ 0x1) == tree_idx) {
-                memcpy(auth_path + heights[offset - 1]*SPX_N,
-                       stack + (offset - 1)*SPX_N, SPX_N);
+                memcpy(auth_path + (heights[offset - 1]*SPX_N),
+                       stack + ((offset - 1)*SPX_N), SPX_N);
             }
         }
     }

--- a/crypto_sign/sphincs-shake-256s-simple/clean/utils.h
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/utils.h
@@ -7,7 +7,9 @@
 #include "context.h"
 #include "params.h"
 
+
 /* To support MSVC use alloca() instead of VLAs. See #20. */
+
 
 /**
  * Converts the value of 'in' to 'outlen' bytes in big-endian byte order.
@@ -51,5 +53,6 @@ void treehash(unsigned char *root, unsigned char *auth_path,
                   const spx_ctx *ctx /* ctx */,
                   uint32_t /* addr_idx */, const uint32_t[8] /* tree_addr */),
               uint32_t tree_addr[8]);
+
 
 #endif

--- a/crypto_sign/sphincs-shake-256s-simple/clean/utilsx1.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/utilsx1.c
@@ -1,8 +1,10 @@
+#include <stdint.h>
 #include <string.h>
 
 #include "utilsx1.h"
 
 #include "address.h"
+#include "context.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
@@ -84,7 +86,7 @@ void treehashx1(unsigned char *root, unsigned char *auth_path,
             /* Set the address of the node we're creating. */
             internal_idx_offset >>= 1;
             set_tree_height(tree_addr, h + 1);
-            set_tree_index(tree_addr, internal_idx / 2 + internal_idx_offset );
+            set_tree_index(tree_addr, (internal_idx / 2) + internal_idx_offset );
 
             unsigned char *left = &stack[h * SPX_N];
             memcpy( &current[0], left, SPX_N );

--- a/crypto_sign/sphincs-shake-256s-simple/clean/wots.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/wots.c
@@ -2,14 +2,12 @@
 #include <string.h>
 
 #include "wots.h"
-#include "wotsx1.h"
+#include "context.h"
 
 #include "address.h"
-#include "hash.h"
 #include "params.h"
 #include "thash.h"
 #include "utils.h"
-#include "utilsx1.h"
 
 // TODO clarify address expectations, and make them more uniform.
 // TODO i.e. do we expect types to be set already?
@@ -42,7 +40,7 @@ static void gen_chain(unsigned char *out, const unsigned char *in,
  * Interprets an array of bytes as integers in base w.
  * This only works when log_w is a divisor of 8.
  */
-static void base_w(unsigned int *output, const int out_len,
+static void base_w(uint32_t *output, const int out_len,
                    const unsigned char *input) {
     int in = 0;
     int out = 0;
@@ -63,8 +61,8 @@ static void base_w(unsigned int *output, const int out_len,
 }
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
-static void wots_checksum(unsigned int *csum_base_w,
-                          const unsigned int *msg_base_w) {
+static void wots_checksum(uint32_t *csum_base_w,
+                          const uint32_t *msg_base_w) {
     unsigned int csum = 0;
     unsigned char csum_bytes[(SPX_WOTS_LEN2 * SPX_WOTS_LOGW + 7) / 8];
     unsigned int i;
@@ -82,7 +80,7 @@ static void wots_checksum(unsigned int *csum_base_w,
 }
 
 /* Takes a message and derives the matching chain lengths. */
-void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
+void chain_lengths(uint32_t *lengths, const unsigned char *msg) {
     base_w(lengths, SPX_WOTS_LEN1, msg);
     wots_checksum(lengths + SPX_WOTS_LEN1, lengths);
 }
@@ -95,14 +93,14 @@ void chain_lengths(unsigned int *lengths, const unsigned char *msg) {
 void wots_pk_from_sig(unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const spx_ctx *ctx, uint32_t addr[8]) {
-    unsigned int lengths[SPX_WOTS_LEN];
+    uint32_t lengths[SPX_WOTS_LEN];
     uint32_t i;
 
     chain_lengths(lengths, msg);
 
     for (i = 0; i < SPX_WOTS_LEN; i++) {
         set_chain_addr(addr, i);
-        gen_chain(pk + i * SPX_N, sig + i * SPX_N,
+        gen_chain(pk + (i * SPX_N), sig + (i * SPX_N),
                   lengths[i], SPX_WOTS_W - 1 - lengths[i], ctx, addr);
     }
 }

--- a/crypto_sign/sphincs-shake-256s-simple/clean/wots.h
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/wots.h
@@ -20,6 +20,6 @@ void wots_pk_from_sig(unsigned char *pk,
  * Compute the chain lengths needed for a given message hash
  */
 #define chain_lengths SPX_NAMESPACE(chain_lengths)
-void chain_lengths(unsigned int *lengths, const unsigned char *msg);
+void chain_lengths(uint32_t *lengths, const unsigned char *msg);
 
 #endif

--- a/crypto_sign/sphincs-shake-256s-simple/clean/wotsx1.c
+++ b/crypto_sign/sphincs-shake-256s-simple/clean/wotsx1.c
@@ -1,14 +1,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "wots.h"
+#include "context.h"
 #include "wotsx1.h"
 
 #include "address.h"
 #include "hash.h"
 #include "params.h"
 #include "thash.h"
-#include "utils.h"
 
 /*
  * This generates a WOTS public key
@@ -32,7 +31,7 @@ void wots_gen_leafx1(unsigned char *dest,
         wots_k_mask = 0;
     } else {
         /* Nope, we're just generating pk's; turn off the signature logic */
-        wots_k_mask = (uint32_t)~0;
+        wots_k_mask = ~0U;
     }
 
     set_keypair_addr( leaf_addr, leaf_idx );
@@ -56,7 +55,7 @@ void wots_gen_leafx1(unsigned char *dest,
             /* Check if this is the value that needs to be saved as a */
             /* part of the WOTS signature */
             if (k == wots_k) {
-                memcpy( info->wots_sig + i * SPX_N, buffer, SPX_N );
+                memcpy( info->wots_sig + (i * SPX_N), buffer, SPX_N );
             }
 
             /* Check if we hit the top of the chain */


### PR DESCRIPTION
Downstream in https://github.com/mupq/pqm4, we are having problems compiling with gcc14 as SPHINCS+ mixes `uint32_t *` and `unsigned *` which leads to errors when using `arm-none-eabi-gcc 14.2`
I tried to apply the minimal changes to make this work. 

Import was done through https://github.com/mkannwischer/sphincsplus/tree/pqclean-export

The core change is this one: https://github.com/mkannwischer/sphincsplus/commit/ccc67011eedb89b89f0936996846d27cfdd30159
Everything else is just to make the CI happy and because of using a newer version of clang-tidy. 

**This PR does not attempt to make any changes beyond that. In paricular this is trying to achieve SLH-DSA compliance.**

The downstream PR is https://github.com/mupq/pqm4/pull/373. 