### PR TITLE
Replace macros in ML-DSA-87 clean/avx2 API and add regression test

### DIFF
--- a/crypto_sign/ml-dsa-87/avx2/api.h
+++ b/crypto_sign/ml-dsa-87/avx2/api.h
@@ -31,9 +31,20 @@ int PQCLEAN_MLDSA87_AVX2_crypto_sign_open_ctx(uint8_t *m, size_t *mlen,
         const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
-#define PQCLEAN_MLDSA87_AVX2_crypto_sign_signature(sig, siglen, m, mlen, sk) PQCLEAN_MLDSA87_AVX2_crypto_sign_signature_ctx(sig, siglen, m, mlen, NULL, 0, sk)
-#define PQCLEAN_MLDSA87_AVX2_crypto_sign(sm, smlen, m, mlen, sk) PQCLEAN_MLDSA87_AVX2_crypto_sign_ctx(sm, smlen, m, mlen, NULL, 0, sk)
-#define PQCLEAN_MLDSA87_AVX2_crypto_sign_verify(sig, siglen, m, mlen, pk) PQCLEAN_MLDSA87_AVX2_crypto_sign_verify_ctx(sig, siglen, m, mlen, NULL, 0, pk)
-#define PQCLEAN_MLDSA87_AVX2_crypto_sign_open(m, mlen, sm, smlen, pk) PQCLEAN_MLDSA87_AVX2_crypto_sign_open_ctx(m, mlen, sm, smlen, NULL, 0, pk)
+int PQCLEAN_MLDSA87_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen,
+        const uint8_t *m, size_t mlen,
+        const uint8_t *sk);
+
+int PQCLEAN_MLDSA87_AVX2_crypto_sign(uint8_t *sm, size_t *smlen,
+                                     const uint8_t *m, size_t mlen,
+                                     const uint8_t *sk);
+
+int PQCLEAN_MLDSA87_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen,
+        const uint8_t *m, size_t mlen,
+        const uint8_t *pk);
+
+int PQCLEAN_MLDSA87_AVX2_crypto_sign_open(uint8_t *m, size_t *mlen,
+        const uint8_t *sm, size_t smlen,
+        const uint8_t *pk);
 
 #endif

--- a/crypto_sign/ml-dsa-87/clean/api.h
+++ b/crypto_sign/ml-dsa-87/clean/api.h
@@ -31,9 +31,20 @@ int PQCLEAN_MLDSA87_CLEAN_crypto_sign_open_ctx(uint8_t *m, size_t *mlen,
         const uint8_t *ctx, size_t ctxlen,
         const uint8_t *pk);
 
-#define PQCLEAN_MLDSA87_CLEAN_crypto_sign_signature(sig, siglen, m, mlen, sk) PQCLEAN_MLDSA87_CLEAN_crypto_sign_signature_ctx(sig, siglen, m, mlen, NULL, 0, sk)
-#define PQCLEAN_MLDSA87_CLEAN_crypto_sign(sm, smlen, m, mlen, sk) PQCLEAN_MLDSA87_CLEAN_crypto_sign_ctx(sm, smlen, m, mlen, NULL, 0, sk)
-#define PQCLEAN_MLDSA87_CLEAN_crypto_sign_verify(sig, siglen, m, mlen, pk) PQCLEAN_MLDSA87_CLEAN_crypto_sign_verify_ctx(sig, siglen, m, mlen, NULL, 0, pk)
-#define PQCLEAN_MLDSA87_CLEAN_crypto_sign_open(m, mlen, sm, smlen, pk) PQCLEAN_MLDSA87_CLEAN_crypto_sign_open_ctx(m, mlen, sm, smlen, NULL, 0, pk)
+int PQCLEAN_MLDSA87_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen,
+        const uint8_t *m, size_t mlen,
+        const uint8_t *sk);
+
+int PQCLEAN_MLDSA87_CLEAN_crypto_sign(uint8_t *sm, size_t *smlen,
+                                      const uint8_t *m, size_t mlen,
+                                      const uint8_t *sk);
+
+int PQCLEAN_MLDSA87_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen,
+        const uint8_t *m, size_t mlen,
+        const uint8_t *pk);
+
+int PQCLEAN_MLDSA87_CLEAN_crypto_sign_open(uint8_t *m, size_t *mlen,
+        const uint8_t *sm, size_t smlen,
+        const uint8_t *pk);
 
 #endif

--- a/test/crypto_sign/functest.c
+++ b/test/crypto_sign/functest.c
@@ -375,6 +375,30 @@ end:
     return res;
 }
 
+static int test_func_ptrs(void) {
+    // This test will likely be optimized away by the compiler if each of the
+    // expected functions actually can be made into a function pointer of the
+    // correct type. Otherwise, a compiler error should occur.
+    int ret = 0;
+
+    int (*keypair_fn)(uint8_t *, uint8_t *) = (crypto_sign_keypair);
+    ret |= keypair_fn == NULL;
+
+    int (*sign_fn)(uint8_t *, size_t *, const uint8_t *, size_t, const uint8_t *) = (crypto_sign);
+    ret |= sign_fn == NULL;
+
+    int (*sign_open_fn)(uint8_t *, size_t *, const uint8_t *, size_t, const uint8_t *) = (crypto_sign_open);
+    ret |= sign_open_fn == NULL;
+
+    int (*sign_signature_fn)(uint8_t *, size_t *, const uint8_t *, size_t, const uint8_t *) = (crypto_sign_signature);
+    ret |= sign_signature_fn == NULL;
+
+    int (*sign_verify_fn)(const uint8_t *, size_t, const uint8_t *, size_t, const uint8_t *) = (crypto_sign_verify);
+    ret |= sign_verify_fn == NULL;
+
+    return ret;
+}
+
 int main(void) {
     // check if CRYPTO_ALGNAME is printable
     puts(CRYPTO_ALGNAME);
@@ -382,6 +406,7 @@ int main(void) {
     result += test_sign();
     result += test_sign_detached();
     result += test_wrong_pk();
+    result += test_func_ptrs();
 
     return result;
 }


### PR DESCRIPTION
I tried to update PQClean to the most recent commit (c23f6bf80e39c05bdd8433d02252960801e4e840) in `node-pqclean` and it still wouldn't compile without a workaround for #576...

I apparently forgot to replace the macros in two of the nine `api.h` files of the ML-DSA implementations in commit ae29fd8d4f1e00e3786f8b3500306b821a9bd5cd. The previous patch did indeed fix the issue at hand, which was about missing function symbols, because the function symbols are indeed declared in `sign.h` and defined in `sign.c` of each implementation. However, consumers that include `api.h` (as opposed to `sign.h`) would still see the old macros for the clean and the avx2 implementations of ML-DSA-87 and thus still will not be able to construct function pointers to the relevant functions when including these particular header files.

The second commit adds simple test routine to `functest.c` that can be evaluated entirely at compile time and simply ensures that the different API functions used by the test can be assigned to function pointers of the expected function signatures.

@thomwiggers I apologize for not catching this in https://github.com/PQClean/PQClean/pull/591.