### PR TITLE
Use correct python3 executable in test_workflows

### DIFF
--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -1,11 +1,13 @@
 from pathlib import Path
+import sys
 
 import helpers
 
 @helpers.skip_windows()
 def test_workflows_up_to_date():
     scriptdir = str(Path("..") / ".github" / "workflows")
-    helpers.run_subprocess(["python3", "generate_workflows.py", "test"],
+    exepath = sys.executable or "python3"
+    helpers.run_subprocess([exepath, "generate_workflows.py", "test"],
                            working_dir=scriptdir)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using the same `python3` executable that is executing the test file itself to run `generate_workflows.py` allows the test to succeed even when the first `python3` binary in the user's `$PATH` is not the same.

Without this change, the test was failing on my local setup: while `jinja2` was available in the virtual environment that was executing `pytest`, but the first occurrence of `python3` in my `$PATH` was a separate Python installation that did not contain `jinja2`. With this patch, the test will use the correct `python3` executable from the virtual environment.