### PR TITLE
Embed ___GNUC_PREREQ macro as some toolchains lack features.h

### DIFF
--- a/common/compat.h
+++ b/common/compat.h
@@ -15,12 +15,12 @@
     typedef long long __m256i_u __attribute__ ((__vector_size__ (32), __may_alias__, __aligned__ (1)));
 
 #if defined(__GNUC__) && !defined(__clang__)
-#include <features.h>
 
-#  if !__GNUC_PREREQ(7, 1) // at least GCC 7.1
+#if defined __GNUC_MINOR__ && ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((7) << 16) + (1))
+#else
 /* Versions of the GCC pre-7.1 don't have __m256*_u types */
 UNALIGNED_VECTOR_POLYFILL_GCC
-#  endif // __GNUC_PREREQ(7,1)
+#endif
 
 #elif defined(__GNUC__) && defined(__clang__)
 


### PR DESCRIPTION
`gcc-arm-none-eabi` toolchain does not ship a `features.h`. This PR does not include it but instead embeds the version checking logic from the `__GNUC_PREREQ` macro. I believe this was the only thing `features.h` was used for.