### PR TITLE
[Security] hqc: fix secret-dependent break in compute_elp (CT hardening)

### DIFF
--- a/crypto_kem/hqc-128/clean/reed_solomon.c
+++ b/crypto_kem/hqc-128/clean/reed_solomon.c
@@ -94,6 +94,8 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
     uint16_t deg_X, deg_X_sigma_p;
     uint16_t dd;
     uint16_t mu;
+    uint16_t diff;
+    uint16_t not_last;
 
     uint16_t i;
 
@@ -122,7 +124,8 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
         mask12 = mask1 & mask2;
         deg_sigma ^= mask12 & (deg_X_sigma_p ^ deg_sigma);
 
-        uint16_t not_last = (uint16_t)(-((uint16_t)(mu - (2 * PARAM_DELTA - 1)) != 0));
+        diff = mu - (2 * PARAM_DELTA - 1);
+        not_last = (uint16_t)(-(uint16_t)((diff | (0 - diff)) >> 15));
 
         pp ^= not_last & mask12 & (mu ^ pp);
         d_p ^= not_last & mask12 & (d ^ d_p);

--- a/crypto_kem/hqc-128/clean/reed_solomon.c
+++ b/crypto_kem/hqc-128/clean/reed_solomon.c
@@ -134,7 +134,7 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
         }
 
         deg_sigma_p ^= not_last & mask12 & (deg_sigma_copy ^ deg_sigma_p);
-        d = syndromes[mu + 1];
+        d ^= not_last & (syndromes[mu + 1] ^ d);
 
         for (i = 1; (i <= mu + 1) && (i <= PARAM_DELTA); ++i) {
             d ^= PQCLEAN_HQC128_CLEAN_gf_mul(sigma[i], syndromes[mu + 1 - i]);
@@ -304,7 +304,7 @@ static void correct_errors(uint8_t *cdw, const uint16_t *error_values) {
  * @param[in] cdw Array of size VEC_N1_SIZE_64 storing the received word
  */
 void PQCLEAN_HQC128_CLEAN_reed_solomon_decode(uint8_t *msg, uint8_t *cdw) {
-    uint16_t syndromes[2 * PARAM_DELTA] = {0};
+    uint16_t syndromes[2 * PARAM_DELTA + 1] = {0};
     uint16_t sigma[1 << PARAM_FFT] = {0};
     uint8_t error[1 << PARAM_M] = {0};
     uint16_t z[PARAM_N1] = {0};

--- a/crypto_kem/hqc-128/clean/reed_solomon.c
+++ b/crypto_kem/hqc-128/clean/reed_solomon.c
@@ -122,17 +122,15 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
         mask12 = mask1 & mask2;
         deg_sigma ^= mask12 & (deg_X_sigma_p ^ deg_sigma);
 
-        if (mu == (2 * PARAM_DELTA - 1)) {
-            break;
-        }
+        uint16_t not_last = (uint16_t)(-((uint16_t)(mu - (2 * PARAM_DELTA - 1)) != 0));
 
-        pp ^= mask12 & (mu ^ pp);
-        d_p ^= mask12 & (d ^ d_p);
+        pp ^= not_last & mask12 & (mu ^ pp);
+        d_p ^= not_last & mask12 & (d ^ d_p);
         for (i = PARAM_DELTA; i; --i) {
-            X_sigma_p[i] = (mask12 & sigma_copy[i - 1]) ^ (~mask12 & X_sigma_p[i - 1]);
+            X_sigma_p[i] = (uint16_t)((not_last & ((mask12 & sigma_copy[i - 1]) ^ (~mask12 & X_sigma_p[i - 1]))) | (~not_last & X_sigma_p[i]));
         }
 
-        deg_sigma_p ^= mask12 & (deg_sigma_copy ^ deg_sigma_p);
+        deg_sigma_p ^= not_last & mask12 & (deg_sigma_copy ^ deg_sigma_p);
         d = syndromes[mu + 1];
 
         for (i = 1; (i <= mu + 1) && (i <= PARAM_DELTA); ++i) {

--- a/crypto_kem/hqc-192/clean/reed_solomon.c
+++ b/crypto_kem/hqc-192/clean/reed_solomon.c
@@ -134,7 +134,7 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
         }
 
         deg_sigma_p ^= not_last & mask12 & (deg_sigma_copy ^ deg_sigma_p);
-        d = syndromes[mu + 1];
+        d ^= not_last & (syndromes[mu + 1] ^ d);
 
         for (i = 1; (i <= mu + 1) && (i <= PARAM_DELTA); ++i) {
             d ^= PQCLEAN_HQC192_CLEAN_gf_mul(sigma[i], syndromes[mu + 1 - i]);
@@ -304,7 +304,7 @@ static void correct_errors(uint8_t *cdw, const uint16_t *error_values) {
  * @param[in] cdw Array of size VEC_N1_SIZE_64 storing the received word
  */
 void PQCLEAN_HQC192_CLEAN_reed_solomon_decode(uint8_t *msg, uint8_t *cdw) {
-    uint16_t syndromes[2 * PARAM_DELTA] = {0};
+    uint16_t syndromes[2 * PARAM_DELTA + 1] = {0};
     uint16_t sigma[1 << PARAM_FFT] = {0};
     uint8_t error[1 << PARAM_M] = {0};
     uint16_t z[PARAM_N1] = {0};

--- a/crypto_kem/hqc-192/clean/reed_solomon.c
+++ b/crypto_kem/hqc-192/clean/reed_solomon.c
@@ -94,6 +94,8 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
     uint16_t deg_X, deg_X_sigma_p;
     uint16_t dd;
     uint16_t mu;
+    uint16_t diff;
+    uint16_t not_last;
 
     uint16_t i;
 
@@ -122,7 +124,8 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
         mask12 = mask1 & mask2;
         deg_sigma ^= mask12 & (deg_X_sigma_p ^ deg_sigma);
 
-        uint16_t not_last = (uint16_t)(-((uint16_t)(mu - (2 * PARAM_DELTA - 1)) != 0));
+        diff = mu - (2 * PARAM_DELTA - 1);
+        not_last = (uint16_t)(-(uint16_t)((diff | (0 - diff)) >> 15));
 
         pp ^= not_last & mask12 & (mu ^ pp);
         d_p ^= not_last & mask12 & (d ^ d_p);

--- a/crypto_kem/hqc-192/clean/reed_solomon.c
+++ b/crypto_kem/hqc-192/clean/reed_solomon.c
@@ -122,17 +122,15 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
         mask12 = mask1 & mask2;
         deg_sigma ^= mask12 & (deg_X_sigma_p ^ deg_sigma);
 
-        if (mu == (2 * PARAM_DELTA - 1)) {
-            break;
-        }
+        uint16_t not_last = (uint16_t)(-((uint16_t)(mu - (2 * PARAM_DELTA - 1)) != 0));
 
-        pp ^= mask12 & (mu ^ pp);
-        d_p ^= mask12 & (d ^ d_p);
+        pp ^= not_last & mask12 & (mu ^ pp);
+        d_p ^= not_last & mask12 & (d ^ d_p);
         for (i = PARAM_DELTA; i; --i) {
-            X_sigma_p[i] = (mask12 & sigma_copy[i - 1]) ^ (~mask12 & X_sigma_p[i - 1]);
+            X_sigma_p[i] = (uint16_t)((not_last & ((mask12 & sigma_copy[i - 1]) ^ (~mask12 & X_sigma_p[i - 1]))) | (~not_last & X_sigma_p[i]));
         }
 
-        deg_sigma_p ^= mask12 & (deg_sigma_copy ^ deg_sigma_p);
+        deg_sigma_p ^= not_last & mask12 & (deg_sigma_copy ^ deg_sigma_p);
         d = syndromes[mu + 1];
 
         for (i = 1; (i <= mu + 1) && (i <= PARAM_DELTA); ++i) {

--- a/crypto_kem/hqc-256/clean/reed_solomon.c
+++ b/crypto_kem/hqc-256/clean/reed_solomon.c
@@ -134,7 +134,7 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
         }
 
         deg_sigma_p ^= not_last & mask12 & (deg_sigma_copy ^ deg_sigma_p);
-        d = syndromes[mu + 1];
+        d ^= not_last & (syndromes[mu + 1] ^ d);
 
         for (i = 1; (i <= mu + 1) && (i <= PARAM_DELTA); ++i) {
             d ^= PQCLEAN_HQC256_CLEAN_gf_mul(sigma[i], syndromes[mu + 1 - i]);
@@ -304,7 +304,7 @@ static void correct_errors(uint8_t *cdw, const uint16_t *error_values) {
  * @param[in] cdw Array of size VEC_N1_SIZE_64 storing the received word
  */
 void PQCLEAN_HQC256_CLEAN_reed_solomon_decode(uint8_t *msg, uint8_t *cdw) {
-    uint16_t syndromes[2 * PARAM_DELTA] = {0};
+    uint16_t syndromes[2 * PARAM_DELTA + 1] = {0};
     uint16_t sigma[1 << PARAM_FFT] = {0};
     uint8_t error[1 << PARAM_M] = {0};
     uint16_t z[PARAM_N1] = {0};

--- a/crypto_kem/hqc-256/clean/reed_solomon.c
+++ b/crypto_kem/hqc-256/clean/reed_solomon.c
@@ -94,6 +94,8 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
     uint16_t deg_X, deg_X_sigma_p;
     uint16_t dd;
     uint16_t mu;
+    uint16_t diff;
+    uint16_t not_last;
 
     uint16_t i;
 
@@ -122,7 +124,8 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
         mask12 = mask1 & mask2;
         deg_sigma ^= mask12 & (deg_X_sigma_p ^ deg_sigma);
 
-        uint16_t not_last = (uint16_t)(-((uint16_t)(mu - (2 * PARAM_DELTA - 1)) != 0));
+        diff = mu - (2 * PARAM_DELTA - 1);
+        not_last = (uint16_t)(-(uint16_t)((diff | (0 - diff)) >> 15));
 
         pp ^= not_last & mask12 & (mu ^ pp);
         d_p ^= not_last & mask12 & (d ^ d_p);

--- a/crypto_kem/hqc-256/clean/reed_solomon.c
+++ b/crypto_kem/hqc-256/clean/reed_solomon.c
@@ -122,17 +122,15 @@ static uint16_t compute_elp(uint16_t *sigma, const uint16_t *syndromes) {
         mask12 = mask1 & mask2;
         deg_sigma ^= mask12 & (deg_X_sigma_p ^ deg_sigma);
 
-        if (mu == (2 * PARAM_DELTA - 1)) {
-            break;
-        }
+        uint16_t not_last = (uint16_t)(-((uint16_t)(mu - (2 * PARAM_DELTA - 1)) != 0));
 
-        pp ^= mask12 & (mu ^ pp);
-        d_p ^= mask12 & (d ^ d_p);
+        pp ^= not_last & mask12 & (mu ^ pp);
+        d_p ^= not_last & mask12 & (d ^ d_p);
         for (i = PARAM_DELTA; i; --i) {
-            X_sigma_p[i] = (mask12 & sigma_copy[i - 1]) ^ (~mask12 & X_sigma_p[i - 1]);
+            X_sigma_p[i] = (uint16_t)((not_last & ((mask12 & sigma_copy[i - 1]) ^ (~mask12 & X_sigma_p[i - 1]))) | (~not_last & X_sigma_p[i]));
         }
 
-        deg_sigma_p ^= mask12 & (deg_sigma_copy ^ deg_sigma_p);
+        deg_sigma_p ^= not_last & mask12 & (deg_sigma_copy ^ deg_sigma_p);
         d = syndromes[mu + 1];
 
         for (i = 1; (i <= mu + 1) && (i <= PARAM_DELTA); ++i) {


### PR DESCRIPTION
## Summary
The Berlekamp loop in `compute_elp()` contains an early `break` on the
final iteration (`mu == 2*PARAM_DELTA-1`), skipping updates to `pp`,
`d_p`, `X_sigma_p`, `deg_sigma_p` and `d`. This creates a timing side
channel — the last iteration executes less work than all others.

## Fix
Replaced the `break` with a constant-time `not_last` mask:
```c
uint16_t not_last = (uint16_t)(-((uint16_t)(mu - (2 * PARAM_DELTA - 1)) != 0));
```
All updates are ANDed with `not_last` so every iteration executes
identical work.

Applied to HQC-128, HQC-192, HQC-256.

## Evidence
Verified with valgrind --tool=memcheck using VALGRIND_MAKE_MEM_UNDEFINED
on secret key:
<img width="976" height="440" alt="Screenshot 2026-05-14 172635" src="https://github.com/user-attachments/assets/dfb1fa7e-b479-496b-bc09-0fe0ed6a00ca" />
See also: open-quantum-safe/liboqs#2429